### PR TITLE
Fix validator PR scoping, CI shell injection, and add missing tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,17 +112,19 @@ jobs:
       - name: Run integration tests
         env:
           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
+          TEST_ALL: ${{ needs.changes.outputs.test_all }}
+          CHANGED_INTEGRATIONS: ${{ needs.changes.outputs.changed_integrations }}
         # language=bash
         run: |
           mp config --root-path . --processes 10 --display-config
 
-          if [[ "${{ needs.changes.outputs.test_all }}" == "true" ]]; then
+          if [[ "$TEST_ALL" == "true" ]]; then
             echo "Shared packages changed — testing all integrations"
             mp test --repository third_party --raise-error-on-violations
           else
-            echo "Testing only changed integrations: ${{ needs.changes.outputs.changed_integrations }}"
+            echo "Testing only changed integrations: $CHANGED_INTEGRATIONS"
             FAILED=0
-            for integration in ${{ needs.changes.outputs.changed_integrations }}; do
+            for integration in $CHANGED_INTEGRATIONS; do
               echo "--- Testing: $integration ---"
               mp test --integration "$integration" --raise-error-on-violations || FAILED=1
             done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,22 +48,27 @@ jobs:
 
       - name: Find changed integrations
         id: find_integrations
+        env:
+          FILTER_MP: ${{ steps.filter.outputs.mp }}
+          FILTER_PACKAGES: ${{ steps.filter.outputs.integration_packages }}
+          FILTER_THIRD_PARTY: ${{ steps.filter.outputs.response_integrations_third_party }}
+          FILTER_THIRD_PARTY_FILES: ${{ steps.filter.outputs.response_integrations_third_party_files }}
         # language=bash
         run: |
           # If shared packages or mp changed, test everything
-          if [[ "${{ steps.filter.outputs.mp }}" == "true" ]] || \
-             [[ "${{ steps.filter.outputs.integration_packages }}" == "true" ]]; then
+          if [[ "$FILTER_MP" == "true" ]] || \
+             [[ "$FILTER_PACKAGES" == "true" ]]; then
             echo "test_all=true" >> $GITHUB_OUTPUT
             echo "integrations=" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           echo "test_all=false" >> $GITHUB_OUTPUT
-          
+
           # Extract unique integration names from changed file paths
