### PR TITLE
Add pip caching to all Linux CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install mp package
       run: |
@@ -99,6 +100,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install mp package
       run: |
@@ -126,6 +128,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install mp package
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,6 +71,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install mp package
       run: |
@@ -99,6 +100,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install mp package
       run: |
@@ -127,6 +129,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install uv
       run: |
@@ -162,6 +165,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install uv
       run: |
@@ -190,6 +194,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install uv
       run: |
@@ -218,6 +223,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install uv
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install mp package
       run: |

--- a/.github/workflows/test_mp.yml
+++ b/.github/workflows/test_mp.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install uv package
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,6 +66,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv
@@ -99,6 +100,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv
@@ -132,6 +134,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv
@@ -165,6 +168,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv
@@ -198,6 +202,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv
@@ -231,6 +236,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv
@@ -264,6 +270,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
     - name: Install mp package
       run: |
         python -m pip install uv


### PR DESCRIPTION
## Summary

Adds `cache: 'pip'` to `actions/setup-python@v5` in all Linux workflow jobs. This caches pip's download directory between CI runs, avoiding re-downloading mp's ~20 dependencies from PyPI every time.

## Changes

Added `cache: 'pip'` to 18 `setup-python` steps across 5 workflows:
- `validate.yml` (7 jobs)
- `build.yml` (3 jobs)
- `test.yml` (1 job)
- `lint.yml` (6 jobs)
- `test_mp.yml` (1 job)

Windows `test-mp-windows` already had `cache: 'pip'`.

## Impact

Estimated ~10-20 seconds saved per job on cache hit (~3-5 min total per PR).

## Test plan

- [x] No behavioral change — only affects download caching
- [x] `cache: 'pip'` is the standard GitHub Actions caching approach
- [x] Windows already uses this pattern successfully