### PR TITLE
Add V2 migration pipeline with two-PR workflow

### DIFF
--- a/packages/mp/src/mp/core/data/exclusions.yaml
+++ b/packages/mp/src/mp/core/data/exclusions.yaml
@@ -412,3 +412,5 @@ excluded_names_where_ssl_default_is_not_true:
   - "MobileIron"
   - "CyberX"
   - "Micro Focus ITSMA"
+
+excluded_names_without_ping_message_format: []

--- a/packages/mp/src/mp/core/exclusions.py
+++ b/packages/mp/src/mp/core/exclusions.py
@@ -118,6 +118,17 @@ def get_excluded_names_without_verify_ssl() -> set[str]:
     return set(data.get("excluded_names_without_verify_ssl", []))
 
 
+def get_excluded_names_without_ping_message_format() -> set[str]:
+    """Return a set of excluded names without ping message format.
+
+    Returns:
+        A set of excluded names without ping message format.
+
+    """
+    data = _load_exclusions_data()
+    return set(data.get("excluded_names_without_ping_message_format", []))
+
+
 def get_excluded_connector_names_without_documentation_link() -> set[str]:
     """Return a set of excluded connector names without documentation link.
 

--- a/packages/mp/src/mp/validate/pre_build_validation/integrations/ping_message_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/integrations/ping_message_validation.py
@@ -19,7 +19,7 @@ import os
 from typing import TYPE_CHECKING
 
 import mp.core.unix
-from mp.core import constants
+from mp.core import constants, exclusions
 from mp.core.exceptions import NonFatalValidationError
 
 if TYPE_CHECKING:
@@ -28,6 +28,42 @@ if TYPE_CHECKING:
 # Required substrings in Ping action output messages per the content design guide
 _SUCCESS_PATTERN = "Successfully connected to the"
 _FAILURE_PATTERN = "Failed to connect to the"
+
+
+def _find_ping_file(actions_dir: Path) -> Path | None:
+    """Find the Ping action file in the actions directory.
+
+    Args:
+        actions_dir: Path to the integration's actions directory.
+
+    Returns:
+        Path to the Ping file, or None if not found.
+
+    """
+    for name in ("Ping.py", "ping.py"):
+        candidate = actions_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _is_ping_changed_in_pr(validation_path: Path) -> bool:
+    """Check if the Ping file was modified in the current PR.
+
+    Args:
+        validation_path: The path of the integration to validate.
+
+    Returns:
+        True if Ping was changed or if not running in CI.
+
+    """
+    head_sha: str | None = os.environ.get("GITHUB_PR_SHA")
+    if not head_sha:
+        return True
+    changed = mp.core.unix.get_files_unmerged_to_main_branch(
+        "main", head_sha, validation_path
+    )
+    return any(p.name in {"Ping.py", "ping.py"} for p in changed)
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -45,12 +81,6 @@ class PingMessageFormatValidation:
     def run(validation_path: Path) -> None:
         """Check that Ping action messages match the required format.
 
-        The content design guide requires:
-        - Success: "Successfully connected to the {integration name}..."
-        - Failure: "Failed to connect to the {product name}..."
-
-        Only runs when the Ping file is new or modified in the current PR.
-
         Args:
             validation_path: The path of the integration to validate.
 
@@ -62,25 +92,12 @@ class PingMessageFormatValidation:
         if not actions_dir.is_dir():
             return
 
-        # Find Ping action file (case-insensitive)
-        ping_file = None
-        for name in ("Ping.py", "ping.py"):
-            candidate = actions_dir / name
-            if candidate.exists():
-                ping_file = candidate
-                break
-
-        if ping_file is None:
+        if validation_path.name in exclusions.get_excluded_names_without_ping_message_format():
             return
 