-          if [[ "${{ steps.filter.outputs.response_integrations_third_party }}" == "true" ]]; then
-            CHANGED_FILES="${{ steps.filter.outputs.response_integrations_third_party_files }}"
-            INTEGRATIONS=$(echo "$CHANGED_FILES" | tr ',' '\n' | \
+          if [[ "$FILTER_THIRD_PARTY" == "true" ]]; then
+            INTEGRATIONS=$(echo "$FILTER_THIRD_PARTY_FILES" | tr ',' '\n' | \
+              sed 's/"//g' | \
               grep "^content/response_integrations/" | \
               sed 's|content/response_integrations/third_party/[^/]*/||' | \
               sed 's|content/response_integrations/power_up[s]*/||' | \

--- a/packages/mp/src/mp/core/unix.py
+++ b/packages/mp/src/mp/core/unix.py
@@ -602,9 +602,9 @@ def get_file_content_from_main_branch(file_path: Path) -> str:
     """
     # git show requires a repo-root-relative path; convert absolute paths.
     try:
+        rev_parse_command: list[str] = ["git", "rev-parse", "--show-toplevel"]
         repo_root_result = sp.run(  # noqa: S603
-            ["git", "rev-parse", "--show-toplevel"],
-            check=True, text=True, capture_output=True,
+            rev_parse_command, check=True, text=True, capture_output=True,
         )
         relative_path: pathlib.Path = file_path.relative_to(repo_root_result.stdout.strip())
     except (sp.CalledProcessError, ValueError):

--- a/packages/mp/src/mp/core/unix.py
+++ b/packages/mp/src/mp/core/unix.py
@@ -600,7 +600,17 @@ def get_file_content_from_main_branch(file_path: Path) -> str:
         NonFatalCommandError: If the git command fails (e.g., file not found on main).
 
     """
-    git_path_arg: str = f"origin/main:{file_path.as_posix()}"
+    # git show requires a repo-root-relative path; convert absolute paths.
+    try:
+        repo_root_result = sp.run(  # noqa: S603
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True, text=True, capture_output=True,
+        )
+        relative_path: pathlib.Path = file_path.relative_to(repo_root_result.stdout.strip())
+    except (sp.CalledProcessError, ValueError):
+        relative_path = file_path
+
+    git_path_arg: str = f"origin/main:{relative_path.as_posix()}"
     command: list[str] = ["git", "show", git_path_arg]
 
     try:

--- a/packages/mp/src/mp/core/unix.py
+++ b/packages/mp/src/mp/core/unix.py
@@ -604,7 +604,10 @@ def get_file_content_from_main_branch(file_path: Path) -> str:
     try:
         rev_parse_command: list[str] = ["git", "rev-parse", "--show-toplevel"]
         repo_root_result = sp.run(  # noqa: S603
-            rev_parse_command, check=True, text=True, capture_output=True,
+            rev_parse_command,
+            check=True,
+            text=True,
+            capture_output=True,
         )
         relative_path: pathlib.Path = file_path.relative_to(repo_root_result.stdout.strip())
     except (sp.CalledProcessError, ValueError):

--- a/packages/mp/src/mp/validate/pre_build_validation/integrations/json_result_example_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/integrations/json_result_example_validation.py
@@ -55,10 +55,12 @@ class JsonResultExampleValidation:
         """
         # Only validate integrations with changes in the current PR
         head_sha: str | None = os.environ.get("GITHUB_PR_SHA")
+        changed_files: set[str] | None = None
         if head_sha:
             changed = mp.core.unix.get_files_unmerged_to_main_branch("main", head_sha, validation_path)
             if not changed:
                 return
+            changed_files = {p.name for p in changed}
 
         actions_dir = validation_path / constants.ACTIONS_DIR
         resources_dir = validation_path / "resources"
@@ -70,6 +72,10 @@ class JsonResultExampleValidation:
 
         for py_file in actions_dir.glob("*.py"):
             if py_file.name.startswith("_"):
+                continue
+
+            # In PR context, only check actions that were actually changed
+            if changed_files is not None and py_file.name not in changed_files:
                 continue
 
             # Check only non-comment lines for JSON result patterns

--- a/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
@@ -100,8 +100,7 @@ class ReleaseNotesDateValidation:
         # This avoids penalising pre-existing entries that predate the requirement.
         existing_versions: set[str] = set()
         if head_sha:
-            changed = mp.core.unix.get_files_unmerged_to_main_branch("main", head_sha, validation_path)
-            if not changed:
+            if not mp.core.unix.get_files_unmerged_to_main_branch("main", head_sha, validation_path):
                 return
             existing_versions = _versions_on_main(rn_path)
 

--- a/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
@@ -35,6 +35,10 @@ def _normalize_version(v: object) -> str:
     YAML parses unquoted ``1.0`` as ``float`` and ``1`` as ``int``, causing
     ``str(1.0) == "1.0"`` while ``str(1) == "1"``.  Converting through
     ``float`` first ensures both map to the same representation.
+
+    Returns:
+        A canonical string representation of the version.
+
     """
     try:
         f = float(str(v))
@@ -43,6 +47,26 @@ def _normalize_version(v: object) -> str:
         return str(f)
     except (ValueError, OverflowError, TypeError):
         return str(v)
+
+
+def _versions_on_main(rn_path: Path) -> set[str]:
+    """Return normalized version strings from the main-branch release notes.
+
+    Args:
+        rn_path: Path to the release_notes.yaml file in the working tree.
+
+    Returns:
+        Set of canonical version strings already on main, or an empty set
+        when the file does not yet exist on main or cannot be parsed.
+
+    """
+    try:
+        base_content = yaml.safe_load(mp.core.unix.get_file_content_from_main_branch(rn_path))
+        if isinstance(base_content, list):
+            return {_normalize_version(note.get("integration_version", "")) for note in base_content}
+    except mp.core.unix.NonFatalCommandError:
+        pass  # File doesn't exist on main — new integration, validate all entries
+    return set()
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -79,12 +103,7 @@ class ReleaseNotesDateValidation:
             changed = mp.core.unix.get_files_unmerged_to_main_branch("main", head_sha, validation_path)
             if not changed:
                 return
-            try:
-                base_content = yaml.safe_load(mp.core.unix.get_file_content_from_main_branch(rn_path))
-                if isinstance(base_content, list):
-                    existing_versions = {_normalize_version(note.get("integration_version", "")) for note in base_content}
-            except mp.core.unix.NonFatalCommandError:
-                pass  # File doesn't exist on main yet — all entries are new
+            existing_versions = _versions_on_main(rn_path)
 
         date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
         invalid: list[str] = []

--- a/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
@@ -29,6 +29,22 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def _normalize_version(v: object) -> str:
+    """Normalize a YAML-parsed version value to a canonical string.
+
+    YAML parses unquoted ``1.0`` as ``float`` and ``1`` as ``int``, causing
+    ``str(1.0) == "1.0"`` while ``str(1) == "1"``.  Converting through
+    ``float`` first ensures both map to the same representation.
+    """
+    try:
+        f = float(str(v))
+        if f == int(f):
+            return str(int(f))
+        return str(f)
+    except (ValueError, OverflowError, TypeError):
+        return str(v)
+
+
 @dataclasses.dataclass(slots=True, frozen=True)
 class ReleaseNotesDateValidation:
     """Validate that release notes have valid publish dates."""
@@ -66,14 +82,14 @@ class ReleaseNotesDateValidation:
             try:
                 base_content = yaml.safe_load(mp.core.unix.get_file_content_from_main_branch(rn_path))
                 if isinstance(base_content, list):
-                    existing_versions = {str(note.get("integration_version", "")) for note in base_content}
+                    existing_versions = {_normalize_version(note.get("integration_version", "")) for note in base_content}
             except mp.core.unix.NonFatalCommandError:
                 pass  # File doesn't exist on main yet — all entries are new
 
         date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
         invalid: list[str] = []
         for note in content:
-            version = str(note.get("integration_version", "?"))
+            version = _normalize_version(note.get("integration_version", "?"))
             if head_sha and version in existing_versions:
                 continue  # Pre-existing entry — skip
             publish_time = str(note.get("publish_time", ""))

--- a/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/pre_build_validation/integrations/release_notes_date_validation.py
@@ -47,10 +47,6 @@ class ReleaseNotesDateValidation:
 
         """
         head_sha: str | None = os.environ.get("GITHUB_PR_SHA")
-        if head_sha:
-            changed = mp.core.unix.get_files_unmerged_to_main_branch("main", head_sha, validation_path)
-            if not changed:
-                return
 
         rn_path = validation_path / constants.RELEASE_NOTES_FILE
         if not rn_path.exists():
@@ -60,12 +56,28 @@ class ReleaseNotesDateValidation:
         if not content or not isinstance(content, list):
             return
 
+        # In PR context, only validate entries that are new (not present on main).
+        # This avoids penalising pre-existing entries that predate the requirement.
+        existing_versions: set[str] = set()
+        if head_sha:
+            changed = mp.core.unix.get_files_unmerged_to_main_branch("main", head_sha, validation_path)
+            if not changed:
+                return
+            try:
+                base_content = yaml.safe_load(mp.core.unix.get_file_content_from_main_branch(rn_path))
+                if isinstance(base_content, list):
+                    existing_versions = {str(note.get("integration_version", "")) for note in base_content}
+            except mp.core.unix.NonFatalCommandError:
+                pass  # File doesn't exist on main yet — all entries are new
+
         date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
         invalid: list[str] = []
         for note in content:
+            version = str(note.get("integration_version", "?"))
+            if head_sha and version in existing_versions:
+                continue  # Pre-existing entry — skip
             publish_time = str(note.get("publish_time", ""))
             if not date_pattern.match(publish_time):
-                version = note.get("integration_version", "?")
                 invalid.append(f"v{version}: '{publish_time}'")
 
         if invalid:

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_empty_init_files_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_empty_init_files_validation.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the EmptyInitFilesValidation class."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from mp.core.exceptions import NonFatalValidationError
+from mp.validate.pre_build_validation.integrations.empty_init_files_validation import (
+    EmptyInitFilesValidation,
+)
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+class TestEmptyInitFilesValidation:
+    """Test suite for the EmptyInitFilesValidation runner."""
+
+    validator_runner = EmptyInitFilesValidation()
+
+    def test_success_on_empty_init_file(self, temp_integration: pathlib.Path) -> None:
+        """Test that a completely empty __init__.py passes validation."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("", encoding="utf-8")
+
+        self.validator_runner.run(temp_integration)
+
+    def test_success_on_license_header_only(self, temp_integration: pathlib.Path) -> None:
+        """Test that __init__.py with only a license header comment passes."""
+        license_header = (
+            "# Copyright 2026 Google LLC\n"
+            "#\n"
+            "# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+            "# you may not use this file except in compliance with the License.\n"
+            "# You may obtain a copy of the License at\n"
+            "#\n"
+            "#     http://www.apache.org/licenses/LICENSE-2.0\n"
+            "#\n"
+            "# Unless required by applicable law or agreed to in writing, software\n"
+            "# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+            "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
+            "# See the License for the specific language governing permissions and\n"
+            "# limitations under the License.\n"
+        )
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text(license_header, encoding="utf-8")
+
+        self.validator_runner.run(temp_integration)
+
+    def test_success_on_future_import_only(self, temp_integration: pathlib.Path) -> None:
+        """Test that __init__.py with only a future import passes."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("from __future__ import annotations\n", encoding="utf-8")
+
+        self.validator_runner.run(temp_integration)
+
+    def test_failure_on_init_with_real_import(self, temp_integration: pathlib.Path) -> None:
+        """Test that __init__.py with a real import statement fails."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("import os\n", encoding="utf-8")
+
+        with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
+            self.validator_runner.run(temp_integration)
+
+    def test_failure_on_init_with_from_import(self, temp_integration: pathlib.Path) -> None:
+        """Test that __init__.py with a from-import (not future) statement fails."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("from .some_module import SomeClass\n", encoding="utf-8")
+
+        with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
+            self.validator_runner.run(temp_integration)
+
+    def test_tests_dir_init_not_checked(self, temp_integration: pathlib.Path) -> None:
+        """Test that __init__.py inside the tests/ directory is not validated."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        tests_init = tests_dir / "__init__.py"
+        tests_init.write_text("import os\nfrom something import bad\n", encoding="utf-8")
+
+        # Should not raise — tests/ is not in _CHECKED_DIRS
+        self.validator_runner.run(temp_integration)
+
+    def test_missing_init_file_in_checked_dir_is_skipped(self, temp_integration: pathlib.Path) -> None:
+        """Test that a missing __init__.py in a checked dir is skipped gracefully."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.unlink(missing_ok=True)
+
+        # Should not raise — missing file is simply skipped
+        self.validator_runner.run(temp_integration)
+
+    def test_ci_context_with_no_changes_skips(self, temp_integration: pathlib.Path) -> None:
+        """Test that in CI with no changed files the validation is skipped."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("import os\n", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[],
+            ),
+        ):
+            # No changes reported — validation is skipped, no error raised
+            self.validator_runner.run(temp_integration)
+
+    def test_ci_context_with_changes_validates(self, temp_integration: pathlib.Path) -> None:
+        """Test that in CI with changed files the validation runs and can fail."""
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("import os\n", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[init_file],
+            ),
+        ):
+            with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
+                self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_empty_init_files_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_empty_init_files_validation.py
@@ -134,3 +134,24 @@ class TestEmptyInitFilesValidation:
         ):
             with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
                 self.validator_runner.run(temp_integration)
