### PR TITLE
Standardize CI change-detection filters and add skip labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,13 @@ jobs:
   build_google:
     name: Build Google Integrations
     needs: changes
-    if: ${{ needs.changes.outputs.response_integrations_google == 'true' || needs.changes.outputs.mp == 'true' || needs.changes.outputs.integration_packages == 'true' }}
+    if: >-
+      (needs.changes.outputs.response_integrations_google == 'true' ||
+       needs.changes.outputs.mp == 'true' ||
+       needs.changes.outputs.integration_packages == 'true') &&
+      (github.event_name != 'pull_request' ||
+       (!contains(github.event.pull_request.labels.*.name, 'skip-build') &&
+        !contains(github.event.pull_request.labels.*.name, 'ci-minimal')))
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -85,7 +91,13 @@ jobs:
   build_third_party:
     name: Build Third-Party Integrations
     needs: changes
-    if: ${{ needs.changes.outputs.response_integrations_third_party == 'true' || needs.changes.outputs.mp == 'true' || needs.changes.outputs.integration_packages == 'true' }}
+    if: >-
+      (needs.changes.outputs.response_integrations_third_party == 'true' ||
+       needs.changes.outputs.mp == 'true' ||
+       needs.changes.outputs.integration_packages == 'true') &&
+      (github.event_name != 'pull_request' ||
+       (!contains(github.event.pull_request.labels.*.name, 'skip-build') &&
+        !contains(github.event.pull_request.labels.*.name, 'ci-minimal')))
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -113,7 +125,12 @@ jobs:
   build_playbooks:
     name: Build Playbooks
     needs: changes
-    if: ${{ needs.changes.outputs.playbooks == 'true' || needs.changes.outputs.mp == 'true' }}
+    if: >-
+      (needs.changes.outputs.playbooks == 'true' ||
+       needs.changes.outputs.mp == 'true') &&
+      (github.event_name != 'pull_request' ||
+       (!contains(github.event.pull_request.labels.*.name, 'skip-build') &&
+        !contains(github.event.pull_request.labels.*.name, 'ci-minimal')))
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,12 @@ on:
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
   pull_request:
     branches:
     - '**'
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -43,7 +41,6 @@ jobs:
         filters: |
           mp:
             - 'packages/mp/**'
-            - '.github/workflows/**'
           integration_packages:
             - 'packages/envcommon/**'
             - 'packages/tipcommon/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,14 +7,12 @@ on:
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
   pull_request:
     branches:
     - '**'
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -27,9 +25,7 @@ jobs:
       response_integrations_google: ${{ steps.filter.outputs.response_integrations_google }}
       response_integrations_third_party: ${{ steps.filter.outputs.response_integrations_third_party }}
       mp: ${{ steps.filter.outputs.mp }}