-        # Only enforce on files changed in the current PR
-        head_sha: str | None = os.environ.get("GITHUB_PR_SHA")
-        if head_sha:
-            changed = mp.core.unix.get_files_unmerged_to_main_branch(
-                "main", head_sha, validation_path
-            )
-            if not any(p.name in {"Ping.py", "ping.py"} for p in changed):
-                return
+        ping_file = _find_ping_file(actions_dir)
+        if ping_file is None or not _is_ping_changed_in_pr(validation_path):
+            return
 
         content = ping_file.read_text(encoding="utf-8")
         issues: list[str] = []

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -1,0 +1,257 @@
+# Migration Pipeline
+
+Tools for migrating integrations from [tip-marketplace](https://chronicle-soar.googlesource.com/tip-marketplace) (GOB) to [content-hub](https://github.com/chronicle/content-hub) (GitHub).
+
+## Overview
+
+The migration pipeline converts integrations from the legacy tip-marketplace format to the content-hub format. This involves:
+
+- **Directory restructuring** — monolithic layout to deconstructed source (`ActionsScripts/` -> `actions/`, `Managers/` -> `core/`, etc.)
+- **Import rewrites** — SDK prefix (`soar_sdk.`), TIPCommon submodule split, relative imports
+- **Test generation** — mock infrastructure (`product.py`, `session.py`, `conftest.py`, `test_ping.py`)
+- **Dependency management** — `requirements.txt` -> `pyproject.toml` + `uv.lock`
+- **Metadata** — version bump, release notes, license headers
+
+## Two-PR Workflow (V2)
+
+Migrations are split into two PRs to produce thin, reviewable Gerrit CLs on tip-marketplace:
+
+### PR1: Faithful Migration (`--minimal`)
+
+Performs only the structural changes needed to make the integration work in content-hub. The resulting Gerrit CL (created automatically by the Louhi sync flow) has a thin diff vs. tip-marketplace — mainly TIPCommon import style changes, version +1, and license headers.
+
+```bash
+./tools/migration/migrate_integration.sh --minimal <IntegrationName>
+```
+
+**What it does:**
+- Restructures directories (`mp build -d`)
+- Rewrites all imports (SDK, TIPCommon, internal, test mocks)
+- Renames `_init_managers` -> `_init_api_clients` (TIPCommon 2.x)
+- Replaces `SiemplifySession` -> `requests.Session()` (5 integrations)
+- Generates test infrastructure (product.py, session.py, conftest.py, test_ping.py)
+- Bumps version by +1 and appends a migration release note
+- Adds license headers to all source files
+- Adds integration to ruff.toml exclusions (suppresses lint for legacy code)
+- Adds integration to validator exclusion lists (SSL + Ping message format)
+- Runs lint auto-fix, validation, and tests
+
+**What it skips (deferred to PR2):**
+- Adding/fixing the Verify SSL parameter
+- Rewriting Ping action messages to standard format
+- Version reset to 1.0
+- Release notes history cleanup
+
+**After PR1 merges:**
+- The Louhi `[GitHub] Sync Content Hub to GOB` flow fires automatically
+- A Gerrit CL is created on tip-marketplace with the minimal diff
+- Reviewer approves the CL -> integration is now synced
+
+### PR2: Standardization
+
+Applies content-hub standards after the faithful migration has landed:
+
+```bash
+./tools/migration/standardize.sh <snake_name>
+```
+
+**What it does:**
+- Adds/fixes Verify SSL parameter in `definition.yaml`
+- Flags Ping actions that need message format updates
+- Removes integration from validator exclusion lists
+- Runs lint, validation, and tests
+
+**After PR2 merges:**
+- A second Gerrit CL is created with the improvement changes
+- Reviewer can inspect exactly what was changed vs. the faithful migration
+
+## Scripts
+
+### `migrate_integration.sh`
+
+End-to-end orchestrator. Runs all migration steps in sequence.
+
+```
+Usage: ./tools/migration/migrate_integration.sh [--minimal] <IntegrationName> [destination_dir]
+
+  --minimal         Faithful migration only (skip Verify SSL, Ping rewrite).
+                    For use with the two-PR workflow.
+  IntegrationName   Name as it appears in tip-marketplace (e.g., UrlScanIo, Shodan)
+  destination_dir   Where to place the migrated integration
+                    (default: content/response_integrations/google_new_test)
+```
+
+**Steps:**
+
+| Step | Description |
+|------|-------------|
+| 1 | `migrate.py` — structure/import migration |
+| 1b | Post-migration fixes — JSON result naming, ruff exclusions, release notes cleanup, legacy test cleanup |
+| 2 | `generate_test_mocks.py` — test mock generation (skipped if hand-written mocks exist) |
+| 3 | `mp check --fix` + `mp format` — lint auto-fix |
+| 4 | `mp validate` + `mp check` + `mp build` — validation |
+| 5 | `pytest tests -v` — run tests |
+| 6 | Verify no real HTTP calls in tests |
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PYTHON` | auto-detected | Python interpreter with `libcst` and `mp` available |
+| `MIGRATION_BATCH_MODE` | `false` | Set to `true` when running multiple migrations in a batch (skips per-integration ruff.toml and mp config) |
+
+**Prerequisites:**
+- `mp`, `uv`, `addlicense` on PATH
+- tip-marketplace cloned at `../tip-marketplace` (sibling to content-hub)
+- Python 3.11 available
+
+### `migrate.py`
+
+Core migration engine using `libcst` CST transformers. Called by `migrate_integration.sh`.
+
+```
+Usage: python migrate.py <integrations_path> <dst_path> --tests-dir <tests_path>
+                         [--integrations-list "Name1 Name2"]
+                         [--skip-verify-ssl]
+                         [--debug]
+
+  integrations_path   Source integrations directory (e.g., ../tip-marketplace/Integrations)
+  dst_path            Destination directory in content-hub
+  --tests-dir         Path to tip-marketplace Tests directory
+  --integrations-list Space-separated list of integration names to process
+  --skip-verify-ssl   Skip adding/fixing the Verify SSL parameter (used by --minimal)
+  --debug             Enable debug logging
+```
+
+**Transformations applied:**
+
+| Category | Transformation | Produces GOB diff? |
+|----------|---------------|-------------------|
+| Structure | Directory deconstruction (`mp build -d`) | No (reversed by `mp build`) |
+| Structure | snake_case directory naming | No (reversed by `mp build`) |
+| Structure | stdlib/pip collision avoidance (`http` -> `http_integration`) | No |
+| Imports | SDK prefix (`soar_sdk.`) | No (reversed by `mp build`) |
+| Imports | Relative imports (`from ..core.Manager`) | No (reversed by `mp build`) |
+| Imports | TIPCommon submodule split | **Yes** — `from TIPCommon import X` -> `from TIPCommon.extraction import X` |
+| Imports | Test mock imports (`Tests.mocks` -> `integration_testing`) | No (tests not in build) |
+| Code | `_init_managers` -> `_init_api_clients` | **Yes** — method rename |
+| Code | `SiemplifySession` -> `requests.Session()` | **Yes** — 5 integrations only |
+| Code | Verify SSL parameter (skippable with `--skip-verify-ssl`) | **Yes** — definition.yaml change |
+| Metadata | Version bump (+1) | **Yes** — in `Integration-Name.def` and `RN.json` |
+| Metadata | Migration release note appended | **Yes** — new entry in `RN.json` |
+| Metadata | License headers (`addlicense`) | **Yes** — on all `.py` files |
+| Metadata | `requires-python` upper bound (`>=3.11,<3.12`) | No (not in build output) |
+| Metadata | ruff.toml exclusion | No (not in build output) |
+
+**Key insight:** `mp build` reverses SDK prefix and relative imports back to the tip-marketplace style. The main sources of diff in a Gerrit CL are: TIPCommon imports, version bump, license headers, and method/session renames.
+
+### `generate_test_mocks.py`
+
+Generates test mock infrastructure by analyzing the integration's Manager class and Ping action.
+
+```
+Usage: python generate_test_mocks.py <integration_path>
+```
+
+**Generated files:**
+
+| File | Description |
+|------|-------------|
+| `tests/core/product.py` | Fake API dataclass with `fail_requests()` context manager |
+| `tests/core/session.py` | `MockSession` with `@router` decorated methods for each detected endpoint |
+| `tests/conftest.py` | Pytest fixtures that monkeypatch all HTTP transports |
+| `tests/test_actions/test_ping.py` | `test_ping_success` and `test_ping_failure` tests |
+| `tests/common.py` | `INTEGRATION_PATH` and `CONFIG_PATH` constants |
+| `tests/config.json` | Test configuration with mock values for integration parameters |
+
+**Detection methods for endpoints:**
+1. `ENDPOINTS` dict in Manager
+2. f-string URL construction
+3. `urljoin()` calls
+4. `.format()` calls
+5. String concatenation
+6. Direct `requests.get/post` calls
+
+**Pass rate:** ~41% on all unmigrated integrations; ~78% on standard REST integrations.
+
+### `standardize.sh`
+
+Applies content-hub standards to a previously migrated integration (PR2 of the two-PR workflow).
+
+```
+Usage: ./tools/migration/standardize.sh <integration_snake_name> [integration_parent_dir]
+
+  integration_snake_name   snake_case name (e.g., certly, url_scan_io)
+  integration_parent_dir   Parent directory (default: content/response_integrations/google)
+```
+
+**Steps:**
+1. Adds/fixes Verify SSL parameter in `definition.yaml`
+2. Checks Ping action messages and flags non-compliant ones for manual update
+3. Removes integration from validator exclusion lists (`exclusions.yaml`)
+4. Runs `mp check --fix` + `mp format` + `mp validate` + tests
+
+## How the Louhi GOB Sync Works
+
+When changes to `content/response_integrations/google/**` are merged to `main`, the Louhi flow `[GitHub] Sync Content Hub to GOB` triggers automatically:
+
+1. **Build** — `mp build integration <name>` converts content-hub source to deployable format
+2. **Compare** — For first-time migrations (no `.migration_ignore`), runs comparison tool and logs diffs as context (non-blocking)
+3. **Copy** — Copies built artifacts to tip-marketplace
+4. **CL** — Creates a Gerrit CL on tip-marketplace with the diff
+5. **Notify** — Posts the CL link to Google Chat
+
+The two-PR workflow ensures:
+- **PR1 merge** -> thin Gerrit CL (mainly TIPCommon imports + version bump)
+- **PR2 merge** -> improvements Gerrit CL (Verify SSL, Ping, etc.)
+
+## Validator Exclusion Lists
+
+During `--minimal` migration, integrations are added to exclusion lists to pass validation without Verify SSL or Ping message format changes. These lists live in:
+
+```
+packages/mp/src/mp/core/data/exclusions.yaml
+```
+
+| Key | Validator skipped |
+|-----|------------------|
+| `excluded_names_without_verify_ssl` | SSL Parameter validation |
+| `excluded_names_without_ping_message_format` | Ping Message Format validation |
+
+The `standardize.sh` script removes integrations from these lists after applying the fixes.
+
+## Troubleshooting
+
+### Import errors when running tests
+
+If tests fail with `ModuleNotFoundError: No module named 'OverflowManager'` or similar:
+
+```bash
+export PYTHONPATH=$PYTHONPATH:$(pwd)/.venv/lib/python3.11/site-packages/soar_sdk
+source .venv/bin/activate
+pytest tests -v
+```
+
+This is caused by legacy wheel packages using top-level SDK imports. The fix is to add the `soar_sdk` directory to `PYTHONPATH`.
+
+### `mp` command not found
+
+The `mp` tool must be installed in a venv accessible on PATH:
+
+```bash
+export PATH="$(git worktree list | head -1 | awk '{print $1}')/.venv/bin:$PATH"
+```
+
+### tip-marketplace not found
+
+Clone tip-marketplace as a sibling to content-hub:
+
+```bash
+cd ..
+git clone https://chronicle-soar.googlesource.com/tip-marketplace
+cd tip-marketplace && git checkout rc
+```
+
+### Validation fails on `exclusions.yaml`
+
+If you see a YAML parse error in `exclusions.yaml`, check that no list key has `[]` (inline empty array) with block entries below it. The `--minimal` flag handles this, but manual edits may introduce it.

--- a/tools/migration/migrate.py
+++ b/tools/migration/migrate.py
@@ -1,0 +1,1167 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+
+
+
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tomllib
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Union, cast
+
+import libcst as cst
+import mp.core.file_utils
+import toml
+import yaml
+from mp.build_project.integrations_repo import IntegrationsRepo
+from mp.core.config import get_local_packages_path, get_marketplace_path
+from mp.core.constants import SDK_MODULES
+from mp.core.unix import add_dependencies_to_toml
+from mp.core.utils.common import str_to_snake_case
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn
+
+# --- Global Configuration Constants ---
+
+WIDGETS_DIR = "Widgets"
+PYPROJECT_TOML = "pyproject.toml"
+PYTHONPATH_FILE = "pythonpath.txt"
+RELEASE_NOTES_FILE = "release_notes.yaml"
+RUFF_TOML = "ruff.toml"
+
+INTEGRATIONS_PATH_MAPPING = {
+    "ActionsScripts": "actions",
+    "JobsScrips": "jobs",
+    "Managers": "core",
+    "ConnectorScripts": "connectors",
+    "ConnectorsScripts": "connectors",
+}
+
+TESTS_PATH_MAPPING = {
+    "session": "requests.session",
+    "response": "requests.response",
+}
+
+# integration_testing 2.x renamed get_json_file_content -> get_def_file_content.
+# Legacy tests use the old name. The mapping renames both calls and imports.
+TESTS_FUNCTIONS_MAPPING = {"get_json_file_content": "get_def_file_content"}
+
+TIPCOMMON_FUNCTIONS_MAPPING = {
+    # --- TIPCommon.extraction ---
+    "extract_configuration_param": "TIPCommon.extraction",
+    "extract_action_param": "TIPCommon.extraction",
+    "extract_connector_param": "TIPCommon.extraction",
+    "extract_job_param": "TIPCommon.extraction",
+    "extract_script_param": "TIPCommon.extraction",
+    # --- TIPCommon.transformation ---
+    "construct_csv": "TIPCommon.transformation",
+    "add_prefix_to_dict": "TIPCommon.transformation",
+    "dict_to_flat": "TIPCommon.transformation",
+    "flat_dict_to_csv": "TIPCommon.transformation",
+    "convert_comma_separated_to_list": "TIPCommon.transformation",
+    "convert_list_to_comma_string": "TIPCommon.transformation",
+    "string_to_multi_value": "TIPCommon.transformation",
+    "add_prefix_to_dict_keys": "TIPCommon.transformation",
+    "adjust_to_csv": "TIPCommon.transformation",
+    "get_unicode": "TIPCommon.transformation",
+    # --- TIPCommon.smp_time ---
+    "is_approaching_timeout": "TIPCommon.smp_time",
+    "get_last_success_time": "TIPCommon.smp_time",
+    "save_timestamp": "TIPCommon.smp_time",
+    "validate_timestamp": "TIPCommon.smp_time",
+    "unix_now": "TIPCommon.smp_time",
+    "siemplify_save_timestamp": "TIPCommon.smp_time",
+    "siemplify_fetch_timestamp": "TIPCommon.smp_time",
+    "convert_datetime_to_unix_time": "TIPCommon.smp_time",
+    "utc_now": "TIPCommon.smp_time",
+    # --- TIPCommon.filters ---
+    "filter_old_alerts": "TIPCommon.filters",
+    "pass_whitelist_filter": "TIPCommon.filters",
+    "filter_old_ids": "TIPCommon.filters",
+    # --- TIPCommon.utils ---
+    "is_overflowed": "TIPCommon.utils",
+    "is_test_run": "TIPCommon.utils",
+    "none_to_default_value": "TIPCommon.utils",
+    "platform_supports_db": "TIPCommon.utils",
+    "is_empty_string_or_none": "TIPCommon.utils",
+    # --- TIPCommon.smp_io ---
+    "read_ids": "TIPCommon.smp_io",
+    "write_ids": "TIPCommon.smp_io",
+    "read_content": "TIPCommon.smp_io",
+    "write_content": "TIPCommon.smp_io",
+    "write_ids_with_timestamp": "TIPCommon.smp_io",
+    "read_ids_by_timestamp": "TIPCommon.smp_io",
+    # --- TIPCommon.consts ---
+    "UNIX_FORMAT": "TIPCommon.consts",
+    "WHITELIST_FILTER": "TIPCommon.consts",
+    "BLACKLIST_FILTER": "TIPCommon.consts",
+    "NUM_OF_MILLI_IN_SEC": "TIPCommon.consts",
+    "TIMEOUT_THRESHOLD": "TIPCommon.consts",
+    "DATETIME_FORMAT": "TIPCommon.consts",
+    "IDS_DB_KEY": "TIPCommon.consts",
+    "IDS_FILE_NAME": "TIPCommon.consts",
+}
+
+MIGRATION_RELEASE_NOTE_TEMPLATE = {
+    "description": (
+        "Integration - Source code for the integration is now available publicly on "
+        "Github. Link to repo: https://github.com/chronicle/content-hub"
+    ),
+    "integration_version": "{integration_version}",
+    "item_name": "{item_name}",
+    "item_type": "Integration",
+    "publish_time": "{publish_time}",
+    "new": False,
+    "regressive": False,
+    "deprecated": False,
+    "removed": False,
+    "ticket_number": "495762513",
+}
+
+NEW_IMPORT_TEST_CONTENT = (
+    "from __future__ import annotations\n\n"
+    "from integration_testing.default_tests.import_test import import_all_integration_modules\n\n"
+    "from .. import common\n\n\n"
+    "def test_imports() -> None:\n"
+    "    import_all_integration_modules(common.INTEGRATION_PATH)\n"
+)
+
+# Initialize Rich Console and Logging
+console = Console()
+logging.basicConfig(
+    level="INFO",
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[RichHandler(rich_tracebacks=True, console=console)],
+)
+logger = logging.getLogger("refactor_integration")
+
+
+# --- Utility Functions ---
+
+
+def _capitalize_first_letter(s: str) -> str:
+    """Capitalizes the first letter of a string, leaving the rest unchanged."""
+    return s[:1].upper() + s[1:] if s else s
+
+
+def _get_module_path_str(module_node: Optional[cst.BaseExpression]) -> str:
+    """Recursively reconstructs the full dotted path from a CST node."""
+    if module_node is None:
+        return ""
+    if isinstance(module_node, cst.Name):
+        return module_node.value
+    if isinstance(module_node, cst.Attribute):
+        return f"{_get_module_path_str(module_node.value)}.{module_node.attr.value}"
+    return ""
+
+
+def _remap_sdk_path(path: str) -> str:
+    """Adds 'soar_sdk.' prefix to modules from the SDK."""
+    if path and path.split(".")[0] in SDK_MODULES:
+        return f"soar_sdk.{path}"
+    return path
+
+
+# --- CST Transformers ---
+
+
+class ImportTransformer(cst.CSTTransformer):
+    """Handles remapping of imports during integration refactoring."""
+
+    def __init__(self, integration_name: str, deconstructed_name: str,
+                 core_module_names: set[str] | None = None):
+        super().__init__()
+        self.integration_name = integration_name
+        self.deconstructed_name = deconstructed_name
+        self.needs_abc_import = False
+        self.has_abc_import = False
+        # Names of .py files in core/ (without extension) for bare import detection
+        self.core_module_names = core_module_names or set()
+
+    def _remap_integration_path(self, path: str) -> str:
+        prefix = f"Integrations.{self.integration_name}"
+        if not path.startswith(prefix):
+            return path
+
+        parts = path[len(prefix) :].strip(".").split(".")
+        if parts and parts[0] in INTEGRATIONS_PATH_MAPPING:
+            parts[0] = INTEGRATIONS_PATH_MAPPING[parts[0]]
+
+        return ".".join(filter(None, [self.deconstructed_name] + parts))
+
+    def visit_Import(self, node: cst.Import) -> None:
+        for alias in node.names:
+            if isinstance(alias, cst.ImportAlias) and alias.name.value == "abc":
+                self.has_abc_import = True
+
+    def leave_Import(self, original_node: cst.Import, updated_node: cst.Import) -> cst.Import:
+        new_aliases = []
+        for alias in updated_node.names:
+            if isinstance(alias, cst.ImportAlias):
+                old_path = _get_module_path_str(alias.name)
+                remapped_path = self._remap_integration_path(old_path)
+                new_path = _remap_sdk_path(remapped_path)
+                new_aliases.append(alias.with_changes(name=cst.parse_expression(new_path)))
+            else:
+                new_aliases.append(alias)
+        return updated_node.with_changes(names=tuple(new_aliases))
+
+    def leave_ImportFrom(
+        self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
+    ) -> Union[cst.ImportFrom, cst.RemovalSentinel]:
+        if updated_node.module is None:
+            return updated_node
+
+        module_path = _get_module_path_str(updated_node.module)
+
+        if "Tests.mocks.product" in module_path:
+            self.needs_abc_import = True
+            return cst.RemoveFromParent()
+
+        # Handle SDK module relocations (CaseInfo moved from SiemplifyConnectors
+        # to SiemplifyConnectorsDataModel)
+        if module_path == "SiemplifyConnectors" and isinstance(updated_node.names, (list, tuple)):
+            names = [a.name.value for a in updated_node.names if isinstance(a, cst.ImportAlias)]
+            if "CaseInfo" in names:
+                return updated_node.with_changes(
+                    module=cst.parse_expression("soar_sdk.SiemplifyConnectorsDataModel"),
+                    relative=(),
+                )
+
+        remapped_path = _remap_sdk_path(module_path)
+
+        if module_path.startswith(f"Integrations.{self.integration_name}"):
+            remapped = self._remap_integration_path(remapped_path)
+            return updated_node.with_changes(
+                module=cst.parse_expression(remapped),
+                relative=(),
+            )
+
+        test_prefix = f"Tests.integrations.{self.integration_name}"
+        if module_path.startswith(test_prefix):
+            new_module = module_path.replace(test_prefix, f"{self.deconstructed_name}.tests", 1)
+            return updated_node.with_changes(
+                module=cst.parse_expression(new_module),
+                relative=(),
+            )
+
+        if "Tests.mocks" in module_path:
+            return self._handle_mock_utility_imports(updated_node, module_path)
+
+        if module_path == "TIPCommon":
+            return self._handle_tip_common_imports(updated_node)
+
+        if remapped_path != module_path:
+            return updated_node.with_changes(
+                module=cst.parse_expression(remapped_path), relative=()
+            )
+
+        # Detect bare imports matching core/ module files
+        # e.g., "from datamodels import X" -> "from .datamodels import X" (in core/)
+        #    or "from datamodels import X" -> "from ..core.datamodels import X" (in actions/)
+        if self.core_module_names and module_path in self.core_module_names:
+            return updated_node.with_changes(
+                module=cst.parse_expression(f"core.{module_path}"),
+                relative=(cst.Dot(), cst.Dot()),
+            )
+
+        return updated_node
+
+    def _handle_tip_common_imports(self, node: cst.ImportFrom) -> Union[cst.ImportFrom, cst.FlattenSentinel]:
+        if isinstance(node.names, cst.ImportStar):
+            return node
+
+        submodule_to_names: Dict[str, list[cst.ImportAlias]] = {}
+        for alias in node.names:
+            if not isinstance(alias, cst.ImportAlias):
+                continue
+            name = alias.name.value
+            submodule = TIPCOMMON_FUNCTIONS_MAPPING.get(name, "TIPCommon")
+            submodule_to_names.setdefault(submodule, []).append(alias)
+
+        if not submodule_to_names:
+            return node
+
+        if len(submodule_to_names) == 1:
+            submodule = next(iter(submodule_to_names))
+            return node.with_changes(module=cst.parse_expression(submodule), relative=())
+
+        new_imports = []
+        for submodule, names in submodule_to_names.items():
+            # Strip trailing comma from last alias to avoid syntax errors
+            last = names[-1]
+            if isinstance(getattr(last, "comma", None), cst.Comma):
+                names[-1] = last.with_changes(comma=cst.MaybeSentinel.DEFAULT)
+            new_imports.append(
+                node.with_changes(
+                    module=cst.parse_expression(submodule), names=tuple(names), relative=()
+                )
+            )
+
+        return cst.FlattenSentinel(new_imports)
+
+    def _handle_mock_utility_imports(self, node: cst.ImportFrom, path: str) -> cst.ImportFrom:
+        new_path = path.replace("Tests.mocks", "integration_testing")
+        for old, new in TESTS_PATH_MAPPING.items():
+            new_path = new_path.replace(old, new)
+
+        if isinstance(node.names, cst.ImportStar):
+            return node.with_changes(module=cst.parse_expression(new_path), relative=())
+
+        new_names = []
+        for alias in node.names:
+            if not isinstance(alias, cst.ImportAlias):
+                new_names.append(alias)
+                continue
+            name = alias.name.value
+            if name in TESTS_FUNCTIONS_MAPPING:
+                new_name = cst.Name(TESTS_FUNCTIONS_MAPPING[name])
+                new_names.append(alias.with_changes(name=new_name))
+            elif name in ("set_is_first_run_to", "set_is_test_run_to"):
+                new_names.extend([
+                    cst.ImportAlias(name=cst.Name(f"{name}_true")),
+                    cst.ImportAlias(name=cst.Name(f"{name}_false")),
+                ])
+            else:
+                new_names.append(alias)
+        return node.with_changes(
+            module=cst.parse_expression(new_path), relative=(), names=tuple(new_names)
+        )
+
+    def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:
+        func = updated_node.func
+        if isinstance(func, cst.Name) and func.value in (
+            "set_is_first_run_to",
+            "set_is_test_run_to",
+        ):
+            if updated_node.args:
+                val = updated_node.args[0].value
+                if isinstance(val, cst.Name) and val.value in ("True", "False"):
+                    new_func_name = f"{func.value}_{val.value.lower()}"
+                    return updated_node.with_changes(func=cst.Name(new_func_name), args=[])
+
+        if isinstance(func, (cst.Name, cst.Attribute)):
+            name_node = func.attr if isinstance(func, cst.Attribute) else func
+            if name_node.value in TESTS_FUNCTIONS_MAPPING:
+                new_name = cst.Name(TESTS_FUNCTIONS_MAPPING[name_node.value])
+                if isinstance(func, cst.Attribute):
+                    return updated_node.with_changes(func=func.with_changes(attr=new_name))
+                return updated_node.with_changes(func=new_name)
+        return updated_node
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        """Rename function definitions listed in TESTS_FUNCTIONS_MAPPING."""
+        name = updated_node.name.value
+        if name in TESTS_FUNCTIONS_MAPPING:
+            new_name = TESTS_FUNCTIONS_MAPPING[name]
+            return updated_node.with_changes(name=cst.Name(new_name))
+        return updated_node
+
+    def leave_SimpleString(
+        self, original_node: cst.SimpleString, updated_node: cst.SimpleString
+    ) -> cst.SimpleString:
+        raw_val = updated_node.value.strip("'\"")
+        quote = updated_node.value[0]
+
+        if raw_val.startswith(f"Integrations.{self.integration_name}"):
+            remapped = self._remap_integration_path(raw_val)
+            return updated_node.with_changes(value=f"{quote}{remapped}{quote}")
+
+        test_prefix = f"Tests.integrations.{self.integration_name}"
+        if raw_val.startswith(test_prefix):
+            replaced = raw_val.replace(test_prefix, "tests", 1)
+            return updated_node.with_changes(value=f"{quote}{replaced}{quote}")
+
+        if raw_val.endswith((".actiondef", ".connectordef", ".jobdef")):
+            new_val = (
+                raw_val
+                .replace(".actiondef", ".yaml")
+                .replace(".connectordef", ".yaml")
+                .replace(".jobdef", ".yaml")
+            )
+            return updated_node.with_changes(value=f"{quote}{new_val}{quote}")
+        return updated_node
+
+    def leave_ClassDef(
+        self, original_node: cst.ClassDef, updated_node: cst.ClassDef
+    ) -> cst.ClassDef:
+        new_bases = [
+            b.with_changes(value=cst.parse_expression("abc.ABC"))
+            if (isinstance(b.value, cst.Name) and b.value.value == "MockProduct")
+            else b
+            for b in updated_node.bases
+        ]
+        if any(b != old_b for b, old_b in zip(new_bases, updated_node.bases)):
+            self.needs_abc_import = True
+            return updated_node.with_changes(bases=new_bases)
+        return updated_node
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        if self.needs_abc_import and not self.has_abc_import:
+            new_body = list(updated_node.body)
+            idx = 1 if new_body and self._is_future(new_body[0]) else 0
+            new_body.insert(idx, cast(cst.SimpleStatementLine, cst.parse_statement("import abc")))
+            return updated_node.with_changes(body=tuple(new_body))
+        return updated_node
+
+    @staticmethod
+    def _is_future(node: Any) -> bool:
+        return (
+            isinstance(node, cst.SimpleStatementLine)
+            and isinstance(node.body[0], cst.ImportFrom)
+            and getattr(node.body[0].module, "value", "") == "__future__"
+        )
+
+
+class UpsertIntegrationPathTransformer(cst.CSTTransformer):
+    """Ensures necessary imports and INTEGRATION_PATH exist in common.py."""
+
+    def __init__(self):
+        super().__init__()
+        self.has_future = False
+        self.has_pathlib = False
+        self.has_int_path = False
+
+    def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
+        if node.module and isinstance(node.module, cst.Name) and node.module.value == "__future__":
+            if isinstance(node.names, Sequence):
+                if any(
+                    isinstance(a, cst.ImportAlias) and a.name.value == "annotations"
+                    for a in node.names
+                ):
+                    self.has_future = True
+
+    def visit_Import(self, node: cst.Import) -> None:
+        if any(isinstance(a, cst.ImportAlias) and a.name.value == "pathlib" for a in node.names):
+            self.has_pathlib = True
+
+    def leave_Assign(
+        self, original_node: cst.Assign, updated_node: cst.Assign
+    ) -> Union[cst.Assign, cst.AnnAssign]:
+        if len(updated_node.targets) == 1:
+            target = updated_node.targets[0].target
+            if isinstance(target, cst.Name) and target.value == "INTEGRATION_PATH":
+                self.has_int_path = True
+                return cst.AnnAssign(
+                    target=target,
+                    annotation=cst.Annotation(cst.parse_expression("pathlib.Path")),
+                    value=cst.parse_expression("pathlib.Path(__file__).parent.parent"),
+                )
+        return updated_node
+
+    def leave_AnnAssign(
+        self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign
+    ) -> cst.AnnAssign:
+        if (
+            isinstance(updated_node.target, cst.Name)
+            and updated_node.target.value == "INTEGRATION_PATH"
+        ):
+            self.has_int_path = True
+            return updated_node.with_changes(
+                annotation=cst.Annotation(cst.parse_expression("pathlib.Path")),
+                value=cst.parse_expression("pathlib.Path(__file__).parent.parent"),
+            )
+        return updated_node
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        new_body = list(updated_node.body)
+        if not self.has_int_path:
+            new_body.append(
+                cast(
+                    cst.SimpleStatementLine,
+                    cst.parse_statement(
+                        "INTEGRATION_PATH: pathlib.Path = pathlib.Path(__file__).parent.parent"
+                    ),
+                )
+            )
+        if not self.has_pathlib:
+            new_body.insert(0, cast(cst.SimpleStatementLine, cst.parse_statement("import pathlib")))
+        if not self.has_future:
+            new_body.insert(
+                0,
+                cast(
+                    cst.SimpleStatementLine,
+                    cst.parse_statement("from __future__ import annotations"),
+                ),
+            )
+        return updated_node.with_changes(body=tuple(new_body))
+
+
+# --- Main Engine ---
+
+
+class IntegrationRefactorer:
+    """The core engine for refactoring integrations."""
+
+    def __init__(self, integrations_root: Path, dst_path: Path, tests_dir: Path, integrations_list: Optional[str] = None, skip_verify_ssl: bool = False):
+        self.integrations_root = integrations_root.resolve()
+        self.dst_path = dst_path.resolve()
+        self.tests_dir = tests_dir.resolve()
+        self.integrations_list = integrations_list
+        self.skip_verify_ssl = skip_verify_ssl
+        self.repo = IntegrationsRepo(self.integrations_root, self.dst_path, default_source=False)
+
+    def process_all(self):
+        """Processes integrations found in the root directory or from the provided list string."""
+        if self.integrations_list:
+            target_names = [
+                word for word in self.integrations_list.split() 
+                if not word.startswith("(")
+            ]
+            integrations = []
+            for name in target_names:
+                p = self.integrations_root / name
+                if p.is_dir() and mp.core.file_utils.is_integration(p):
+                    integrations.append(p)
+                else:
+                    logger.warning(f"Integration target not found or invalid: {name}")
+        else:
+            integrations = [
+                p
+                for p in self.integrations_root.iterdir()
+                if p.is_dir() and mp.core.file_utils.is_integration(p)
+            ]
+
+        if not integrations:
+            logger.warning(f"No integrations found in {self.integrations_root}")
+            return
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Refactoring integrations...", total=len(integrations))
+            for integration_path in integrations:
+                try:
+                    self.refactor_single(integration_path)
+                except Exception as e:
+                    logger.error(f"Failed to refactor {integration_path.name}: {e}", exc_info=True)
+                progress.advance(task)
+
+    def refactor_single(self, integration_path: Path):
+        """Refactors a single integration."""
+        integration_name = integration_path.name
+        deconstructed_path = self.dst_path / str_to_snake_case(integration_name)
+
+        logger.info(f"[bold blue]Processing: {integration_name}[/bold blue]")
+
+        # 1. Widgets
+        self.convert_widgets(integration_path)
+
+        # 2. Deconstruct
+        logger.info("Deconstructing integration...")
+        self.repo.deconstruct_integration(integration_path)
+
+        self.copy_ai_descriptions(integration_path, deconstructed_path)
+
+        # 2a. Fix requires-python, release notes, and Verify SSL
+        self._fix_requires_python(deconstructed_path)
+        self._fix_release_notes(deconstructed_path)
+        if not self.skip_verify_ssl:
+            self._fix_verify_ssl(deconstructed_path)
+
+        # 2b. Fix imports in integration source files (actions, core, etc.)
+        logger.info("Fixing imports in integration source files...")
+        # Collect core/ module names for bare import detection
+        core_dir = deconstructed_path / "core"
+        core_module_names = {
+            f.stem for f in core_dir.glob("*.py")
+            if f.stem != "__init__"
+        } if core_dir.is_dir() else set()
+
+        excluded = {".venv", "tests", "__pycache__"}
+        for file_path in deconstructed_path.rglob("*.py"):
+            if not any(p in excluded for p in file_path.parts):
+                self._transform_python_file(file_path, integration_name, deconstructed_path.name, core_module_names)
+
+        # 2c. Replace SiemplifySession with requests.Session
+        # SiemplifySession was a TIPCommon 1.x class (requests.Session subclass
+        # that masked sensitive data in error messages). Removed in TIPCommon 2.x.
+        # Only 5 integrations use it. Direct rewrite is cleanest.
+        self._replace_siemplify_session(deconstructed_path)
+
+        # 2d. Rename _init_managers -> _init_api_clients (TIPCommon 2.x rename)
+        self._rename_deprecated_methods(deconstructed_path)
+
+        # 3. Tests
+        self.convert_tests(integration_name, deconstructed_path)
+
+        # 4. Version & Sync
+        self.increment_version_and_sync(deconstructed_path, integration_name)
+
+        # 5. License Headers
+        self.add_license_headers(deconstructed_path)
+
+        # 6. Ruff Exclude (skip in batch mode to avoid race condition on shared file)
+        if not os.environ.get("MIGRATION_BATCH_MODE"):
+            self.add_to_ruff_specific_integrations(deconstructed_path.name)
+
+    @staticmethod
+    def _fix_release_notes(deconstructed_path: Path):
+        """Fix empty publish_time in release notes (validation requires YYYY-MM-DD)."""
+        rn_path = deconstructed_path / RELEASE_NOTES_FILE
+        if not rn_path.exists():
+            return
+        content = rn_path.read_text(encoding="utf-8")
+        notes = yaml.safe_load(content)
+        if not notes:
+            return
+        changed = False
+        for note in notes:
+            pt = note.get("publish_time")
+            if not pt or pt == "":
+                note["publish_time"] = "2020-01-01"
+                changed = True
+        if changed:
+            with open(rn_path, "w", encoding="utf-8") as f:
+                yaml.dump(notes, f, default_flow_style=False, sort_keys=False)
+            logger.info("Fixed empty publish_time entries in release_notes.yaml")
+
+    @staticmethod
+    def _fix_verify_ssl(deconstructed_path: Path):
+        """Ensure Verify SSL parameter exists with default 'true' and correct description."""
+        def_path = deconstructed_path / "definition.yaml"
+        if not def_path.exists():
+            return
+        data = yaml.safe_load(def_path.read_text(encoding="utf-8"))
+        if not data:
+            return
+        
+        params = data.setdefault("parameters", [])
+        ssl_param = next((p for p in params if p.get("name") == "Verify SSL"), None)
+        
+        if not ssl_param:
+            ssl_param = {
+                "name": "Verify SSL",
+                "type": "boolean",
+                "is_mandatory": False,
+                "integration_identifier": data.get("identifier", deconstructed_path.name)
+            }
+            params.append(ssl_param)
+            changed = True
+        else:
+            changed = False
+
+        if not ssl_param.get("default_value") or ssl_param["default_value"] == "":
+            ssl_param["default_value"] = "true"
+            changed = True
+            
+        expected_desc = (
+            "If selected, the integration validates the SSL certificate "
+            f"when connecting to {data.get('name', 'the server')}. Selected by default."
+        )
+        if ssl_param.get("description") != expected_desc:
+            ssl_param["description"] = expected_desc
+            changed = True
+
+        if changed:
+            with open(def_path, "w", encoding="utf-8") as f:
+                yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            logger.info("Fixed/Added Verify SSL in definition.yaml")
+
+    @staticmethod
+    def _fix_requires_python(deconstructed_path: Path):
+        """Fix requires-python to include upper bound (>=3.11,<3.12)."""
+        pyproject_path = deconstructed_path / PYPROJECT_TOML
+        if not pyproject_path.exists():
+            return
+        content = pyproject_path.read_text(encoding="utf-8")
+        if 'requires-python = ">=3.11"' in content:
+            content = content.replace(
+                'requires-python = ">=3.11"',
+                'requires-python = ">=3.11,<3.12"'
+            )
+            pyproject_path.write_text(content, encoding="utf-8")
+
+    def copy_ai_descriptions(self, integration_path: Path, deconstructed_path: Path):
+        src = integration_path / "resources" / "ai" / "actions_ai_description.yaml"
+        if src.is_file():
+            dst_dir = deconstructed_path / "resources"
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst_dir / src.name)
+        else:
+            logger.info(f"No actions_ai_description.yaml found for {integration_path.name}, skipping.")
+
+    def convert_widgets(self, integration_path: Path):
+        widgets_dir = integration_path / WIDGETS_DIR
+        if not widgets_dir.is_dir():
+            logger.debug(f"No 'Widgets' directory in {integration_path.name}")
+            return
+
+        for json_file in widgets_dir.glob("*.json"):
+            try:
+                with open(json_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                converted = self._transform_widget_data(data)
+                with open(json_file, "w", encoding="utf-8") as f:
+                    json.dump(converted, f, indent=4)
+            except Exception as e:
+                logger.error(f"Error converting widget {json_file.name}: {e}")
+
+    @staticmethod
+    def _transform_widget_data(data: Dict[str, Any]) -> Dict[str, Any]:
+        transformed = {}
+        for key, value in data.items():
+            new_key = _capitalize_first_letter(key)
+            if new_key == "DataDefinition":
+                transformed[new_key] = value
+            elif new_key == "ConditionsGroup" and isinstance(value, dict):
+                transformed_group = {}
+                for cg_key, cg_value in value.items():
+                    new_cg_key = _capitalize_first_letter(cg_key)
+                    if new_cg_key == "Conditions" and isinstance(cg_value, list):
+                        transformed_group[new_cg_key] = [
+                            {_capitalize_first_letter(k): v for k, v in item.items()}
+                            for item in cg_value
+                            if isinstance(item, dict)
+                        ]
+                    else:
+                        transformed_group[new_cg_key] = cg_value
+                transformed[new_key] = transformed_group
+            else:
+                transformed[new_key] = value
+        return transformed
+
+    def convert_tests(self, integration_name: str, deconstructed_path: Path):
+        tests_src_path = self.tests_dir / "integrations" / integration_name
+        tests_dest_path = deconstructed_path / "tests"
+        deconstructed_name = deconstructed_path.name
+
+        if tests_src_path.is_dir() and not tests_dest_path.is_dir():
+            shutil.copytree(tests_src_path, tests_dest_path)
+
+        self._cleanup_test_files(tests_dest_path)
+        self._handle_test_dependencies(deconstructed_path, tests_dest_path)
+        self._refactor_common_py(tests_dest_path)
+
+        for file_path in tests_dest_path.rglob("*.py"):
+            self._transform_python_file(file_path, integration_name, deconstructed_name)
+
+        for root, _, _ in os.walk(tests_dest_path):
+            (Path(root) / "__init__.py").touch(exist_ok=True)
+
+        self._ensure_conftest_plugins(tests_dest_path)
+
+    def _cleanup_test_files(self, tests_path: Path):
+        paths_to_delete = [tests_path / PYTHONPATH_FILE] + list(tests_path.rglob("test_imports.py"))
+        for file in paths_to_delete:
+            if file.exists():
+                file.unlink()
+
+    def _handle_test_dependencies(self, deconstructed_path: Path, tests_dest_path: Path):
+        pyproject_path = deconstructed_path / PYPROJECT_TOML
+        if not pyproject_path.exists():
+            return
+
+        with pyproject_path.open("rb") as f:
+            pyproject_data = tomllib.load(f)
+
+        dev_deps = pyproject_data.get("dependency-groups", {}).get("dev", [])
+        reg_deps = pyproject_data.get("project", {}).get("dependencies", [])
+        all_deps = dev_deps + reg_deps
+
+        if not any(d.startswith("integration-testing") for d in dev_deps):
+            self._add_local_deps(deconstructed_path)
+            self._check_mock_imports(tests_dest_path)
+
+    @staticmethod
+    def _find_packages_dir(path: Path) -> Path | None:
+        """Walk up from integration path to find the packages/ directory."""
+        candidate = path.resolve()
+        while candidate.parent != candidate:
+            if (candidate / "packages" / "tipcommon").exists():
+                return candidate / "packages"
+            candidate = candidate.parent
+        return None
+
+    @staticmethod
+    def _add_local_deps(path: Path):
+        # Discover packages/ by walking up from integration path.
+        # Don't use get_local_packages_path() — mp config gets reverted.
+        local_path = IntegrationRefactorer._find_packages_dir(path)
+        if local_path is None:
+            logger.warning("Cannot find packages/ directory — dev deps will be missing")
+            return
+
+        whls = {
+            "environmentcommon": local_path / "envcommon" / "whls" / "EnvironmentCommon-1.0.3-py3-none-any.whl",
+            "integration-testing": local_path / "integration_testing_whls" / "integration_testing-2.2.22-py3-none-any.whl",
+            "tipcommon": local_path / "tipcommon" / "whls" / "TIPCommon-2.2.22-py2.py3-none-any.whl",
+        }
+        existing = {name: p for name, p in whls.items() if p.exists()}
+        if not existing:
+            logger.warning(f"No wheel files found at {local_path}")
+            return
+
+        # Write deps directly to pyproject.toml instead of calling uv add
+        # (uv add fails when --default-index is missing from the installed mp)
+        pyproject_path = path / PYPROJECT_TOML
+        with open(pyproject_path, "r", encoding="utf-8") as f:
+            data = toml.load(f)
+
+        dev_group = data.setdefault("dependency-groups", {}).setdefault("dev", [])
+        sources = data.setdefault("tool", {}).setdefault("uv", {}).setdefault("sources", {})
+
+        # Add wheel-based deps
+        for name, whl_path in existing.items():
+            if not any(name in d for d in dev_group):
+                dev_group.append(name)
+            rel_path = os.path.relpath(whl_path, path)
+            sources[name] = {"path": rel_path}
+
+        # Ensure base dev deps are present (pytest, soar-sdk, etc.)
+        # These may have been lost if the deconstruct step's uv add failed
+        base_dev_deps = {
+            "pytest>=8.3.5": None,
+            "pytest-json-report>=1.5.0": None,
+            "pytest-mock>=3.14.0": None,
+            "soar-sdk": {"git": "https://github.com/chronicle/soar-sdk.git"},
+        }
+        for dep, source in base_dev_deps.items():
+            dep_name = dep.split(">=")[0].split("==")[0]
+            if not any(dep_name in d for d in dev_group):
+                dev_group.append(dep)
+            if source and dep_name not in sources:
+                sources[dep_name] = source
+
+        # Ensure PyPI index is configured
+        uv_section = data.setdefault("tool", {}).setdefault("uv", {})
+        if "index" not in uv_section:
+            uv_section["index"] = [{"url": "https://pypi.org/simple", "default": True}]
+
+        with open(pyproject_path, "w", encoding="utf-8") as f:
+            toml.dump(data, f)
+        # uv sync will be called by increment_version_and_sync() later
+
+    @staticmethod
+    def _add_test_framework_deps(path: Path):
+        local_path = IntegrationRefactorer._find_packages_dir(path)
+        if local_path is None:
+            return
+
+        whls = {
+            "environmentcommon": local_path / "envcommon" / "whls" / "EnvironmentCommon-1.0.3-py3-none-any.whl",
+            "integration-testing": local_path / "integration_testing_whls" / "integration_testing-2.2.22-py3-none-any.whl",
+        }
+        existing = {name: p for name, p in whls.items() if p.exists()}
+        if not existing:
+            return
+
+        pyproject_path = path / PYPROJECT_TOML
+        with open(pyproject_path, "r", encoding="utf-8") as f:
+            data = toml.load(f)
+
+        dev_group = data.setdefault("dependency-groups", {}).setdefault("dev", [])
+        sources = data.setdefault("tool", {}).setdefault("uv", {}).setdefault("sources", {})
+
+        for name, whl_path in existing.items():
+            if not any(name in d for d in dev_group):
+                dev_group.append(name)
+            rel_path = os.path.relpath(whl_path, path)
+            sources[name] = {"path": rel_path}
+
+        with open(pyproject_path, "w", encoding="utf-8") as f:
+            toml.dump(data, f)
+
+    @staticmethod
+    def _check_mock_imports(path: Path):
+        for file in path.rglob("*.py"):
+            content = file.read_text()
+            if "from Tests.mocks" in content or "import Tests.mocks" in content:
+                logger.warning(f"Manual intervention needed: Mock imports found in {file}")
+
+    def _refactor_common_py(self, tests_path: Path):
+        common_py = tests_path / "common.py"
+        content = common_py.read_text(encoding="utf-8") if common_py.exists() else ""
+
+        tree = cst.parse_module(content)
+        modified = tree.visit(UpsertIntegrationPathTransformer())
+        common_py.write_text(modified.code, encoding="utf-8")
+
+        test_defaults = tests_path / "test_defaults"
+        test_defaults.mkdir(exist_ok=True)
+        (test_defaults / "test_imports.py").write_text(NEW_IMPORT_TEST_CONTENT)
+
+    def _transform_python_file(
+        self, file_path: Path, integration_name: str, deconstructed_name: str,
+        core_module_names: set[str] | None = None
+    ):
+        try:
+            content = file_path.read_text(encoding="utf-8")
+            wrapper = cst.MetadataWrapper(cst.parse_module(content))
+            transformer = ImportTransformer(integration_name, deconstructed_name, core_module_names)
+            modified_tree = wrapper.visit(transformer)
+
+            if not wrapper.module.deep_equals(modified_tree):
+                file_path.write_text(modified_tree.code, encoding="utf-8")
+        except Exception as e:
+            logger.error(f"Failed to transform {file_path.name}: {e}")
+
+    @staticmethod
+    def _replace_siemplify_session(deconstructed_path: Path):
+        """Replace SiemplifySession (TIPCommon 1.x) with requests.Session.
+
+        SiemplifySession was a requests.Session subclass that masked sensitive
+        data in error messages. It was removed in TIPCommon 2.x with no
+        replacement. Only 5 legacy integrations use it.
+
+        Rewrites:
+          from TIPCommon import SiemplifySession
+            -> (removed, requests is already imported)
+          self.session = SiemplifySession(sensitive_data_arr=[...])
+            -> self.session = requests.Session()
+          session = SiemplifySession(...)
+            -> session = requests.Session()
+          SiemplifySession().encode_data(x)
+            -> x[:1] + "..." + x[-1:]  (inline the trivial masking logic)
+        """
+        import re
+
+        excluded = {".venv", "tests", "__pycache__"}
+        for file_path in deconstructed_path.rglob("*.py"):
+            if any(p in excluded for p in file_path.parts):
+                continue
+
+            content = file_path.read_text(encoding="utf-8")
+            if "SiemplifySession" not in content:
+                continue
+
+            original = content
+
+            # Step 1: Replace constructor calls FIRST (before removing the name)
+            #   SiemplifySession(sensitive_data_arr=[...])  -> requests.Session()
+            #   SiemplifySession(...)                       -> requests.Session()
+            #   SiemplifySession()                          -> requests.Session()
+            # Use a greedy match that handles nested brackets like [api_key]
+            content = re.sub(
+                r"SiemplifySession\(.*?\)(?=\s*$|\s*\n)",
+                "requests.Session()",
+                content,
+                flags=re.MULTILINE,
+            )
+
+            # Step 2: Remove import lines
+            # Case 1: sole import — from TIPCommon import SiemplifySession
+            content = re.sub(
+                r"^from TIPCommon import SiemplifySession\s*\n",
+                "",
+                content,
+                flags=re.MULTILINE,
+            )
+            # Case 2: part of multi-import — from TIPCommon import X, SiemplifySession, Y
+            content = re.sub(
+                r",\s*SiemplifySession",
+                "",
+                content,
+            )
+            content = re.sub(
+                r"SiemplifySession\s*,\s*",
+                "",
+                content,
+            )
+
+            # Step 3: Clean up encode_sensitive_data calls left from SiemplifySession
+            # SiemplifySession had encode_sensitive_data() for masking secrets in errors.
+            # After rewriting to requests.Session(), these calls will crash (AttributeError).
+            content = re.sub(
+                r"self\.session\.encode_sensitive_data\(([^)]+)\)",
+                r"\1",
+                content,
+            )
+
+            # Step 4: Ensure 'import requests' is present
+            if "import requests" not in content and "requests.Session()" in content:
+                lines = content.split("\n")
+                last_import_idx = 0
+                for i, line in enumerate(lines):
+                    if line.startswith(("import ", "from ")):
+                        last_import_idx = i
+                lines.insert(last_import_idx + 1, "import requests")
+                content = "\n".join(lines)
+
+            if content != original:
+                file_path.write_text(content, encoding="utf-8")
+                logger.info(f"Replaced SiemplifySession in {file_path.name}")
+
+    @staticmethod
+    def _rename_deprecated_methods(deconstructed_path: Path):
+        """Rename TIPCommon 1.x abstract methods to 2.x names.
+
+        TIPCommon 2.x renamed _init_managers -> _init_api_clients in the
+        Action base class. Legacy integrations that implement the old name
+        can't be instantiated (abstract method not implemented).
+        """
+        excluded = {".venv", "tests", "__pycache__"}
+        for file_path in deconstructed_path.rglob("*.py"):
+            if any(p in excluded for p in file_path.parts):
+                continue
+            content = file_path.read_text(encoding="utf-8")
+            if "_init_managers" in content:
+                content = content.replace("_init_managers", "_init_api_clients")
+                file_path.write_text(content, encoding="utf-8")
+                logger.info(f"Renamed _init_managers -> _init_api_clients in {file_path.name}")
+
+    @staticmethod
+    def _ensure_conftest_plugins(tests_path: Path):
+        conftest = tests_path / "conftest.py"
+        plugin_line = 'pytest_plugins = ("integration_testing.conftest",)'
+
+        if not conftest.exists():
+            conftest.write_text(f"{plugin_line}\n", encoding="utf-8")
+            return
+
+        content = conftest.read_text(encoding="utf-8")
+        if plugin_line in content:
+            return
+
+        parser_config = cst.PartialParserConfig(python_version=cst.KNOWN_PYTHON_VERSION_STRINGS[-1])
+        tree = cst.parse_module(content, config=parser_config)
+        new_body = list(tree.body)
+        idx = next(
+            (
+                i + 1
+                for i, s in reversed(list(enumerate(new_body)))
+                if isinstance(s, cst.SimpleStatementLine)
+                and isinstance(s.body[0], (cst.Import, cst.ImportFrom))
+            ),
+            0,
+        )
+
+        plugin_stmt = cast(cst.SimpleStatementLine, cst.parse_statement(plugin_line))
+        new_body.insert(idx, plugin_stmt)
+        conftest.write_text(tree.with_changes(body=tuple(new_body)).code, encoding="utf-8")
+
+    def increment_version_and_sync(self, path: Path, name: str):
+        pyproject_path = path / PYPROJECT_TOML
+        if not pyproject_path.is_file():
+            return
+
+        with open(pyproject_path, "r", encoding="utf-8") as f:
+            data = toml.load(f)
+
+        v = data["project"]["version"].split(".")
+        v[0] = str(int(v[0]) + 1)
+        if len(v) > 1:
+            v[1] = "0"
+        new_v = ".".join(v)
+        data["project"]["version"] = new_v
+
+        with open(pyproject_path, "w", encoding="utf-8") as f:
+            toml.dump(data, f)
+
+        # Release Notes
+        rn_path = path / RELEASE_NOTES_FILE
+        note = MIGRATION_RELEASE_NOTE_TEMPLATE.copy()
+        note.update({
+            "integration_version": float(new_v),
+            "item_name": name,
+            "publish_time": datetime.now().strftime("%Y-%m-%d"),
+        })
+        with open(rn_path, "a", encoding="utf-8") as f:
+            f.write("\n")
+            yaml.dump([note], f, default_flow_style=False, sort_keys=False)
+
+        logger.info(f"Running 'uv sync' in {path}...")
+        subprocess.run(["uv", "sync"], cwd=path, check=True)
+
+    @staticmethod
+    def add_license_headers(path: Path):
+        try:
+            subprocess.run(["addlicense", "."], cwd=path, check=True)
+        except Exception as e:
+            logger.error(f"Failed to add license headers: {e}")
+
+    def add_to_ruff_specific_integrations(self, name: str):
+        ruff_path = self.dst_path / "ruff.toml"
+        if not ruff_path.is_file():
+            # Fallback if dst_path doesn't have it
+            ruff_path = get_marketplace_path() / "content" / "response_integrations" / "google" / "ruff.toml"
+            if not ruff_path.is_file():
+                return
+
+        lines = ruff_path.read_text(encoding="utf-8").splitlines()
+        entry = f'"{name}/**" = ["ALL"]'
+        if any(line.strip() == entry for line in lines):
+            return
+
+        new_lines = []
+        in_specific_block = False
+        inserted = False
+
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "# Specific Integrations":
+                in_specific_block = True
+                new_lines.append(line)
+                continue
+            
+            if in_specific_block and not inserted:
+                if not stripped or stripped.startswith("["):
+                    new_lines.append(entry)
+                    inserted = True
+                    in_specific_block = False
+
+            new_lines.append(line)
+
+        if in_specific_block and not inserted:
+            new_lines.append(entry)
+
+        ruff_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Refactor a directory of integrations with elegance."
+    )
+    parser.add_argument("integrations_path", type=str, help="Source integrations directory.")
+    parser.add_argument("dst_path", type=str, help="Destination directory.")
+    parser.add_argument("--tests-dir", type=str, required=True, help="Path to 'Tests' directory.")
+    parser.add_argument("--integrations-list", type=str, help="Optional space-separated list of integrations to process.")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
+    parser.add_argument("--skip-verify-ssl", action="store_true", help="Skip adding/fixing the Verify SSL parameter in definition.yaml.")
+
+    args = parser.parse_args()
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    refactorer = IntegrationRefactorer(
+        Path(args.integrations_path), Path(args.dst_path), Path(args.tests_dir),
+        integrations_list=args.integrations_list,
+        skip_verify_ssl=args.skip_verify_ssl,
+    )
+    refactorer.process_all()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/migration/migrate_integration.sh
+++ b/tools/migration/migrate_integration.sh
@@ -1,0 +1,472 @@
+#!/bin/bash
+# migrate_integration.sh — End-to-end migration pipeline
+#
+# Runs migrate.py (structure/imports migration) followed by
+# generate_test_mocks.py (test mock infrastructure generation).
+#
+# Usage:
+#   ./tools/migration/migrate_integration.sh <IntegrationName> [destination]
+#
+# Examples:
+#   ./tools/migration/migrate_integration.sh UrlScanIo
+#   ./tools/migration/migrate_integration.sh Shodan content/response_integrations/google
+#
+# Prerequisites:
+#   - mp, uv, addlicense on PATH
+#   - tip-marketplace cloned at ../tip-marketplace (sibling to content-hub)
+#   - Python 3.11 available as python3.11
+
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Resolve tip-marketplace location (try common locations)
+TIP_MARKETPLACE=""
+for candidate in \
+    "/usr/local/google/home/eranc/repos/tip-marketplace" \
+    "$REPO_ROOT/../tip-marketplace" \
+    "$REPO_ROOT/../../tip-marketplace"; do
+    if [ -d "$candidate/Integrations" ]; then
+        TIP_MARKETPLACE="$(cd "$candidate" && pwd)"
+        break
+    fi
+done
+
+if [ -z "$TIP_MARKETPLACE" ]; then
+    echo "ERROR: Cannot find tip-marketplace repo. Expected at ../tip-marketplace/"
+    exit 1
+fi
+
+# Use a python with libcst + mp available.
+# Prefer repo venv (has all deps), fall back to main repo venv for worktrees.
+PYTHON="${PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+    for candidate in \
+        "$REPO_ROOT/.venv/bin/python" \
+        "$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')/.venv/bin/python"; do
+        if [ -f "$candidate" ] && "$candidate" -c "import libcst" 2>/dev/null; then
+            PYTHON="$candidate"
+            break
+        fi
+    done
+    PYTHON="${PYTHON:-python3.11}"
+fi
+MIGRATION_SCRIPT="$SCRIPT_DIR/migrate.py"
+MOCK_GENERATOR="$SCRIPT_DIR/generate_test_mocks.py"
+
+# ── Arguments ──────────────────────────────────────────────────────────
+MINIMAL=false
+POSITIONAL=()
+for arg in "$@"; do
+    case "$arg" in
+        --minimal) MINIMAL=true ;;
+        *) POSITIONAL+=("$arg") ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 [--minimal] <IntegrationName> [destination_dir]"
+    echo ""
+    echo "  --minimal         Faithful migration only (skip Verify SSL, Ping rewrite)."
+    echo "                    For use with the two-PR workflow (PR1: migrate, PR2: standardize)."
+    echo "  IntegrationName   Name as it appears in tip-marketplace (e.g., UrlScanIo)"
+    echo "  destination_dir   Where to place the migrated integration"
+    echo "                    (default: content/response_integrations/google_new_test)"
+    exit 1
+fi
+
+INTEGRATION_NAME="$1"
+DEST_DIR="${2:-content/response_integrations/google_new_test}"
+
+# Convert PascalCase to snake_case using mp's logic (handles consecutive capitals
+# like SSLLabs -> ssl_labs, not s_s_l_labs)
+SNAKE_NAME=$($PYTHON -c "from mp.core.utils.common import str_to_snake_case; print(str_to_snake_case('$INTEGRATION_NAME'))" 2>/dev/null \
+  || echo "$INTEGRATION_NAME" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g' | sed -E 's/([a-z])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]')
+
+# Prevent integration directory names from shadowing Python stdlib modules.
+# e.g., HTTP -> http/ shadows stdlib http, breaking `from http.client import ...`
+# for ALL sibling integrations (pytest adds the parent dir to sys.path).
+# Check for stdlib AND pip package name collisions
+COLLISION=$($PYTHON -c "
+import sys
+name = '$SNAKE_NAME'
+# Check stdlib
+if hasattr(sys, 'stdlib_module_names') and name in sys.stdlib_module_names:
+    print(name + '_integration')
+    exit()
+# Check pip packages that integrations commonly import as their own name
+pip_collisions = {'jira', 'slack', 'redis', 'kafka', 'ldap3', 'requests', 'paramiko'}
+if name in pip_collisions:
+    print(name + '_integration')
+    exit()
+print(name)
+" 2>/dev/null || echo "$SNAKE_NAME")
+if [ "$COLLISION" != "$SNAKE_NAME" ]; then
+    echo "  WARNING: '$SNAKE_NAME' shadows a package name — renaming to '$COLLISION'"
+    SNAKE_NAME="$COLLISION"
+fi
+
+INTEGRATION_PATH="$REPO_ROOT/$DEST_DIR/$SNAKE_NAME"
+
+echo "════════════════════════════════════════════════════════════════"
+echo "  Migration Pipeline: $INTEGRATION_NAME"
+if [ "$MINIMAL" = true ]; then
+echo "  Mode:        MINIMAL (faithful migration, skip Verify SSL/Ping)"
+fi
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+echo "  Source:      $TIP_MARKETPLACE/Integrations/$INTEGRATION_NAME"
+echo "  Destination: $INTEGRATION_PATH"
+echo "  Python:      $($PYTHON --version)"
+echo ""
+
+# ── Pre-flight checks ─────────────────────────────────────────────────
+if [ ! -d "$TIP_MARKETPLACE/Integrations/$INTEGRATION_NAME" ]; then
+    echo "ERROR: Integration '$INTEGRATION_NAME' not found in $TIP_MARKETPLACE/Integrations/"
+    exit 1
+fi
+
+if [ ! -f "$MIGRATION_SCRIPT" ]; then
+    echo "ERROR: Migration script not found at $MIGRATION_SCRIPT"
+    exit 1
+fi
+
+if [ ! -f "$MOCK_GENERATOR" ]; then
+    echo "ERROR: Mock generator not found at $MOCK_GENERATOR"
+    exit 1
+fi
+
+# Ensure uv, mp, addlicense are available to subprocesses
+# (migrate.py calls subprocess.run(["uv", "sync"]) etc.)
+MAIN_REPO_VENV="$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')/.venv/bin"
+if [ -d "$MAIN_REPO_VENV" ]; then
+    export PATH="$MAIN_REPO_VENV:$HOME/go/bin:$PATH"
+fi
+
+# Prevent mp validate from auto-opening HTML reports in a browser
+export BROWSER=true
+
+# Use this worktree's mp source for the migration script only.
+# Don't export globally — it leaks into integration venvs and breaks module resolution.
+MP_PYTHONPATH="$REPO_ROOT/packages/mp/src:${PYTHONPATH:-}"
+
+# Ensure mp config points to the correct content-hub root.
+# In batch mode (MIGRATION_BATCH_MODE=true), this is done once by the batch script.
+if [ "${MIGRATION_BATCH_MODE:-}" != "true" ]; then
+    MAIN_REPO="$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')"
+    if [ -d "$MAIN_REPO/packages/tipcommon" ]; then
+        mp config --root-path "$MAIN_REPO" 2>/dev/null || true
+    fi
+fi
+
+if [ -d "$INTEGRATION_PATH" ]; then
+    echo "WARNING: $INTEGRATION_PATH already exists. Removing..."
+    rm -rf "$INTEGRATION_PATH"
+fi
+
+# ── Step 1: Migration (migrate.py) ─────────────────────────────────
+echo ""
+echo "── Step 1/4: Migrating structure and imports ──────────────────"
+echo ""
+
+cd "$REPO_ROOT"
+MIGRATE_ARGS=(
+    "$TIP_MARKETPLACE/Integrations"
+    "$DEST_DIR"
+    --tests-dir "$TIP_MARKETPLACE/Tests"
+    --integrations-list "$INTEGRATION_NAME"
+)
+if [ "$MINIMAL" = true ]; then
+    MIGRATE_ARGS+=(--skip-verify-ssl)
+fi
+PYTHONPATH="$MP_PYTHONPATH" $PYTHON "$MIGRATION_SCRIPT" "${MIGRATE_ARGS[@]}"
+
+# migrate.py uses str_to_snake_case which may produce a different name
+# than our SNAKE_NAME (e.g., we renamed http -> http_integration for stdlib).
+# Find the actual output directory and rename if needed.
+ORIGINAL_SNAKE=$($PYTHON -c "from mp.core.utils.common import str_to_snake_case; print(str_to_snake_case('$INTEGRATION_NAME'))" 2>/dev/null || echo "")
+ORIGINAL_PATH="$REPO_ROOT/$DEST_DIR/$ORIGINAL_SNAKE"
+if [ "$ORIGINAL_PATH" != "$INTEGRATION_PATH" ] && [ -d "$ORIGINAL_PATH" ]; then
+    mv "$ORIGINAL_PATH" "$INTEGRATION_PATH"
+    echo "  Renamed $ORIGINAL_SNAKE -> $SNAKE_NAME (stdlib collision)"
+fi
+
+if [ ! -d "$INTEGRATION_PATH" ]; then
+    echo "ERROR: Migration did not produce output at $INTEGRATION_PATH"
+    exit 1
+fi
+
+echo ""
+echo "  ✓ Migration complete: $INTEGRATION_PATH"
+
+# ── Step 1b: Post-migration fixes ──────────────────────────────────
+echo ""
+echo "── Step 1b: Post-migration fixes ─────────────────────────────"
+
+# Fix JSON result example naming: need BOTH PascalCase (action file stem)
+# AND snake_case (action YAML name). Two validators expect different conventions.
+RESOURCES_DIR="$INTEGRATION_PATH/resources"
+ACTIONS_DIR="$INTEGRATION_PATH/actions"
+if [ -d "$RESOURCES_DIR" ] && [ -d "$ACTIONS_DIR" ]; then
+    for py_file in "$ACTIONS_DIR"/*.py; do
+        [ -f "$py_file" ] || continue
+        stem=$(basename "$py_file" .py)
+        [ "$stem" = "__init__" ] && continue
+        # Convert PascalCase to snake_case using mp's logic (handles DNSResolve -> dns_resolve)
+        snake=$($PYTHON -c "from mp.core.utils.common import str_to_snake_case; print(str_to_snake_case('$stem'))" 2>/dev/null \
+          || echo "$stem" | sed -E 's/([A-Z]+)([A-Z][a-z])/\1_\2/g' | sed -E 's/([a-z])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]')
+        snake_file="$RESOURCES_DIR/${snake}_JsonResult_example.json"
+        pascal_file="$RESOURCES_DIR/${stem}_JsonResult_example.json"
+        # If snake_case exists but PascalCase doesn't, create PascalCase copy
+        if [ -f "$snake_file" ] && [ ! -f "$pascal_file" ]; then
+            cp "$snake_file" "$pascal_file"
+        fi
+        # If PascalCase exists but snake_case doesn't, create snake_case copy
+        if [ -f "$pascal_file" ] && [ ! -f "$snake_file" ]; then
+            cp "$pascal_file" "$snake_file"
+        fi
+    done
+    echo "  ✓ JSON result example dual naming"
+fi
+
+# Fix ticket_number: must be string, not int
+for rn_file in "$INTEGRATION_PATH/release_notes.yaml"; do
+    if [ -f "$rn_file" ]; then
+        sed -i "s/ticket_number: \([0-9][0-9]*\)$/ticket_number: '\1'/" "$rn_file"
+    fi
+done
+echo "  ✓ ticket_number as string"
+
+# Fix empty publish_time
+$PYTHON -c "
+import yaml, sys
+path = '$INTEGRATION_PATH/release_notes.yaml'
+try:
+    data = yaml.safe_load(open(path))
+    changed = False
+    for note in (data or []):
+        if not note.get('publish_time'):
+            note['publish_time'] = '2020-01-01'
+            changed = True
+    if changed:
+        yaml.dump(data, open(path, 'w'), default_flow_style=False, sort_keys=False)
+        print('  ✓ Fixed empty publish_time entries')
+except: pass
+" 2>/dev/null
+
+# Add integration to parent ruff.toml ["ALL"] exclusion (matching existing convention)
+PARENT_RUFF="$(dirname "$INTEGRATION_PATH")/ruff.toml"
+if [ -f "$PARENT_RUFF" ]; then
+    RUFF_ENTRY="\"$SNAKE_NAME/**\" = [\"ALL\"]"
+    if ! grep -q "$SNAKE_NAME" "$PARENT_RUFF" 2>/dev/null; then
+        # Insert before [format] section
+        sed -i "/^\[format\]/i $RUFF_ENTRY" "$PARENT_RUFF"
+        echo "  ✓ Added $SNAKE_NAME to parent ruff.toml exclusions"
+    fi
+fi
+
+# In minimal mode, add integration to validator exclusion lists
+# (removed in PR2 by standardize.sh after applying the fixes)
+if [ "$MINIMAL" = true ]; then
+    EXCLUSIONS_FILE="$REPO_ROOT/packages/mp/src/mp/core/data/exclusions.yaml"
+    if [ -f "$EXCLUSIONS_FILE" ]; then
+        # Helper: add entry to a YAML list key, handling both "key: []" and "key:\n  - ..." formats
+        _add_to_exclusion_list() {
+            local key="$1" value="$2" file="$3"
+            if grep -q "\"$value\"" <(grep -A 100 "$key:" "$file" | head -50) 2>/dev/null; then
+                return  # already present
+            fi
+            # Replace "key: []" with "key:" (remove inline empty array) then append entry
+            sed -i "s/^${key}: \[\]$/${key}:/" "$file"
+            sed -i "/^${key}:/a\\  - \"$value\"" "$file"
+        }
+        _add_to_exclusion_list "excluded_names_without_verify_ssl" "$SNAKE_NAME" "$EXCLUSIONS_FILE"
+        _add_to_exclusion_list "excluded_names_without_ping_message_format" "$SNAKE_NAME" "$EXCLUSIONS_FILE"
+        echo "  ✓ Added $SNAKE_NAME to validator exclusion lists (SSL + Ping)"
+    fi
+fi
+
+# Clean up legacy test files that are incompatible with the new framework
+# (they use patterns like non-relative imports and LegacyActionOutput)
+TESTS_DIR="$INTEGRATION_PATH/tests"
+if [ -d "$TESTS_DIR" ]; then
+    # Remove legacy test files that import from the old conftest patterns
+    for f in "$TESTS_DIR"/test_*.py; do
+        if [ -f "$f" ] && [ "$(basename "$f")" != "test_imports.py" ]; then
+            # Check if it uses legacy patterns (non-relative imports, LegacyActionOutput, etc.)
+            if grep -q "LegacyActionOutput\|from core\.\|from Tests\." "$f" 2>/dev/null; then
+                echo "  Removing incompatible legacy test: $(basename "$f")"
+                rm "$f"
+            fi
+        fi
+    done
+
+    # Remove legacy mock helpers that conflict with generated ones.
+    # BUT preserve mock_data.json — legacy tests load it at module level.
+    # Only remove response.py (conflicts with integration_testing.requests.response).
+    if [ -f "$TESTS_DIR/core/response.py" ]; then
+        echo "  Removing legacy test helper: response.py"
+        rm "$TESTS_DIR/core/response.py"
+    fi
+fi
+
+# ── Step 2: Generate test mocks ────────────────────────────────────────
+echo ""
+echo "── Step 2/4: Generating test mock infrastructure ─────────────"
+echo ""
+
+# Detect if this integration has existing hand-written test infrastructure
+# (product.py with a real class, session.py with routes, conftest with fixtures).
+# If so, skip the generator — the legacy tests are better than generated ones.
+HAS_LEGACY_TESTS=false
+if [ -f "$INTEGRATION_PATH/tests/core/product.py" ] && \
+   grep -q "class " "$INTEGRATION_PATH/tests/core/product.py" 2>/dev/null && \
+   [ -f "$INTEGRATION_PATH/tests/core/session.py" ] && \
+   grep -q "class " "$INTEGRATION_PATH/tests/core/session.py" 2>/dev/null; then
+    HAS_LEGACY_TESTS=true
+    echo "  Integration has existing test infrastructure (product.py + session.py)"
+    echo "  Skipping mock generation — using migrated legacy tests"
+fi
+
+# If legacy conftest has broken imports (non-relative), replace it
+# before running the generator so it can produce a clean one
+CONFTEST="$INTEGRATION_PATH/tests/conftest.py"
+if [ "$HAS_LEGACY_TESTS" = false ] && [ -f "$CONFTEST" ]; then
+    # Check for non-relative imports that won't work in content-hub
+    if grep -q "^from core\." "$CONFTEST" 2>/dev/null; then
+        echo "  Legacy conftest has non-relative imports — replacing with clean version"
+        # Keep only the pytest_plugins line, let generator fill in the rest
+        echo 'pytest_plugins = ("integration_testing.conftest",)' > "$CONFTEST"
+    fi
+fi
+
+if [ "$HAS_LEGACY_TESTS" = false ]; then
+    $PYTHON "$MOCK_GENERATOR" "$INTEGRATION_PATH"
+    echo ""
+    echo "  ✓ Test mock generation complete"
+else
+    echo ""
+    echo "  ✓ Using existing test infrastructure (skipped generation)"
+fi
+
+# ── Step 3: Lint & Fix ─────────────────────────────────────────────────
+echo ""
+echo "── Step 3/6: Lint & auto-fix ─────────────────────────────────"
+echo ""
+
+cd "$INTEGRATION_PATH"
+
+# Auto-fix lint issues (ruff), including unsafe fixes for bare except -> Exception
+echo "  Running: mp check --fix --unsafe-fixes"
+mp check "$INTEGRATION_PATH" --fix --unsafe-fixes 2>&1 | tail -3 || true
+
+# Format
+echo "  Running: mp format"
+mp format "$INTEGRATION_PATH" 2>&1 | tail -3 || true
+
+echo "  ✓ Lint & format complete"
+
+# ── Step 4: Validate (CI-equivalent) ───────────────────────────────────
+echo ""
+echo "── Step 4/6: Validating (CI-equivalent) ──────────────────────"
+echo ""
+
+cd "$INTEGRATION_PATH"
+
+# Pre-build validation (same as CI's mp validate)
+echo "  Running: mp validate integration $SNAKE_NAME --only-pre-build"
+VALIDATE_OUTPUT=$(mp validate integration "$SNAKE_NAME" -q --only-pre-build 2>&1 || true)
+if echo "$VALIDATE_OUTPUT" | grep -q "Passed"; then
+    PASSED=$(echo "$VALIDATE_OUTPUT" | grep -oP 'Passed: \d+' | head -1)
+    echo "  ✓ Pre-build validation passed ($PASSED)"
+elif echo "$VALIDATE_OUTPUT" | grep -q "ValueError\|Error"; then
+    echo "  ✗ Pre-build validation FAILED:"
+    echo "$VALIDATE_OUTPUT" | grep -v "Report available at\|newer version" | tail -5
+    echo ""
+    echo "  ⚠ Fix validation errors before submitting PR"
+fi
+
+# Lint check (same as CI's Code Linter)
+echo "  Running: mp check (lint)"
+LINT_OUTPUT=$(mp check "$INTEGRATION_PATH" 2>&1 || true)
+if echo "$LINT_OUTPUT" | grep -q "LinterWarning\|error"; then
+    echo "  ⚠ Lint issues found (suppressed by ruff.toml exclusion)"
+else
+    echo "  ✓ Lint clean"
+fi
+
+# Build check (same as CI's Build Google Integrations)
+echo "  Running: mp build integration $SNAKE_NAME"
+BUILD_OUTPUT=$(mp build integration "$SNAKE_NAME" 2>&1 || true)
+if echo "$BUILD_OUTPUT" | grep -q "FatalCommandError\|ValueError\|Failed to load"; then
+    echo "  ⚠ Build had issues (may be local env — check CI)"
+else
+    echo "  ✓ Build passed"
+fi
+
+# ── Step 5/6: Run tests ───────────────────────────────────────────────
+echo ""
+echo "── Step 5/6: Running tests ───────────────────────────────────"
+echo ""
+
+export PYTHONPATH="${PYTHONPATH:-}:$(pwd)/.venv/lib/python3.11/site-packages/soar_sdk"
+
+echo "  Running: pytest tests -v"
+if .venv/bin/python -m pytest tests -v 2>&1; then
+    echo ""
+    echo "  ✓ All tests passed"
+else
+    echo ""
+    echo "  ✗ Some tests failed (see output above)"
+fi
+
+# ── Step 6/6: Verify no real HTTP calls ───────────────────────────────
+echo ""
+echo "── Step 6/6: Verify no real HTTP calls ───────────────────────"
+HTTP_CALLS=$(rg "requests\.(get|post|put|delete|request)\(" tests/ --glob="*.py" 2>/dev/null | rg -v "monkeypatch|Mock|mock|setattr|import|lambda|MockSession|router" || true)
+if [ -n "$HTTP_CALLS" ]; then
+    echo "  ⚠ Possible real HTTP calls in tests:"
+    echo "$HTTP_CALLS"
+else
+    echo "  ✓ No real HTTP calls in test code"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo "  Summary: $INTEGRATION_NAME → $SNAKE_NAME"
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+echo "  Location: $INTEGRATION_PATH"
+echo ""
+
+# Check what was generated
+echo "  Files:"
+for f in \
+    "actions/Ping.py" \
+    "core" \
+    "definition.yaml" \
+    "pyproject.toml" \
+    "tests/core/product.py" \
+    "tests/core/session.py" \
+    "tests/conftest.py" \
+    "tests/test_actions/test_ping.py" \
+    "tests/test_defaults/test_imports.py"; do
+    if [ -e "$INTEGRATION_PATH/$f" ]; then
+        echo "    ✓ $f"
+    else
+        echo "    ✗ $f (MISSING)"
+    fi
+done
+
+echo ""
+echo "  To re-run tests manually:"
+echo "    cd $INTEGRATION_PATH"
+echo "    export PYTHONPATH=\$PYTHONPATH:\$(pwd)/.venv/lib/python3.11/site-packages/soar_sdk"
+echo "    .venv/bin/python -m pytest tests -v"
+echo ""
+echo "  To clean up:"
+echo "    rm -rf $INTEGRATION_PATH"

--- a/tools/migration/standardize.sh
+++ b/tools/migration/standardize.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# standardize.sh — Apply content-hub standards to a previously migrated integration
+#
+# This is PR2 of the two-PR migration workflow. It assumes PR1 (faithful
+# migration via migrate_integration.sh --minimal) has already been merged.
+#
+# Usage:
+#   ./tools/migration/standardize.sh <integration_snake_name> [integration_dir]
+#
+# Examples:
+#   ./tools/migration/standardize.sh certly
+#   ./tools/migration/standardize.sh shodan content/response_integrations/google
+#
+# What this script does:
+#   1. Adds/fixes the Verify SSL parameter in definition.yaml
+#   2. Rewrites Ping action to use standard success/failure messages
+#   3. Removes the integration from validator exclusion lists
+#   4. Runs mp validate + mp check --fix + tests
+
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PYTHON="${PYTHON:-python3.11}"
+
+# ── Arguments ──────────────────────────────────────────────────────────
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <integration_snake_name> [integration_parent_dir]"
+    echo ""
+    echo "  integration_snake_name   snake_case name (e.g., certly, url_scan_io)"
+    echo "  integration_parent_dir   Parent directory of the integration"
+    echo "                           (default: content/response_integrations/google)"
+    exit 1
+fi
+
+SNAKE_NAME="$1"
+PARENT_DIR="${2:-content/response_integrations/google}"
+INTEGRATION_PATH="$REPO_ROOT/$PARENT_DIR/$SNAKE_NAME"
+
+if [ ! -d "$INTEGRATION_PATH" ]; then
+    echo "ERROR: Integration not found at $INTEGRATION_PATH"
+    exit 1
+fi
+
+echo "════════════════════════════════════════════════════════════════"
+echo "  Standardize: $SNAKE_NAME"
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+echo "  Path: $INTEGRATION_PATH"
+echo ""
+
+# Prevent mp validate from auto-opening HTML reports
+export BROWSER=true
+
+# ── Step 1: Fix Verify SSL ─────────────────────────────────────────────
+echo "── Step 1: Verify SSL parameter ──────────────────────────────"
+$PYTHON -c "
+import yaml
+from pathlib import Path
+
+def_path = Path('$INTEGRATION_PATH/definition.yaml')
+data = yaml.safe_load(def_path.read_text())
+
+# Get integration display name
+display_name = data.get('display_name', '$SNAKE_NAME')
+
+# Check if Verify SSL already exists
+params = data.get('integration_params', [])
+ssl_exists = any(
+    p.get('param_name', '').lower() in ('verify ssl', 'verify ssl certificate', 'ssl verification')
+    for p in params
+)
+
+if ssl_exists:
+    # Fix default_value to true if needed
+    for p in params:
+        if p.get('param_name', '').lower() in ('verify ssl', 'verify ssl certificate', 'ssl verification'):
+            p['default_value'] = True
+            p['param_type'] = 'boolean'
+            p['is_mandatory'] = False
+            p['description'] = f'If selected, the integration validates the SSL certificate when connecting to {display_name}. Selected by default.'
+    print('  ✓ Fixed existing Verify SSL parameter')
+else:
+    # Add Verify SSL parameter
+    ssl_param = {
+        'param_name': 'Verify SSL',
+        'param_type': 'boolean',
+        'default_value': True,
+        'is_mandatory': False,
+        'description': f'If selected, the integration validates the SSL certificate when connecting to {display_name}. Selected by default.',
+    }
+    params.insert(0, ssl_param)
+    data['integration_params'] = params
+    print('  ✓ Added Verify SSL parameter')
+
+def_path.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
+" 2>&1
+
+# ── Step 2: Fix Ping messages ──────────────────────────────────────────
+echo ""
+echo "── Step 2: Ping action messages ──────────────────────────────"
+PING_FILE=""
+for name in "Ping.py" "ping.py"; do
+    if [ -f "$INTEGRATION_PATH/actions/$name" ]; then
+        PING_FILE="$INTEGRATION_PATH/actions/$name"
+        break
+    fi
+done
+
+if [ -n "$PING_FILE" ]; then
+    PING_CONTENT=$(cat "$PING_FILE")
+    NEEDS_FIX=false
+
+    if ! echo "$PING_CONTENT" | grep -q "Successfully connected to the"; then
+        NEEDS_FIX=true
+    fi
+    if ! echo "$PING_CONTENT" | grep -q "Failed to connect to the"; then
+        NEEDS_FIX=true
+    fi
+
+    if [ "$NEEDS_FIX" = true ]; then
+        echo "  ⚠ Ping messages don't match standard format."
+        echo "  Please manually update $PING_FILE with:"
+        echo "    Success: 'Successfully connected to the {name} server with the provided connection parameters!'"
+        echo "    Failure: 'Failed to connect to the {name} server! Error is {err}'"
+    else
+        echo "  ✓ Ping messages already match standard format"
+    fi
+else
+    echo "  ⚠ No Ping action found"
+fi
+
+# ── Step 3: Remove from exclusion lists ────────────────────────────────
+echo ""
+echo "── Step 3: Remove from validator exclusion lists ──────────────"
+EXCLUSIONS_FILE="$REPO_ROOT/packages/mp/src/mp/core/data/exclusions.yaml"
+if [ -f "$EXCLUSIONS_FILE" ]; then
+    sed -i "/^  - \"$SNAKE_NAME\"$/d" "$EXCLUSIONS_FILE"
+    echo "  ✓ Removed $SNAKE_NAME from exclusion lists"
+fi
+
+# ── Step 4: Lint, validate, test ───────────────────────────────────────
+echo ""
+echo "── Step 4: Lint & validate ───────────────────────────────────"
+
+cd "$INTEGRATION_PATH"
+
+echo "  Running: mp check --fix"
+mp check "$INTEGRATION_PATH" --fix 2>&1 | tail -3 || true
+
+echo "  Running: mp format"
+mp format "$INTEGRATION_PATH" 2>&1 | tail -3 || true
+
+echo "  Running: mp validate integration $SNAKE_NAME --only-pre-build"
+mp validate integration "$SNAKE_NAME" -q --only-pre-build 2>&1 | tail -5 || true
+
+echo ""
+echo "── Running tests ─────────────────────────────────────────────"
+export PYTHONPATH="${PYTHONPATH:-}:$(pwd)/.venv/lib/python3.11/site-packages/soar_sdk"
+.venv/bin/python -m pytest tests -v 2>&1 || true
+
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo "  Standardization complete: $SNAKE_NAME"
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+echo "  Review the changes and create PR2."


### PR DESCRIPTION
## Summary

Adds a V2 migration pipeline that splits integration migrations into two PRs for thinner, more reviewable Gerrit CLs on tip-marketplace.

### Problem

The current migration pipeline does everything in one shot (structural changes, Verify SSL, Ping rewrite, version reset), producing large GOB CLs that are hard to review and fail the comparison tool.

### Solution

- **PR1 (`--minimal`):** Faithful structural migration only. Thin GOB CL (TIPCommon imports, version +1, license headers).
- **PR2 (`standardize.sh`):** Applies content-hub standards (Verify SSL, Ping messages). Separate GOB CL.

### Changes

- `tools/migration/migrate.py` — add `--skip-verify-ssl` flag
- `tools/migration/migrate_integration.sh` — add `--minimal` flag (skips SSL fix, adds to exclusion lists)
- `tools/migration/standardize.sh` — **new** PR2 orchestrator
- `tools/migration/README.md` — **new** comprehensive documentation
- `packages/mp/.../ping_message_validation.py` — add exclusion list support
- `packages/mp/.../exclusions.py` — add `get_excluded_names_without_ping_message_format()`
- `packages/mp/.../exclusions.yaml` — add `excluded_names_without_ping_message_format` key

### Tested

- Ran `migrate_integration.sh --minimal Certly` successfully
- All 22 validators passed (with exclusions)
- All 3 tests passed (test_ping_success, test_ping_failure, test_imports)

## Test plan

- [x] `migrate_integration.sh --minimal Certly` produces valid integration
- [x] `mp validate` passes with exclusions (22/22)
- [x] All tests pass
- [x] No real HTTP calls in test code
- [x] CI passes