+
+    def test_non_init_change_still_validates_all_inits(self, temp_integration: pathlib.Path) -> None:
+        """The CI gate is integration-level (any change triggers), not file-level.
+
+        Changing a non-init file (e.g. an action) still causes ALL __init__.py
+        files in checked dirs to be validated.
+        """
+        init_file = temp_integration / "actions" / "__init__.py"
+        init_file.write_text("import os\n", encoding="utf-8")  # bad content
+        other_changed = temp_integration / "actions" / "ping.py"  # different file changed
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[other_changed],
+            ),
+        ):
+            # Integration has changes → all inits validated → bad actions/__init__.py caught
+            with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
+                self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_empty_init_files_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_empty_init_files_validation.py
@@ -47,14 +47,14 @@ class TestEmptyInitFilesValidation:
         license_header = (
             "# Copyright 2026 Google LLC\n"
             "#\n"
-            "# Licensed under the Apache License, Version 2.0 (the \"License\");\n"
+            '# Licensed under the Apache License, Version 2.0 (the "License");\n'
             "# you may not use this file except in compliance with the License.\n"
             "# You may obtain a copy of the License at\n"
             "#\n"
             "#     http://www.apache.org/licenses/LICENSE-2.0\n"
             "#\n"
             "# Unless required by applicable law or agreed to in writing, software\n"
-            "# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+            '# distributed under the License is distributed on an "AS IS" BASIS,\n'
             "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
             "# See the License for the specific language governing permissions and\n"
             "# limitations under the License.\n"
@@ -76,7 +76,7 @@ class TestEmptyInitFilesValidation:
         init_file = temp_integration / "actions" / "__init__.py"
         init_file.write_text("import os\n", encoding="utf-8")
 
-        with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
+        with pytest.raises(NonFatalValidationError, match=r"__init__\.py files must be empty"):
             self.validator_runner.run(temp_integration)
 
     def test_failure_on_init_with_from_import(self, temp_integration: pathlib.Path) -> None:
@@ -84,7 +84,7 @@ class TestEmptyInitFilesValidation:
         init_file = temp_integration / "actions" / "__init__.py"
         init_file.write_text("from .some_module import SomeClass\n", encoding="utf-8")
 
-        with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
+        with pytest.raises(NonFatalValidationError, match=r"__init__\.py files must be empty"):
             self.validator_runner.run(temp_integration)
 
     def test_tests_dir_init_not_checked(self, temp_integration: pathlib.Path) -> None:
@@ -131,9 +131,9 @@ class TestEmptyInitFilesValidation:
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[init_file],
             ),
+            pytest.raises(NonFatalValidationError, match=r"__init__\.py files must be empty"),
         ):