-      package_envcommon: ${{ steps.filter.outputs.package_envcommon }}
-      package_tipcommon: ${{ steps.filter.outputs.package_tipcommon }}
-      package_integration_testing: ${{ steps.filter.outputs.package_integration_testing }}
+      integration_packages: ${{ steps.filter.outputs.integration_packages }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -49,17 +45,16 @@ jobs:
             - 'content/response_integrations/power_ups/**'
           mp:
             - 'packages/mp/**'
-          package_envcommon:
+          integration_packages:
             - 'packages/envcommon/**'
-          package_tipcommon:
             - 'packages/tipcommon/**'
-          package_integration_testing:
             - 'packages/integration_testing/**'
+            - 'packages/integration_testing_whls/**'
 
   lint_google:
     name: Lint Google Integrations
     needs: changes
-    if: ${{ needs.changes.outputs.response_integrations_google == 'true'}}
+    if: ${{ needs.changes.outputs.response_integrations_google == 'true' || needs.changes.outputs.mp == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -88,7 +83,7 @@ jobs:
   lint_third_party:
     name: Lint Third-Party Integrations
     needs: changes
-    if: ${{ needs.changes.outputs.response_integrations_third_party == 'true'}}
+    if: ${{ needs.changes.outputs.response_integrations_third_party == 'true' || needs.changes.outputs.mp == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -153,7 +148,7 @@ jobs:
   envcommon_linter:
     name: EnvironmentCommon Package Linter
     needs: changes
-    if: ${{ needs.changes.outputs.package_envcommon == 'true' }}
+    if: ${{ needs.changes.outputs.integration_packages == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -182,7 +177,7 @@ jobs:
   tipcommon_linter:
     name: TIPCommon Package Linter
     needs: changes
-    if: ${{ needs.changes.outputs.package_tipcommon == 'true' }}
+    if: ${{ needs.changes.outputs.integration_packages == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -211,7 +206,7 @@ jobs:
   integration_testing_linter:
     name: Integration Testing Package Linter
     needs: changes
-    if: ${{ needs.changes.outputs.package_integration_testing == 'true' }}
+    if: ${{ needs.changes.outputs.integration_packages == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -37,7 +36,6 @@ jobs:
         filters: |
           mp:
             - 'packages/mp/**'
-            - '.github/workflows/**'
           integration_packages:
             - 'packages/envcommon/**'
             - 'packages/tipcommon/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,11 @@ jobs:
   test_third_party:
     name: Test Third-Party Integrations
     needs: changes
-    if: ${{ needs.changes.outputs.test_all == 'true' || needs.changes.outputs.changed_integrations != '' }}
+    if: >-
+      (needs.changes.outputs.test_all == 'true' ||
+       needs.changes.outputs.changed_integrations != '') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-tests') &&
+      !contains(github.event.pull_request.labels.*.name, 'ci-minimal')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test_mp.yml
+++ b/.github/workflows/test_mp.yml
@@ -7,11 +7,13 @@ on:
     - '**'
     paths:
     - 'packages/mp/**'
+    - '.github/workflows/**'
   pull_request:
     branches:
     - '**'
     paths:
     - 'packages/mp/**'
+    - '.github/workflows/**'
 
 jobs:
   test_mp:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,14 +7,12 @@ on:
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
   pull_request:
     branches:
     - '**'
     paths:
     - 'content/**'
     - 'packages/**'
-    - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -41,7 +39,6 @@ jobs:
         filters: |
           mp:
             - 'packages/mp/**'
-            - '.github/workflows/**'
           response_integrations_google:
             - 'content/response_integrations/google/**'
           response_integrations_third_party:
@@ -58,7 +55,7 @@ jobs:
         THIRD_PARTY="${{ steps.filter.outputs.response_integrations_third_party }}"
         PLAYBOOKS="${{ steps.filter.outputs.playbooks }}"
 
-        # If mp/workflows changed, validate everything
+        # If mp package changed, validate everything
         if [[ "$MP" == "true" ]]; then
           echo "args=all_content" >> $GITHUB_OUTPUT
           echo "should_validate=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/windows_workflows.yml
+++ b/.github/workflows/windows_workflows.yml
@@ -84,7 +84,14 @@ jobs:
   validate-integrations-windows:
     name: 2a. Validate Integrations
     needs: changes
-    if: ${{ needs.changes.outputs.mp == 'true' || needs.changes.outputs.integration_packages == 'true' || needs.changes.outputs.response_integrations_google == 'true' || needs.changes.outputs.response_integrations_third_party == 'true' }}
+    if: >-
+      (needs.changes.outputs.mp == 'true' ||
+       needs.changes.outputs.integration_packages == 'true' ||
+       needs.changes.outputs.response_integrations_google == 'true' ||
+       needs.changes.outputs.response_integrations_third_party == 'true') &&
+      (github.event_name != 'pull_request' ||
+       (!contains(github.event.pull_request.labels.*.name, 'skip-windows') &&
+        !contains(github.event.pull_request.labels.*.name, 'ci-minimal')))
     runs-on: windows-latest
     steps:
     - name: Checkout repository
@@ -155,7 +162,12 @@ jobs:
   validate-playbooks-windows:
     name: 3a. Validate Playbooks
     needs: changes
-    if: ${{ needs.changes.outputs.mp == 'true' || needs.changes.outputs.playbooks == 'true' }}
+    if: >-
+      (needs.changes.outputs.mp == 'true' ||
+       needs.changes.outputs.playbooks == 'true') &&
+      (github.event_name != 'pull_request' ||
+       (!contains(github.event.pull_request.labels.*.name, 'skip-windows') &&
+        !contains(github.event.pull_request.labels.*.name, 'ci-minimal')))
     runs-on: windows-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/windows_workflows.yml
+++ b/.github/workflows/windows_workflows.yml
@@ -6,9 +6,17 @@ on:
   push:
     branches:
     - '**'
+    paths:
+    - 'content/**'
+    - 'packages/**'
+    - '.github/workflows/**'
   pull_request:
     branches:
     - '**'
+    paths:
+    - 'content/**'
+    - 'packages/**'
+    - '.github/workflows/**'
 
 jobs:
   changes:
@@ -16,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       mp: ${{ steps.filter.outputs.mp }}
+      ci: ${{ steps.filter.outputs.ci }}
       integration_packages: ${{ steps.filter.outputs.integration_packages }}
       response_integrations_google: ${{ steps.filter.outputs.response_integrations_google }}
       response_integrations_third_party: ${{ steps.filter.outputs.response_integrations_third_party }}
@@ -34,11 +43,13 @@ jobs:
         filters: |
           mp:
             - 'packages/mp/**'
+          ci:
             - '.github/workflows/**'
           integration_packages:
             - 'packages/envcommon/**'
             - 'packages/tipcommon/**'
             - 'packages/integration_testing/**'
+            - 'packages/integration_testing_whls/**'
           response_integrations_google:
             - 'content/response_integrations/google/**'
           response_integrations_third_party:
@@ -50,7 +61,7 @@ jobs:
   test-mp-windows:
     name: 1. Test mp Package
     needs: changes
-    if: ${{ needs.changes.outputs.mp == 'true' }}
+    if: ${{ needs.changes.outputs.mp == 'true' || needs.changes.outputs.ci == 'true' }}
     runs-on: windows-latest
     steps:
     - name: Checkout repository

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,8 +71,8 @@ You can add these labels to a PR to skip expensive CI jobs during development:
 
 | Label | What it skips | When to use |
 |-------|-------------|-------------|
-| `ci-minimal` | Windows integration pipeline, tests, and builds | Draft PRs, quick iterations |
-| `skip-windows` | Windows integration validate/test/build | When Linux CI is sufficient |
+| `ci-minimal` | All builds, integration tests, and Windows pipeline | Draft PRs, quick iterations |
+| `skip-windows` | Windows integration validate/test/build (keeps `test-mp-windows`) | When Linux CI is sufficient |
 | `skip-tests` | Integration test suite | Iterating on `mp` or package internals |
 | `skip-build` | All build jobs | When validate + lint is enough |
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,6 +65,19 @@ for this purpose.
 * **Version Bump**: If you are modifying an existing content, remember to increase the version of
   that content. This is required for the changes to be released.
 
+### CI Skip Labels
+
+You can add these labels to a PR to skip expensive CI jobs during development:
+
+| Label | What it skips | When to use |
+|-------|-------------|-------------|
+| `ci-minimal` | Windows integration pipeline, tests, and builds | Draft PRs, quick iterations |
+| `skip-windows` | Windows integration validate/test/build | When Linux CI is sufficient |
+| `skip-tests` | Integration test suite | Iterating on `mp` or package internals |
+| `skip-build` | All build jobs | When validate + lint is enough |
+
+**Important:** Remove skip labels before requesting review. All CI checks should pass before merge.
+
 ### Pre-Submission Checklist
 
 Before submitting your Pull Request, please review


### PR DESCRIPTION
## Summary

Follows up on #702 (merged). Standardizes CI change-detection filters and adds PR label-based skip support for expensive CI jobs.

### Filter standardization
Split the `mp` dorny/paths-filter into `mp` (`packages/mp/**`) and `ci` (`.github/workflows/**`) so workflow-only changes no longer trigger full integration validate/build/test runs (~15 min on Windows, ~5 min on Linux). Also consolidated `lint.yml` package filters and added missing `integration_testing_whls` to `windows_workflows.yml`.

### Skip labels
Added PR label-based skipping for expensive CI jobs. Labels need to be created by a maintainer.

## Changes

| File | What changed |
|------|-------------|
| `build.yml` | Remove `.github/workflows/**` from paths + mp filter. Add `skip-build` + `ci-minimal` label support. |
| `lint.yml` | Remove `.github/workflows/**` from paths. Consolidate package filters into `integration_packages`. Add `mp` to lint job conditions. |
| `test.yml` | Remove `.github/workflows/**` from paths + mp filter. Add `skip-tests` + `ci-minimal` label support. |
| `test_mp.yml` | Add `.github/workflows/**` to paths so mp tests run on CI changes. |
| `validate.yml` | Remove `.github/workflows/**` from paths + mp filter. Fix stale comment. |
| `windows_workflows.yml` | Add top-level `paths:` filter. Split `mp`/`ci` filters. Fix missing `integration_testing_whls`. Add `skip-windows` + `ci-minimal` label support (keeps `test-mp-windows` running). |
| `docs/contributing.md` | Document CI skip labels. |

## CI skip labels (create after merge)

| Label | Skips | Use case |
|-------|-------|----------|
| `ci-minimal` | Windows integration pipeline + tests + builds | Draft PRs, quick iterations |
| `skip-windows` | Windows integration validate/test/build (keeps `test-mp-windows`) | When Linux CI is sufficient |
| `skip-tests` | Integration test suite (`test.yml`) | Iterating on mp/package internals |
| `skip-build` | All build jobs (`build.yml`) | When validate + lint is enough |

## Trigger behavior after this change

| Change | mp tests | Integration lint | Integration validate/build/test | Playbook validate/build |
|--------|----------|-----------------|--------------------------------|------------------------|
| `packages/mp/**` | YES | YES | YES | YES |
| `.github/workflows/**` | YES | NO | NO | NO |
| `packages/{envcommon,tipcommon,...}/**` | NO | YES | YES | NO |
| `content/.../google/**` | NO | YES | YES | NO |
| `content/.../third_party/**` or `power_ups/**` | NO | YES | YES | YES |
| `content/playbooks/**` | NO | NO | NO | YES |

## Checklist

- [x] I have read and followed the project's contributing guide
- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings
- [x] My changes pass all existing tests
- [x] My changes do not introduce any PII or sensitive customer data
- [x] My changes do not expose any internal-only code examples, configurations, or URLs
- [x] All code examples, comments, and messages are generic and suitable for a public repository

## Test plan

- [x] Branch protection: only `CodeQL` is a required status check
- [x] Skip labels use push-event guards where needed
- [x] Multiple review agents confirmed all changes are correct