### PR TITLE
Fix: resolve 2 small issues in result examples migration logic

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.8.1"
+version = "1.8.2"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/core/data_models/action/dynamic_results_metadata.py
+++ b/packages/mp/src/mp/core/data_models/action/dynamic_results_metadata.py
@@ -105,12 +105,8 @@ class DynamicResultsMetadata(
             A non-built version of the dynamic results metadata dict
 
         """
-        example: str | None = None
-        if self.result_example is not None:
-            example = json.dumps(self.result_example)
-
         return NonBuiltDynamicResultsMetadata(
-            result_example_path=example,
+            result_example_path=self.result_example,
             result_name=self.result_name,
             show_result=self.show_result,
         )

--- a/packages/mp/src/mp/core/data_models/action/metadata.py
+++ b/packages/mp/src/mp/core/data_models/action/metadata.py
@@ -288,7 +288,10 @@ class ActionMetadata(
                 drm.result_example = None
                 continue
 
-            json_file_name: str = f"{self.name}_{drm.result_name}_example.json"
+            json_file_name: str = (
+                f"{mp.core.utils.str_to_snake_case(self.name)}"
+                f"_{drm.result_name}_example.json"
+            )
             json_file_path: str = f"{mp.core.constants.RESOURCES_DIR}/{json_file_name}"
             drm.result_example = json_file_path
 

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION

## Description

1. resolve double quotes in result_example field in the output yaml
2. convert to snake_case when setting result example file name

---

## Checklist:

Please ensure you have completed the following items before submitting your PR.
This helps us review your contribution faster and more efficiently.

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.

---

## Screenshots (If Applicable)

If your changes involve UI or visual elements, please include screenshots or GIFs here.
Ensure any sensitive data is redacted or generalized.

---

## Further Comments / Questions

Any additional comments, questions, or areas where you'd like specific feedback.