-            with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
-                self.validator_runner.run(temp_integration)
+            self.validator_runner.run(temp_integration)
 
     def test_non_init_change_still_validates_all_inits(self, temp_integration: pathlib.Path) -> None:
         """The CI gate is integration-level (any change triggers), not file-level.
@@ -151,7 +151,7 @@ class TestEmptyInitFilesValidation:
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[other_changed],
             ),
-        ):
             # Integration has changes → all inits validated → bad actions/__init__.py caught
-            with pytest.raises(NonFatalValidationError, match="__init__.py files must be empty"):
-                self.validator_runner.run(temp_integration)
+            pytest.raises(NonFatalValidationError, match=r"__init__\.py files must be empty"),
+        ):
+            self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_json_result_example_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_json_result_example_validation.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import shutil
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -23,6 +24,9 @@ from mp.core.exceptions import NonFatalValidationError
 from mp.validate.pre_build_validation.integrations.json_result_example_validation import (
     JsonResultExampleValidation,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 VALIDATOR = JsonResultExampleValidation()
 
@@ -63,7 +67,6 @@ class TestJsonResultExampleValidationLocal:
         VALIDATOR.run(temp_integration)  # _ prefix — skipped, no error
 
     def test_no_actions_dir_passes(self, temp_integration: Path) -> None:
-        import shutil
         shutil.rmtree(temp_integration / "actions")
         VALIDATOR.run(temp_integration)  # no error
 
@@ -78,9 +81,9 @@ class TestJsonResultExampleValidationCI:
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
             mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[action]),
+            pytest.raises(NonFatalValidationError, match="get_data"),
         ):
-            with pytest.raises(NonFatalValidationError, match="get_data"):
-                VALIDATOR.run(temp_integration)
+            VALIDATOR.run(temp_integration)
 
     def test_unchanged_action_missing_example_passes(self, temp_integration: Path) -> None:
         """Pre-existing action without example should not be flagged if not in diff."""
@@ -125,6 +128,6 @@ class TestJsonResultExampleValidationCI:
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
             mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[action]),
+            pytest.raises(NonFatalValidationError, match="new_action"),
         ):
-            with pytest.raises(NonFatalValidationError, match="new_action"):
-                VALIDATOR.run(temp_integration)
+            VALIDATOR.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_json_result_example_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_json_result_example_validation.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mp.core.exceptions import NonFatalValidationError
+from mp.validate.pre_build_validation.integrations.json_result_example_validation import (
+    JsonResultExampleValidation,
+)
+
+VALIDATOR = JsonResultExampleValidation()
+
+
+class TestJsonResultExampleValidationLocal:
+    """Local mp validate runs (no GITHUB_PR_SHA) — all action files are checked."""
+
+    def test_action_with_example_passes(self, temp_integration: Path) -> None:
+        # mock_integration already has ping.py (no JSON result) and
+        # ping_JsonResult_example.json — baseline should pass
+        VALIDATOR.run(temp_integration)
+
+    def test_action_with_json_result_missing_example_fails(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+
+        with pytest.raises(NonFatalValidationError, match="get_data"):
+            VALIDATOR.run(temp_integration)
+
+    def test_action_with_example_present_passes(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+        example = temp_integration / "resources" / "get_data_JsonResult_example.json"
+        example.write_text('{"key": "value"}', encoding="utf-8")
+
+        VALIDATOR.run(temp_integration)  # no error
+
+    def test_action_with_json_result_in_comment_ignored(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("# result.add_result_json(data)\n", encoding="utf-8")
+
+        VALIDATOR.run(temp_integration)  # comment-only — no error
+
+    def test_private_action_file_skipped(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "_helpers.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+
+        VALIDATOR.run(temp_integration)  # _ prefix — skipped, no error
+
+    def test_no_actions_dir_passes(self, temp_integration: Path) -> None:
+        import shutil
+        shutil.rmtree(temp_integration / "actions")
+        VALIDATOR.run(temp_integration)  # no error
+
+
+class TestJsonResultExampleValidationCI:
+    """CI runs (GITHUB_PR_SHA set) — only changed action files are checked."""
+
+    def test_changed_action_missing_example_fails(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[action]),
+        ):
+            with pytest.raises(NonFatalValidationError, match="get_data"):
+                VALIDATOR.run(temp_integration)
+
+    def test_unchanged_action_missing_example_passes(self, temp_integration: Path) -> None:
+        """Pre-existing action without example should not be flagged if not in diff."""
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+        # action is NOT in the changed files list
+        other_changed = [temp_integration / "definition.yaml"]
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=other_changed),
+        ):
+            VALIDATOR.run(temp_integration)  # pre-existing gap — not flagged
+
+    def test_no_changes_skips_entirely(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[]),
+        ):
+            VALIDATOR.run(temp_integration)  # skipped entirely
+
+    def test_changed_action_with_example_passes(self, temp_integration: Path) -> None:
+        action = temp_integration / "actions" / "get_data.py"
+        action.write_text("result.add_result_json(data)", encoding="utf-8")
+        example = temp_integration / "resources" / "get_data_JsonResult_example.json"
+        example.write_text('{"key": "value"}', encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[action]),
+        ):
+            VALIDATOR.run(temp_integration)  # no error
+
+    def test_new_action_in_pr_checked(self, temp_integration: Path) -> None:
+        """Newly added action files in the PR are subject to the check."""
+        action = temp_integration / "actions" / "new_action.py"
+        action.write_text("self.json_results = results", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[action]),
+        ):
+            with pytest.raises(NonFatalValidationError, match="new_action"):
+                VALIDATOR.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import shutil
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -121,10 +122,9 @@ class TestPingMessageFormatValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[ping_file],
-            ),
+            ), pytest.raises(NonFatalValidationError, match="Ping success message must contain")
         ):
-            with pytest.raises(NonFatalValidationError, match="Ping success message must contain"):
-                self.validator_runner.run(temp_integration)
+            self.validator_runner.run(temp_integration)
 
     def test_failure_on_missing_failure_message(self, temp_integration: pathlib.Path) -> None:
         """Test failure when the ping file lacks the required failure message."""
@@ -136,10 +136,9 @@ class TestPingMessageFormatValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[ping_file],
-            ),
+            ), pytest.raises(NonFatalValidationError, match="Ping failure message must contain")
         ):
-            with pytest.raises(NonFatalValidationError, match="Ping failure message must contain"):
-                self.validator_runner.run(temp_integration)
+            self.validator_runner.run(temp_integration)
 
     def test_failure_on_both_messages_missing(self, temp_integration: pathlib.Path) -> None:
         """Test failure when the ping file is missing both required messages."""
@@ -151,10 +150,9 @@ class TestPingMessageFormatValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[ping_file],
-            ),
+            ), pytest.raises(NonFatalValidationError)
         ):
-            with pytest.raises(NonFatalValidationError):
-                self.validator_runner.run(temp_integration)
+            self.validator_runner.run(temp_integration)
 
     def test_ci_ping_not_changed_skips_validation(self, temp_integration: pathlib.Path) -> None:
         """Test that validation is skipped when ping file is not changed in CI."""
@@ -187,8 +185,6 @@ class TestPingMessageFormatValidation:
 
     def test_no_actions_directory_skips_validation(self, temp_integration: pathlib.Path) -> None:
         """Test that a missing actions/ directory is handled gracefully."""
-        import shutil
-
         actions_dir = temp_integration / constants.ACTIONS_DIR
         if actions_dir.exists():
             shutil.rmtree(actions_dir)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
@@ -205,3 +205,12 @@ class TestPingMessageFormatValidation:
 
         # No ping file found — should not raise
         self.validator_runner.run(temp_integration)
+
+    def test_failure_on_missing_success_message_no_ci(self, temp_integration: pathlib.Path) -> None:
+        """Test that bad ping content fails in a local (non-CI) run too."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text(_MISSING_SUCCESS_PING_CONTENT, encoding="utf-8")
+
+        # No GITHUB_PR_SHA → validator always runs (no CI gate)
+        with pytest.raises(NonFatalValidationError, match="Ping success message must contain"):
+            self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PingMessageFormatValidation class."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from mp.core import constants
+from mp.core.exceptions import NonFatalValidationError
+from mp.validate.pre_build_validation.integrations.ping_message_validation import (
+    PingMessageFormatValidation,
+)
+
+if TYPE_CHECKING:
+    import pathlib
+
+_GOOD_PING_CONTENT = """\
+from __future__ import annotations
+
+SCRIPT_NAME = "Ping"
+
+
+def main() -> None:
+    try:
+        # attempt connectivity check
+        pass
+        output = "Successfully connected to the Mock Integration server with the provided connection parameters!"
+    except Exception as e:
+        output = f"Failed to connect to the Mock Integration server! Error is {e}"
+    print(output)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+_MISSING_SUCCESS_PING_CONTENT = """\
+from __future__ import annotations
+
+SCRIPT_NAME = "Ping"
+
+
+def main() -> None:
+    try:
+        pass
+    except Exception as e:
+        output = f"Failed to connect to the Mock Integration server! Error is {e}"
+        print(output)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+_MISSING_FAILURE_PING_CONTENT = """\
+from __future__ import annotations
+
+SCRIPT_NAME = "Ping"
+
+
+def main() -> None:
+    output = "Successfully connected to the Mock Integration server with the provided connection parameters!"
+    print(output)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+class TestPingMessageFormatValidation:
+    """Test suite for the PingMessageFormatValidation runner."""
+
+    validator_runner = PingMessageFormatValidation()
+
+    def test_success_on_correct_messages_no_ci(self, temp_integration: pathlib.Path) -> None:
+        """Test that a ping with correct success and failure messages passes (non-CI)."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text(_GOOD_PING_CONTENT, encoding="utf-8")
+
+        # No GITHUB_PR_SHA → always validates
+        self.validator_runner.run(temp_integration)
+
+    def test_success_on_correct_messages_ci_ping_changed(self, temp_integration: pathlib.Path) -> None:
+        """Test that a correct ping passes when the ping file is changed in CI."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text(_GOOD_PING_CONTENT, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[ping_file],
+            ),
+        ):
+            self.validator_runner.run(temp_integration)
+
+    def test_failure_on_missing_success_message(self, temp_integration: pathlib.Path) -> None:
+        """Test failure when the ping file lacks the required success message."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text(_MISSING_SUCCESS_PING_CONTENT, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[ping_file],
+            ),
+        ):
+            with pytest.raises(NonFatalValidationError, match="Ping success message must contain"):
+                self.validator_runner.run(temp_integration)
+
+    def test_failure_on_missing_failure_message(self, temp_integration: pathlib.Path) -> None:
+        """Test failure when the ping file lacks the required failure message."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text(_MISSING_FAILURE_PING_CONTENT, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[ping_file],
+            ),
+        ):
+            with pytest.raises(NonFatalValidationError, match="Ping failure message must contain"):
+                self.validator_runner.run(temp_integration)
+
+    def test_failure_on_both_messages_missing(self, temp_integration: pathlib.Path) -> None:
+        """Test failure when the ping file is missing both required messages."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text("def main():\n    pass\n\nif __name__ == '__main__':\n    main()\n", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[ping_file],
+            ),
+        ):
+            with pytest.raises(NonFatalValidationError):
+                self.validator_runner.run(temp_integration)
+
+    def test_ci_ping_not_changed_skips_validation(self, temp_integration: pathlib.Path) -> None:
+        """Test that validation is skipped when ping file is not changed in CI."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        # Write bad content that would fail if validated
+        ping_file.write_text("def main():\n    pass\n", encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                # Return a changed file that is NOT Ping.py or ping.py
+                return_value=[temp_integration / constants.ACTIONS_DIR / "some_other_action.py"],
+            ),
+        ):
+            # Ping not in changed files → _is_ping_changed_in_pr returns False → skip
+            self.validator_runner.run(temp_integration)
+
+    def test_excluded_integration_skips_validation(self, temp_integration: pathlib.Path) -> None:
+        """Test that an excluded integration is skipped regardless of ping content."""
+        ping_file = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_file.write_text("def main():\n    pass\n", encoding="utf-8")
+
+        with mock.patch(
+            "mp.core.exclusions.get_excluded_names_without_ping_message_format",
+            return_value={temp_integration.name},
+        ):
+            # Integration name is excluded — should not raise
+            self.validator_runner.run(temp_integration)
+
+    def test_no_actions_directory_skips_validation(self, temp_integration: pathlib.Path) -> None:
+        """Test that a missing actions/ directory is handled gracefully."""
+        import shutil
+
+        actions_dir = temp_integration / constants.ACTIONS_DIR
+        if actions_dir.exists():
+            shutil.rmtree(actions_dir)
+
+        # Should not raise
+        self.validator_runner.run(temp_integration)
+
+    def test_no_ping_file_skips_validation(self, temp_integration: pathlib.Path) -> None:
+        """Test that a missing ping file is skipped gracefully."""
+        ping_py = temp_integration / constants.ACTIONS_DIR / "ping.py"
+        ping_upper = temp_integration / constants.ACTIONS_DIR / "Ping.py"
+        ping_py.unlink(missing_ok=True)
+        ping_upper.unlink(missing_ok=True)
+
+        # No ping file found — should not raise
+        self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_ping_message_format_validation.py
@@ -122,7 +122,8 @@ class TestPingMessageFormatValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[ping_file],
-            ), pytest.raises(NonFatalValidationError, match="Ping success message must contain")
+            ),
+            pytest.raises(NonFatalValidationError, match="Ping success message must contain"),
         ):
             self.validator_runner.run(temp_integration)
 
@@ -136,7 +137,8 @@ class TestPingMessageFormatValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[ping_file],
-            ), pytest.raises(NonFatalValidationError, match="Ping failure message must contain")
+            ),
+            pytest.raises(NonFatalValidationError, match="Ping failure message must contain"),
         ):
             self.validator_runner.run(temp_integration)
 
@@ -150,7 +152,8 @@ class TestPingMessageFormatValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[ping_file],
-            ), pytest.raises(NonFatalValidationError)
+            ),
+            pytest.raises(NonFatalValidationError),
         ):
             self.validator_runner.run(temp_integration)
 

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_release_notes_date_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_release_notes_date_validation.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -25,9 +24,6 @@ from mp.core.unix import NonFatalCommandError
 from mp.validate.pre_build_validation.integrations.release_notes_date_validation import (
     ReleaseNotesDateValidation,
 )
-
-if TYPE_CHECKING:
-    pass
 
 VALIDATOR = ReleaseNotesDateValidation()
 
@@ -100,7 +96,7 @@ class TestReleaseNotesDateValidationLocal:
         """In local runs, all entries (including pre-existing) are validated."""
         rn = temp_integration / "release_notes.yaml"
         rn.write_text(TWO_ENTRY_RN_OLD_MISSING, encoding="utf-8")
-        with pytest.raises(NonFatalValidationError, match="v1.0"):
+        with pytest.raises(NonFatalValidationError, match=r"v1:"):
             VALIDATOR.run(temp_integration)
 
 
@@ -140,7 +136,7 @@ class TestReleaseNotesDateValidationCI:
             mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
             mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=OLD_MAIN_RN),
         ):
-            with pytest.raises(NonFatalValidationError, match="v2.0"):
+            with pytest.raises(NonFatalValidationError, match=r"v2:"):
                 VALIDATOR.run(temp_integration)
 
     def test_no_changes_in_integration_skips(self, temp_integration: Path) -> None:
@@ -176,3 +172,28 @@ class TestReleaseNotesDateValidationCI:
         ):
             with pytest.raises(NonFatalValidationError, match="invalid publish_time"):
                 VALIDATOR.run(temp_integration)
+
+    def test_float_int_version_coercion_skips_correctly(self, temp_integration: Path) -> None:
+        """YAML parses unquoted 1.0 as float and 1 as int — both must be treated as equal
+        so a pre-existing entry with version 1.0 (float) is skipped when comparing to a
+        new entry at version 2.0, and the old float-versioned entry isn't re-validated."""
+        # Main branch has unquoted 1.0 → parsed as float by yaml.safe_load
+        old_main_rn_unquoted = "- integration_version: 1.0\n  description: Initial\n"
+        # Current file has new entry (2.0) plus pre-existing (1.0, no publish_time)
+        current_rn = (
+            "- integration_version: 2.0\n"
+            "  publish_time: '2026-04-28'\n"
+            "  description: New\n"
+            "- integration_version: 1.0\n"
+            "  description: Initial\n"
+        )
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(current_rn, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=old_main_rn_unquoted),
+        ):
+            # v1.0 pre-exists on main (unquoted float); v2.0 is new with valid date → pass
+            VALIDATOR.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_release_notes_date_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_release_notes_date_validation.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from mp.core.exceptions import NonFatalValidationError
+from mp.core.unix import NonFatalCommandError
+from mp.validate.pre_build_validation.integrations.release_notes_date_validation import (
+    ReleaseNotesDateValidation,
+)
+
+if TYPE_CHECKING:
+    pass
+
+VALIDATOR = ReleaseNotesDateValidation()
+
+VALID_RN = """\
+- integration_version: '1.0'
+  publish_time: '2024-01-01'
+  description: Initial release
+"""
+
+INVALID_RN = """\
+- integration_version: '1.0'
+  publish_time: ''
+  description: Initial release
+"""
+
+MISSING_PUBLISH_TIME_RN = """\
+- integration_version: '1.0'
+  description: Initial release
+"""
+
+TWO_ENTRY_RN_VALID = """\
+- integration_version: '2.0'
+  publish_time: '2026-04-28'
+  description: New feature
+- integration_version: '1.0'
+  publish_time: '2024-01-01'
+  description: Initial release
+"""
+
+TWO_ENTRY_RN_OLD_MISSING = """\
+- integration_version: '2.0'
+  publish_time: '2026-04-28'
+  description: New feature
+- integration_version: '1.0'
+  description: Initial release
+"""
+
+OLD_MAIN_RN = """\
+- integration_version: '1.0'
+  description: Initial release
+"""
+
+
+class TestReleaseNotesDateValidationLocal:
+    """Local mp validate runs (no GITHUB_PR_SHA) — all entries are checked."""
+
+    def test_valid_date_passes(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(VALID_RN, encoding="utf-8")
+        VALIDATOR.run(temp_integration)  # no error
+
+    def test_invalid_date_fails(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(INVALID_RN, encoding="utf-8")
+        with pytest.raises(NonFatalValidationError, match="invalid publish_time"):
+            VALIDATOR.run(temp_integration)
+
+    def test_missing_publish_time_fails(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(MISSING_PUBLISH_TIME_RN, encoding="utf-8")
+        with pytest.raises(NonFatalValidationError, match="invalid publish_time"):
+            VALIDATOR.run(temp_integration)
+
+    def test_no_release_notes_file_passes(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.unlink(missing_ok=True)
+        VALIDATOR.run(temp_integration)  # no error
+
+    def test_old_entry_without_publish_time_fails_locally(self, temp_integration: Path) -> None:
+        """In local runs, all entries (including pre-existing) are validated."""
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(TWO_ENTRY_RN_OLD_MISSING, encoding="utf-8")
+        with pytest.raises(NonFatalValidationError, match="v1.0"):
+            VALIDATOR.run(temp_integration)
+
+
+class TestReleaseNotesDateValidationCI:
+    """CI runs (GITHUB_PR_SHA set) — only new entries are checked."""
+
+    def _make_changed(self, temp_integration: Path) -> list[Path]:
+        return [temp_integration / "release_notes.yaml"]
+
+    def test_new_valid_entry_passes(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(TWO_ENTRY_RN_OLD_MISSING, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=OLD_MAIN_RN),
+        ):
+            # v1.0 is pre-existing on main (no publish_time) — should be skipped
+            # v2.0 is new and has a valid date — should pass
+            VALIDATOR.run(temp_integration)
+
+    def test_new_invalid_entry_fails(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        new_rn = """\
+- integration_version: '2.0'
+  publish_time: ''
+  description: New feature
+- integration_version: '1.0'
+  publish_time: '2024-01-01'
+  description: Initial release
+"""
+        rn.write_text(new_rn, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=OLD_MAIN_RN),
+        ):
+            with pytest.raises(NonFatalValidationError, match="v2.0"):
+                VALIDATOR.run(temp_integration)
+
+    def test_no_changes_in_integration_skips(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(INVALID_RN, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=[]),
+        ):
+            VALIDATOR.run(temp_integration)  # skipped entirely — no error
+
+    def test_new_integration_not_on_main_all_entries_validated(self, temp_integration: Path) -> None:
+        """When file doesn't exist on main, NonFatalCommandError is caught and all entries checked."""
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(VALID_RN, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch("mp.core.unix.get_file_content_from_main_branch", side_effect=NonFatalCommandError("not found")),
+        ):
+            VALIDATOR.run(temp_integration)  # valid date — passes
+
+    def test_new_integration_not_on_main_invalid_date_fails(self, temp_integration: Path) -> None:
+        rn = temp_integration / "release_notes.yaml"
+        rn.write_text(INVALID_RN, encoding="utf-8")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch("mp.core.unix.get_file_content_from_main_branch", side_effect=NonFatalCommandError("not found")),
+        ):
+            with pytest.raises(NonFatalValidationError, match="invalid publish_time"):
+                VALIDATOR.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_release_notes_date_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_release_notes_date_validation.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -24,6 +24,9 @@ from mp.core.unix import NonFatalCommandError
 from mp.validate.pre_build_validation.integrations.release_notes_date_validation import (
     ReleaseNotesDateValidation,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 VALIDATOR = ReleaseNotesDateValidation()
 
@@ -112,7 +115,10 @@ class TestReleaseNotesDateValidationCI:
 
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
-            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=self._make_changed(temp_integration),
+            ),
             mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=OLD_MAIN_RN),
         ):
             # v1.0 is pre-existing on main (no publish_time) — should be skipped
@@ -133,11 +139,14 @@ class TestReleaseNotesDateValidationCI:
 
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
-            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=self._make_changed(temp_integration),
+            ),
             mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=OLD_MAIN_RN),
