### PR TITLE
Fix: Standardize CI change-detection filters and fix power_ups path typo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             - 'content/response_integrations/google/**'
           response_integrations_third_party:
             - 'content/response_integrations/third_party/**'
-            - 'content/response_integrations/power_up/**'
+            - 'content/response_integrations/power_ups/**'
           playbooks:
             - 'content/playbooks/**'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
             - 'content/response_integrations/google/**'
           response_integrations_third_party:
             - 'content/response_integrations/third_party/**'
-            - 'content/response_integrations/power_up/**'
+            - 'content/response_integrations/power_ups/**'
           mp:
             - 'packages/mp/**'
           package_envcommon:

--- a/.github/workflows/third_party_code_check.yml
+++ b/.github/workflows/third_party_code_check.yml
@@ -7,14 +7,14 @@ on:
     - '**'
     paths:
     - 'content/response_integrations/third_party/**'
-    - 'content/response_integrations/power_up/**'
+    - 'content/response_integrations/power_ups/**'
 
   pull_request:
     branches:
     - '**'
     paths:
     - 'content/response_integrations/third_party/**'
-    - 'content/response_integrations/power_up/**'
+    - 'content/response_integrations/power_ups/**'
 
 jobs:
   mp_check:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,7 +46,7 @@ jobs:
             - 'content/response_integrations/google/**'
           response_integrations_third_party:
             - 'content/response_integrations/third_party/**'
-            - 'content/response_integrations/power_up/**'
+            - 'content/response_integrations/power_ups/**'
           playbooks:
             - 'content/playbooks/**'
 

--- a/.github/workflows/windows_workflows.yml
+++ b/.github/workflows/windows_workflows.yml
@@ -43,7 +43,7 @@ jobs:
             - 'content/response_integrations/google/**'
           response_integrations_third_party:
             - 'content/response_integrations/third_party/**'
-            - 'content/response_integrations/power_up/**'
+            - 'content/response_integrations/power_ups/**'
           playbooks:
             - 'content/playbooks/**'
 

--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,9 @@ cython_debug/
 .vscode/
 
 
+### Claude Code
+.claude/
+
 ### mp
 .integrations_cache/
 .mp_cache/


### PR DESCRIPTION
## Summary

**Bug fix:** Path filters in 5 workflow files referenced `power_up/` instead of the correct `power_ups/` directory, causing validate/build/lint/code-check/Windows CI jobs to silently skip for `power_ups/` integrations (e.g., `git_sync` in PR #686).

**Standardization:** Split the `mp` dorny/paths-filter into `mp` (`packages/mp/**`) and `ci` (`.github/workflows/**`) so workflow-only changes no longer trigger full integration validate/build/test runs (~15 min on Windows, ~5 min on Linux). Also standardized filter definitions across all workflows.

**Skip labels:** Added PR label-based skipping for expensive CI jobs.

## Changes

| File | What changed |
|------|-------------|
| `validate.yml` | Fix `power_ups` typo. Remove `.github/workflows/**` from paths + mp filter. Fix stale comment. |
| `build.yml` | Fix `power_ups` typo. Remove `.github/workflows/**` from paths + mp filter. Add `skip-build` + `ci-minimal` label support. |
| `lint.yml` | Fix `power_ups` typo. Remove `.github/workflows/**` from paths. Consolidate package filters into `integration_packages`. Add `mp` to lint job conditions. |
| `third_party_code_check.yml` | Fix `power_ups` typo (2 occurrences). |
| `windows_workflows.yml` | Fix `power_ups` typo. Add top-level `paths:` filter. Split `mp`/`ci` filters. Add missing `integration_testing_whls`. Add `skip-windows` + `ci-minimal` label support (keeps `test-mp-windows` running). |
| `test.yml` | Remove `.github/workflows/**` from paths + mp filter. Add `skip-tests` + `ci-minimal` label support. |
| `test_mp.yml` | Add `.github/workflows/**` to paths so mp tests run on CI changes. |
| `.gitignore` | Add `.claude/` directory. |

## CI skip labels

After merge, create these labels in the repo:

| Label | Skips | Use case |
|-------|-------|----------|
| `ci-minimal` | Windows integration pipeline + tests + builds | Draft PRs, quick iterations, CI-only changes |
| `skip-windows` | Windows integration validate/test/build (keeps `test-mp-windows`) | When Linux CI is sufficient |
| `skip-tests` | Integration test suite (`test.yml`) | Iterating on mp/package internals |
| `skip-build` | All build jobs (`build.yml`) | When validate + lint is enough |

## Trigger behavior after this change

| Change | mp tests | Integration lint | Integration validate/build/test | Playbook validate/build |
|--------|----------|-----------------|--------------------------------|------------------------|
| `packages/mp/**` | YES | YES | YES | YES |
| `.github/workflows/**` | YES | NO | NO | NO |
| `packages/{envcommon,tipcommon,...}/**` | NO | YES | YES | NO |
| `content/.../google/**` | NO | YES | YES | NO |
| `content/.../third_party/**` or `power_ups/**` | NO | YES | YES | YES |
| `content/playbooks/**` | NO | NO | NO | YES |

## Checklist

- [x] I have read and followed the project's contributing guide
- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings
- [x] My changes pass all existing tests
- [x] My changes do not introduce any PII or sensitive customer data
- [x] My changes do not expose any internal-only code examples, configurations, or URLs
- [x] All code examples, comments, and messages are generic and suitable for a public repository

## Test plan

- [x] Branch protection: only `CodeQL` is a required status check - none of the modified job names are required
- [x] This PR only changes `.github/workflows/**` + `.gitignore` - only `test_mp.yml` and `windows_workflows.yml` `test-mp-windows` should trigger real work
- [x] All review agents confirmed changes are correct across all workflow files
- [x] Skip labels use push-event guards (`github.event_name != 'pull_request'`) where needed