+            pytest.raises(NonFatalValidationError, match=r"v2:"),
         ):
-            with pytest.raises(NonFatalValidationError, match=r"v2:"):
-                VALIDATOR.run(temp_integration)
+            VALIDATOR.run(temp_integration)
 
     def test_no_changes_in_integration_skips(self, temp_integration: Path) -> None:
         rn = temp_integration / "release_notes.yaml"
@@ -156,7 +165,10 @@ class TestReleaseNotesDateValidationCI:
 
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
-            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=self._make_changed(temp_integration),
+            ),
             mock.patch("mp.core.unix.get_file_content_from_main_branch", side_effect=NonFatalCommandError("not found")),
         ):
             VALIDATOR.run(temp_integration)  # valid date — passes
@@ -167,11 +179,14 @@ class TestReleaseNotesDateValidationCI:
 
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
-            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=self._make_changed(temp_integration),
+            ),
             mock.patch("mp.core.unix.get_file_content_from_main_branch", side_effect=NonFatalCommandError("not found")),
+            pytest.raises(NonFatalValidationError, match="invalid publish_time"),
         ):
-            with pytest.raises(NonFatalValidationError, match="invalid publish_time"):
-                VALIDATOR.run(temp_integration)
+            VALIDATOR.run(temp_integration)
 
     def test_float_int_version_coercion_skips_correctly(self, temp_integration: Path) -> None:
         """YAML parses unquoted 1.0 as float and 1 as int — both must be treated as equal
@@ -192,7 +207,10 @@ class TestReleaseNotesDateValidationCI:
 
         with (
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
-            mock.patch("mp.core.unix.get_files_unmerged_to_main_branch", return_value=self._make_changed(temp_integration)),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=self._make_changed(temp_integration),
+            ),
             mock.patch("mp.core.unix.get_file_content_from_main_branch", return_value=old_main_rn_unquoted),
         ):
             # v1.0 pre-exists on main (unquoted float); v2.0 is new with valid date → pass

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_support_email_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_support_email_validation.py
@@ -85,7 +85,7 @@ class TestSupportEmailValidation:
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
-                return_value=["some_file.py"],
+                return_value=[Path("some_file.py")],
             ),
             pytest.raises(NonFatalValidationError, match="support email"),
         ):

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_support_email_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_support_email_validation.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the SupportEmailValidation class."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+import toml
+
+from mp.core.exceptions import NonFatalValidationError
+from mp.validate.pre_build_validation.integrations.support_email_validation import (
+    SupportEmailValidation,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _write_pyproject(integration_path: Path, description: str) -> None:
+    """Write a minimal pyproject.toml with the given description."""
+    content = {
+        "project": {
+            "name": "mock_integration",
+            "version": "1.0",
+            "description": description,
+        }
+    }
+    pyproject_path = integration_path / "pyproject.toml"
+    with pyproject_path.open("w") as f:
+        f.write(toml.dumps(content))
+
+
+@pytest.fixture
+def partner_integration(non_built_integration: Path) -> Iterator[Path]:
+    """Create a temporary copy of the mock integration under a 'partner' parent directory."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        partner_dir = temp_root / "partner"
+        partner_dir.mkdir()
+        temp_path = partner_dir / non_built_integration.name
+        shutil.copytree(non_built_integration.resolve(), temp_path)
+        yield temp_path
+
+
+class TestSupportEmailValidation:
+    """Test suite for the SupportEmailValidation validator."""
+
+    runner = SupportEmailValidation()
+
+    def test_community_integration_skipped(self, temp_integration: Path) -> None:
+        """Test that community integrations (not under 'partner') are skipped."""
+        # temp_integration lives under 'third_party/mock_integration/', no 'partner' in parts
+        # No email in description — should still pass because validator skips non-partner paths
+        _write_pyproject(temp_integration, "No email here at all")
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_partner_with_valid_email_passes(self, partner_integration: Path) -> None:
+        """Test that a partner integration with a valid support email passes."""
+        _write_pyproject(partner_integration, "Support contact: support@example.com")
+        self.runner.run(partner_integration)  # Should not raise
+
+    def test_partner_missing_email_fails_in_ci(self, partner_integration: Path) -> None:
+        """Test that a partner integration without an email fails when run in CI context."""
+        _write_pyproject(partner_integration, "No email in this description")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=["some_file.py"],
+            ),
+            pytest.raises(NonFatalValidationError, match="support email"),
+        ):
+            self.runner.run(partner_integration)
+
+    def test_partner_no_changes_in_ci_skips_validation(self, partner_integration: Path) -> None:
+        """Test that a partner integration with no changed files in CI is skipped."""
+        _write_pyproject(partner_integration, "No email in this description")
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[],
+            ),
+        ):
+            self.runner.run(partner_integration)  # Should not raise
+
+    def test_partner_missing_email_fails_outside_ci(self, partner_integration: Path) -> None:
+        """Test that a partner integration without an email fails when not in CI context."""
+        _write_pyproject(partner_integration, "No email in this description")
+
+        # No GITHUB_PR_SHA set — validator runs unconditionally for partner integrations
+        with (
+            mock.patch.dict("os.environ", {}, clear=True),
+            pytest.raises(NonFatalValidationError, match="support email"),
+        ):
+            self.runner.run(partner_integration)
+
+    def test_partner_email_various_formats_pass(self, partner_integration: Path) -> None:
+        """Test that various valid email formats in the description are accepted."""
+        email_descriptions = [
+            "Contact: user@domain.com",
+            "Reach us at support.team@sub.example.org",
+            "Email: foo-bar@baz.io for help",
+        ]
+        for description in email_descriptions:
+            _write_pyproject(partner_integration, description)
+            self.runner.run(partner_integration)  # Should not raise
+
+    def test_partner_missing_pyproject_skips(self, partner_integration: Path) -> None:
+        """Test that a missing pyproject.toml causes the validator to skip gracefully."""
+        pyproject = partner_integration / "pyproject.toml"
+        pyproject.unlink(missing_ok=True)
+        self.runner.run(partner_integration)  # Should not raise

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_test_config_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_test_config_validation.py
@@ -116,6 +116,7 @@ class TestTestConfigValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[temp_integration / "actions" / "ping.py"],
-            ), pytest.raises(NonFatalValidationError, match=r"missing tests/config\.json")
+            ),
+            pytest.raises(NonFatalValidationError, match=r"missing tests/config\.json"),
         ):
             self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_test_config_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_test_config_validation.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the TestConfigValidation class."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from mp.core.exceptions import NonFatalValidationError
+from mp.validate.pre_build_validation.integrations.test_config_validation import (
+    TestConfigValidation,
+)
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+class TestTestConfigValidation:
+    """Test suite for the TestConfigValidation runner."""
+
+    validator_runner = TestConfigValidation()
+
+    def test_success_on_valid_config(self, temp_integration: pathlib.Path) -> None:
+        """Test that a valid tests/config.json (dict) passes validation."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        config_file = tests_dir / "config.json"
+        config_file.write_text(json.dumps({"api_root": "https://example.com", "api_key": "secret"}), encoding="utf-8")
+
+        self.validator_runner.run(temp_integration)
+
+    def test_failure_on_missing_config(self, temp_integration: pathlib.Path) -> None:
+        """Test failure when tests/config.json is absent."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        # Ensure config.json does not exist
+        config_file = tests_dir / "config.json"
+        config_file.unlink(missing_ok=True)
+
+        with pytest.raises(NonFatalValidationError, match="missing tests/config.json"):
+            self.validator_runner.run(temp_integration)
+
+    def test_failure_on_invalid_json(self, temp_integration: pathlib.Path) -> None:
+        """Test failure when tests/config.json contains malformed JSON."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        config_file = tests_dir / "config.json"
+        config_file.write_text("{ this is not valid json }", encoding="utf-8")
+
+        with pytest.raises(NonFatalValidationError, match="not valid JSON"):
+            self.validator_runner.run(temp_integration)
+
+    def test_failure_on_list_config(self, temp_integration: pathlib.Path) -> None:
+        """Test failure when tests/config.json is a JSON array instead of an object."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        config_file = tests_dir / "config.json"
+        config_file.write_text(json.dumps([{"api_root": "https://example.com"}]), encoding="utf-8")
+
+        with pytest.raises(NonFatalValidationError, match="must be a JSON object"):
+            self.validator_runner.run(temp_integration)
+
+    def test_no_tests_directory_is_skipped_gracefully(self, temp_integration: pathlib.Path) -> None:
+        """Test that a missing tests/ directory is skipped without raising."""
+        tests_dir = temp_integration / "tests"
+        # Remove the tests directory entirely if it exists
+        if tests_dir.exists():
+            import shutil
+
+            shutil.rmtree(tests_dir)
+
+        # Should not raise — no tests dir is handled gracefully
+        self.validator_runner.run(temp_integration)
+
+    def test_ci_context_with_no_changes_skips(self, temp_integration: pathlib.Path) -> None:
+        """Test that in CI with no changed files the validation is skipped."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        # Deliberately omit config.json — would normally fail
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[],
+            ),
+        ):
+            # No changed files reported — validation is skipped entirely
+            self.validator_runner.run(temp_integration)
+
+    def test_ci_context_with_changes_validates(self, temp_integration: pathlib.Path) -> None:
+        """Test that in CI with changed files the validation runs and can fail."""
+        tests_dir = temp_integration / "tests"
+        tests_dir.mkdir(exist_ok=True)
+        # Deliberately omit config.json — should fail once CI gate is open
+        config_file = tests_dir / "config.json"
+        config_file.unlink(missing_ok=True)
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[temp_integration / "actions" / "ping.py"],
+            ),
+        ):
+            with pytest.raises(NonFatalValidationError, match="missing tests/config.json"):
+                self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_test_config_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_test_config_validation.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -53,7 +54,7 @@ class TestTestConfigValidation:
         config_file = tests_dir / "config.json"
         config_file.unlink(missing_ok=True)
 
-        with pytest.raises(NonFatalValidationError, match="missing tests/config.json"):
+        with pytest.raises(NonFatalValidationError, match=r"missing tests/config\.json"):
             self.validator_runner.run(temp_integration)
 
     def test_failure_on_invalid_json(self, temp_integration: pathlib.Path) -> None:
@@ -81,8 +82,6 @@ class TestTestConfigValidation:
         tests_dir = temp_integration / "tests"
         # Remove the tests directory entirely if it exists
         if tests_dir.exists():
-            import shutil
-
             shutil.rmtree(tests_dir)
 
         # Should not raise — no tests dir is handled gracefully
@@ -117,7 +116,6 @@ class TestTestConfigValidation:
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
                 return_value=[temp_integration / "actions" / "ping.py"],
-            ),
+            ), pytest.raises(NonFatalValidationError, match=r"missing tests/config\.json")
         ):
-            with pytest.raises(NonFatalValidationError, match="missing tests/config.json"):
-                self.validator_runner.run(temp_integration)
+            self.validator_runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_version_consistency_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_version_consistency_validation.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -28,10 +27,6 @@ from mp.core.exceptions import NonFatalValidationError
 from mp.validate.pre_build_validation.integrations.version_consistency_validation import (
     VersionConsistencyValidation,
 )
-
-if TYPE_CHECKING:
-    pass
-
 
 def _write_pyproject_version(integration_path: Path, version: str) -> None:
     """Write a minimal pyproject.toml with the given version."""
@@ -142,7 +137,7 @@ class TestVersionConsistencyValidation:
             mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
             mock.patch(
                 "mp.core.unix.get_files_unmerged_to_main_branch",
-                return_value=["some_file.py"],
+                return_value=[Path("some_file.py")],
             ),
             pytest.raises(NonFatalValidationError, match="doesn't match"),
         ):
@@ -161,3 +156,12 @@ class TestVersionConsistencyValidation:
         rn_path = temp_integration / "release_notes.yaml"
         rn_path.write_text("", encoding="utf-8")
         self.runner.run(temp_integration)  # Should not raise
+
+    def test_pyproject_matches_non_last_entry_fails(self, temp_integration: Path) -> None:
+        """Only the last RN entry is compared; matching an earlier entry is not sufficient."""
+        # pyproject=2.0 matches the middle entry but NOT the last (3.0) — should fail
+        _write_pyproject_version(temp_integration, "2.0")
+        _write_release_notes(temp_integration, ["1.0", "2.0", "3.0"])
+
+        with pytest.raises(NonFatalValidationError, match="doesn't match"):
+            self.runner.run(temp_integration)

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_version_consistency_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_version_consistency_validation.py
@@ -28,6 +28,7 @@ from mp.validate.pre_build_validation.integrations.version_consistency_validatio
     VersionConsistencyValidation,
 )
 
+
 def _write_pyproject_version(integration_path: Path, version: str) -> None:
     """Write a minimal pyproject.toml with the given version."""
     content = {

--- a/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_version_consistency_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_pre_build_validations/test_integrations/test_version_consistency_validation.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the VersionConsistencyValidation class."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+import toml
+import yaml
+
+from mp.core.exceptions import NonFatalValidationError
+from mp.validate.pre_build_validation.integrations.version_consistency_validation import (
+    VersionConsistencyValidation,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+def _write_pyproject_version(integration_path: Path, version: str) -> None:
+    """Write a minimal pyproject.toml with the given version."""
+    content = {
+        "project": {
+            "name": "mock_integration",
+            "version": version,
+            "description": "Mock integration",
+        }
+    }
+    pyproject_path = integration_path / "pyproject.toml"
+    with pyproject_path.open("w") as f:
+        f.write(toml.dumps(content))
+
+
+def _write_release_notes(integration_path: Path, versions: list[str]) -> None:
+    """Write a release_notes.yaml with entries for the given versions."""
+    entries = [
+        {
+            "integration_version": v,
+            "description": f"Release {v}",
+            "publish_time": "2024-01-01",
+            "item_name": "Integration Name",
+            "item_type": "Integration",
+            "new": i == 0,
+            "regressive": False,
+            "deprecated": False,
+            "removed": False,
+            "ticket_number": "TICKET-1",
+        }
+        for i, v in enumerate(versions)
+    ]
+    rn_path = integration_path / "release_notes.yaml"
+    rn_path.write_text(yaml.dump(entries), encoding="utf-8")
+
+
+class TestVersionConsistencyValidation:
+    """Test suite for the VersionConsistencyValidation validator."""
+
+    runner = VersionConsistencyValidation()
+
+    def test_matching_versions_pass(self, temp_integration: Path) -> None:
+        """Test that matching versions in pyproject.toml and release_notes.yaml pass."""
+        _write_pyproject_version(temp_integration, "2.0")
+        _write_release_notes(temp_integration, ["1.0", "2.0"])
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_mismatched_versions_fail(self, temp_integration: Path) -> None:
+        """Test that mismatched versions raise NonFatalValidationError."""
+        _write_pyproject_version(temp_integration, "3.0")
+        _write_release_notes(temp_integration, ["1.0", "2.0"])
+
+        with pytest.raises(NonFatalValidationError, match="doesn't match"):
+            self.runner.run(temp_integration)
+
+    def test_trailing_zero_normalization_passes(self, temp_integration: Path) -> None:
+        """Test that '1.0' in pyproject.toml matches '1' in release_notes.yaml."""
+        _write_pyproject_version(temp_integration, "1.0")
+        _write_release_notes(temp_integration, ["1"])
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_trailing_zero_normalization_reversed_passes(self, temp_integration: Path) -> None:
+        """Test that '1' in pyproject.toml matches '1.0' in release_notes.yaml."""
+        _write_pyproject_version(temp_integration, "1")
+        _write_release_notes(temp_integration, ["1.0"])
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_multiple_trailing_zeros_normalized(self, temp_integration: Path) -> None:
+        """Test that '2.0.0' normalizes correctly to match '2'."""
+        _write_pyproject_version(temp_integration, "2.0.0")
+        _write_release_notes(temp_integration, ["2"])
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_missing_release_notes_skips_gracefully(self, temp_integration: Path) -> None:
+        """Test that a missing release_notes.yaml causes the validator to skip."""
+        _write_pyproject_version(temp_integration, "1.0")
+        rn_path = temp_integration / "release_notes.yaml"
+        rn_path.unlink(missing_ok=True)
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_missing_pyproject_skips_gracefully(self, temp_integration: Path) -> None:
+        """Test that a missing pyproject.toml causes the validator to skip."""
+        _write_release_notes(temp_integration, ["1.0"])
+        pyproject_path = temp_integration / "pyproject.toml"
+        pyproject_path.unlink(missing_ok=True)
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_no_changes_in_ci_skips_validation(self, temp_integration: Path) -> None:
+        """Test that no changed files in CI causes the validator to skip."""
+        _write_pyproject_version(temp_integration, "3.0")
+        _write_release_notes(temp_integration, ["1.0", "2.0"])
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=[],
+            ),
+        ):
+            self.runner.run(temp_integration)  # Should not raise — no changes detected
+
+    def test_mismatched_versions_detected_in_ci(self, temp_integration: Path) -> None:
+        """Test that version mismatch is detected when changes exist in CI."""
+        _write_pyproject_version(temp_integration, "3.0")
+        _write_release_notes(temp_integration, ["1.0", "2.0"])
+
+        with (
+            mock.patch.dict("os.environ", {"GITHUB_PR_SHA": "abc123"}),
+            mock.patch(
+                "mp.core.unix.get_files_unmerged_to_main_branch",
+                return_value=["some_file.py"],
+            ),
+            pytest.raises(NonFatalValidationError, match="doesn't match"),
+        ):
+            self.runner.run(temp_integration)
+
+    def test_latest_release_note_is_used_for_comparison(self, temp_integration: Path) -> None:
+        """Test that only the last entry in release_notes.yaml is compared."""
+        # pyproject has 3.0, the LAST release note entry has 3.0 — should pass
+        _write_pyproject_version(temp_integration, "3.0")
+        _write_release_notes(temp_integration, ["1.0", "2.0", "3.0"])
+        self.runner.run(temp_integration)  # Should not raise
+
+    def test_empty_release_notes_skips_gracefully(self, temp_integration: Path) -> None:
+        """Test that an empty release_notes.yaml causes the validator to skip."""
+        _write_pyproject_version(temp_integration, "1.0")
+        rn_path = temp_integration / "release_notes.yaml"
+        rn_path.write_text("", encoding="utf-8")
+        self.runner.run(temp_integration)  # Should not raise


### PR DESCRIPTION
## Summary

- **Validator bug fix:** `JsonResultExampleValidation` and `ReleaseNotesDateValidation` (added in #671) were incorrectly flagging pre-existing issues in integrations touched by a PR. Both now scope to only the content introduced in the current PR.
- **CI bug fix:** `test.yml` "Find changed integrations" step was injecting `${{ }}` expressions directly into the shell script body, causing a `command not found` failure when `paths-filter` output contained unexpected content (seen in #716). Moved to `env:` variables (safe injection pattern).
- **Tests:** Added 7 test files covering all 5 validators from #671 that had no tests, plus the two fixed validators. 64 new tests total.

## Changes

### `json_result_example_validation.py`
Previously: checked all action `.py` files if *any* file in the integration changed.
Now: only checks action files that appear in the PR diff. Pre-existing actions missing their `_JsonResult_example.json` no longer block unrelated PRs.

### `release_notes_date_validation.py`
Previously: validated every entry in `release_notes.yaml`, including historical ones that predate the `publish_time` requirement.
Now: diffs `release_notes.yaml` against `origin/main` and skips entries that already existed — only newly added entries must have a valid `publish_time`. Also narrows `except Exception` → `except NonFatalCommandError`.

### `.github/workflows/test.yml`
Previously: inline `${{ steps.filter.outputs.* }}` in `run:` block — content from `paths-filter` was injected verbatim into the shell script, causing exit code 127 (`Violation: command not found`) in #716.
Now: expressions moved to `env:` variables; also adds `sed 's/"//g'` to strip quotes from the CSV file list.

### New test files (7)
| File | Tests | Covers |
|------|-------|--------|
| `test_json_result_example_validation.py` | 11 | Changed-file scoping, comment exclusion, new file detection |
| `test_release_notes_date_validation.py` | 11 | Pre-existing skip, new-integration fallback, local vs CI |
| `test_support_email_validation.py` | 7 | Community bypass, partner pass/fail, CI skip |
| `test_version_consistency_validation.py` | 11 | Match/mismatch, trailing `.0` normalization, missing files |
| `test_empty_init_files_validation.py` | 9 | Empty/comments/`__future__` pass, real imports fail |
| `test_test_config_validation.py` | 7 | Valid dict, missing, bad JSON, list, no tests dir |
| `test_ping_message_format_validation.py` | 9 | Correct/missing messages, CI exclusions |

## Test plan

- [x] All 64 new tests pass locally (`uv run pytest tests/ -k "..."`)
- [x] Existing test suite unaffected
- [x] Validator behavior unchanged for local `mp validate` runs (no `GITHUB_PR_SHA`)