### PR TITLE
[Buganizer ID: 505642512]: rename 'integration_version' to 'version' in release notes

### DIFF
--- a/content/playbooks/third_party/community/alert_prioritization/release_notes.yaml
+++ b/content/playbooks/third_party/community/alert_prioritization/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Alert Prioritization
   item_type: Block
   publish_time: '2026-01-22'

--- a/content/playbooks/third_party/community/alert_priority/release_notes.yaml
+++ b/content/playbooks/third_party/community/alert_priority/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Alert Priority
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/amazon_web_services_cloud_platform_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/amazon_web_services_cloud_platform_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Amazon Web Services Cloud Platform Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/aws_ec2_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/aws_ec2_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS EC2 Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/aws_ec2_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/aws_ec2_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS EC2 Enrichment
   item_type: Block
   publish_time: '2026-01-22'

--- a/content/playbooks/third_party/community/aws_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/aws_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/aws_instance_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/aws_instance_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS Instance Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/aws_user_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/aws_user_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS User Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/aws_users_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/aws_users_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS Users Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/azure_ad_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/azure_ad_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Azure AD Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/azure_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/azure_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Azure Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/azure_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/azure_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Azure Enrichment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/azure_user_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/azure_user_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New block
-  integration_version: 1.0
+  version: 1.0
   item_name: Azure User Containment
   item_type: Block
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/clean_case/release_notes.yaml
+++ b/content/playbooks/third_party/community/clean_case/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Block
-  integration_version: 1.0
+  version: 1.0
   item_name: Playbook name
   item_type: Playbook
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/cortex_xdr_remediation_block/release_notes.yaml
+++ b/content/playbooks/third_party/community/cortex_xdr_remediation_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Cortex XDR Remediation Block
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/crowd_strike_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/crowd_strike_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: CrowdStrike Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/crowd_strike_falcon_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/crowd_strike_falcon_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of CrowdStrike Falcon Enrichment playbook for enriching indicators with CrowdStrike Falcon data
-    integration_version: 1.0
+    version: 1.0
     item_name: CrowdStrike Falcon Enrichment
     item_type: Block
     publish_time: '2026-04-22'

--- a/content/playbooks/third_party/community/crowd_strike_falcon_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/crowd_strike_falcon_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: CrowdStrike Falcon Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/crowdstrike_falcon_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/crowdstrike_falcon_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Crowdstrike Falcon Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/duplicate_alert_check/release_notes.yaml
+++ b/content/playbooks/third_party/community/duplicate_alert_check/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Block
-  integration_version: 1.0
+  version: 1.0
   item_name: Playbook name
   item_type: Playbook
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/gcp_compute_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gcp_compute_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GCP Compute Enrichment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/gcp_compute_sa_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gcp_compute_sa_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GCP Compute SA Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/gcp_compute_vm_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gcp_compute_vm_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GCP Compute VM Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/gcp_iam_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gcp_iam_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GCP IAM Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/gcp_instance_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gcp_instance_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GCP Instance Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/gcp_service_account_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gcp_service_account_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GCP Service Account Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_cloud_compute_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_cloud_compute_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Cloud Compute Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_cloud_compute_platform_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_cloud_compute_platform_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Cloud Compute Platform Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/google_cloud_security_command_center_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_cloud_security_command_center_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Cloud Secuirty Command Center Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/google_sec_ops_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_sec_ops_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google SecOps Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_sec_ops_priority/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_sec_ops_priority/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google SecOps Priority
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_sec_ops_siem_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_sec_ops_siem_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google SecOps SIEM Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_threat_intel_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_threat_intel_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Threat Intel Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_workspace_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_workspace_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Workspace Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/google_workspace_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_workspace_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google WorkSpace Enrichment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/google_workspace_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_workspace_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Workspace Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/google_workspace_user_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_workspace_user_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Workspace User Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/google_workspace_user_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/google_workspace_user_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Workspace User Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/gti_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/gti_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: GTI Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/high_risk_entities/release_notes.yaml
+++ b/content/playbooks/third_party/community/high_risk_entities/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: High Risk Entities
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/high_risk_users_check/release_notes.yaml
+++ b/content/playbooks/third_party/community/high_risk_users_check/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: High Risk Users Check
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/mati_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/mati_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Block
-  integration_version: 1.0
+  version: 1.0
   item_name: Mati Enrichment
   item_type: Block
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/microsoft_azure_cloud_platform_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/microsoft_azure_cloud_platform_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Microsoft Azure Cloud Platform Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/microsoft_defender_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/microsoft_defender_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Microsoft Defender Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/microsoft_defender_for_endpoint_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/microsoft_defender_for_endpoint_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Microsoft Defender For Endpoint Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/microsoft_defender_for_endpoint_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/microsoft_defender_for_endpoint_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Microsoft Defender For Endpoint Enrichment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/microsoft_defender_for_endpoint_instances_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/microsoft_defender_for_endpoint_instances_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Microsoft Defender For Endpoint Instances Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/microsoft_defender_for_endpoint_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/microsoft_defender_for_endpoint_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Microsoft Defender for Endpoint Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/mimecast_block_sender/release_notes.yaml
+++ b/content/playbooks/third_party/community/mimecast_block_sender/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Mimecast Block Sender
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/mimecast_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/mimecast_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Mimecast Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/mimecast_investigation/release_notes.yaml
+++ b/content/playbooks/third_party/community/mimecast_investigation/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Mimecast Investigation
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/mimecast_remediation/release_notes.yaml
+++ b/content/playbooks/third_party/community/mimecast_remediation/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Mimecast Remediation
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/mimecast_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/mimecast_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Mimecast Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/mitre/release_notes.yaml
+++ b/content/playbooks/third_party/community/mitre/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: MITRE
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/mitre_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/mitre_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: MITRE Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/okta_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/okta_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Okta Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/okta_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/okta_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Okta Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/okta_remediation_block/release_notes.yaml
+++ b/content/playbooks/third_party/community/okta_remediation_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Okta Remediation Block
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/okta_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/okta_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Okta Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/okta_user_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/okta_user_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Okta User Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/out_of_hours_check/release_notes.yaml
+++ b/content/playbooks/third_party/community/out_of_hours_check/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Block
-  integration_version: 1.0
+  version: 1.0
   item_name: Playbook name
   item_type: Playbook
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/palo_alto_cortex_xdr_isolate_endpoint/release_notes.yaml
+++ b/content/playbooks/third_party/community/palo_alto_cortex_xdr_isolate_endpoint/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Palo Alto Cortex XDR Isolate Endpoint
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/palo_alto_cortex_xdr_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/palo_alto_cortex_xdr_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Palo Alto Cortex XDR Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/proofpoint_campaign_details/release_notes.yaml
+++ b/content/playbooks/third_party/community/proofpoint_campaign_details/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Proofpoint Campaign Details
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/proofpoint_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/proofpoint_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Proofpoint Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/proofpoint_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/proofpoint_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Proofpoint Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/salesforce_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/salesforce_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Salesforce Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/scc_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/scc_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Release description
-  integration_version: 1.0
+  version: 1.0
   item_name: SCC Enrichment
   item_type: Playbook
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/sdl_gti_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/sdl_gti_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Block
-  integration_version: 1.0
+  version: 1.0
   item_name: Playbook name
   item_type: Playbook
   publish_time: '2025-11-06'
@@ -8,7 +8,7 @@
   deprecated: false
   removed: false
 - description: Fix Block Issues
-  integration_version: 2.0
+  version: 2.0
   item_name: Playbook name
   item_type: Playbook
   publish_time: '2026-02-10'

--- a/content/playbooks/third_party/community/sentinel_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/sentinel_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Sentinel Containment
   item_type: Block
   publish_time: '2026-01-27'

--- a/content/playbooks/third_party/community/sentinel_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/sentinel_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Sentinel Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/sentinel_one_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/sentinel_one_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Sentinel One Containment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/sentinel_one_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/sentinel_one_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Sentinel One Enrichment
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/sentinel_one_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/sentinel_one_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: SentinelOne Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/set_initial_severity/release_notes.yaml
+++ b/content/playbooks/third_party/community/set_initial_severity/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Set Initial Severity
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/symantec_endpoint_protection_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/symantec_endpoint_protection_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Symantec Endpoint Protection Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/symantec_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/symantec_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Symantec Enrichment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/symantec_enrichment_and_investigation/release_notes.yaml
+++ b/content/playbooks/third_party/community/symantec_enrichment_and_investigation/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Symantec Enrichment and Investigation
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/symantec_remediation/release_notes.yaml
+++ b/content/playbooks/third_party/community/symantec_remediation/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Symantec Remediation
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/tag_case_with_time_span/release_notes.yaml
+++ b/content/playbooks/third_party/community/tag_case_with_time_span/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Block
-  integration_version: 1.0
+  version: 1.0
   item_name: Playbook name
   item_type: Playbook
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/vt_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/community/vt_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New block for playbook
-  integration_version: 1.0
+  version: 1.0
   item_name: VT Enrichment
   item_type: Block
   publish_time: '2025-11-06'

--- a/content/playbooks/third_party/community/zscaler_containment/release_notes.yaml
+++ b/content/playbooks/third_party/community/zscaler_containment/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Standalone Block for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Zscaler Containment
   item_type: Block
   publish_time: '2026-01-23'

--- a/content/playbooks/third_party/community/zscaler_containment_block/release_notes.yaml
+++ b/content/playbooks/third_party/community/zscaler_containment_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Zscaler Containment Block
   item_type: block
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/community/zscaler_starting_playbook/release_notes.yaml
+++ b/content/playbooks/third_party/community/zscaler_starting_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Playbook for Content Hub
-  integration_version: 1.0
+  version: 1.0
   item_name: Zscaler Starting Playbook
   item_type: Playbook
   publish_time: '2026-01-26'

--- a/content/playbooks/third_party/partner/censys_entity_enrichment/release_notes.yaml
+++ b/content/playbooks/third_party/partner/censys_entity_enrichment/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Censys Entity Enrichment playbook for automated threat intelligence and asset discovery
-    integration_version: 1.0
+    version: 1.0
     item_name: Censys - Entity Enrichment
     item_type: Playbook
     publish_time: '2025-11-06'

--- a/content/playbooks/third_party/partner/censys_host_history/release_notes.yaml
+++ b/content/playbooks/third_party/partner/censys_host_history/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Censys Host History playbook for retrieving historical host data and timeline events
-    integration_version: 1.0
+    version: 1.0
     item_name: Censys - Host History
     item_type: Playbook
     publish_time: '2025-11-06'
@@ -8,7 +8,7 @@
     deprecated: false
     removed: false
 -   description: Updated playbook definition with improved description and metadata
-    integration_version: 2.0
+    version: 2.0
     item_name: Censys - Host History
     item_type: Playbook
     publish_time: '2026-04-14'

--- a/content/playbooks/third_party/partner/censys_related_infrastructure/release_notes.yaml
+++ b/content/playbooks/third_party/partner/censys_related_infrastructure/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: "Initial release of the Censys Related Infrastructure playbook, powered by the CensEye API. This release enables security teams to map adversary networks by identifying shared traits among internet-facing assets — pivoting from a single IOC to uncover the full scope of a threat actor's infrastructure. For more details, see the Censys documentation: https://docs.censys.com/docs/platform-threat-hunting-use-censeye-to-build-detections"
-    integration_version: 1.0
+    version: 1.0
     item_name: Censys - Related Infrastructure
     item_type: Playbook
     publish_time: '2026-04-09'

--- a/content/playbooks/third_party/partner/censys_rescan/release_notes.yaml
+++ b/content/playbooks/third_party/partner/censys_rescan/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Censys Rescan playbook for initiating and tracking asset rescans
-    integration_version: 1.0
+    version: 1.0
     item_name: Censys - Rescan
     item_type: Playbook
     publish_time: '2025-11-06'
@@ -8,7 +8,7 @@
     deprecated: false
     removed: false
 -   description: Updated playbook definition with improved description and metadata
-    integration_version: 2.0
+    version: 2.0
     item_name: Censys - Rescan
     item_type: Playbook
     publish_time: '2026-04-14'

--- a/content/playbooks/third_party/partner/cyware_intel_exchange_add_remove_ioc_from_allowed_list/release_notes.yaml
+++ b/content/playbooks/third_party/partner/cyware_intel_exchange_add_remove_ioc_from_allowed_list/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Add-Remove IOC from Allowed List playbook for managing IOCs based on confidence scores in Cyware Intel Exchange
-    integration_version: 1.0
+    version: 1.0
     item_name: Cyware Intel Exchange - Add-Remove IOC from Allowed List
     item_type: Playbook
     publish_time: '2025-11-06'

--- a/content/playbooks/third_party/partner/cyware_intel_exchange_add_remove_ioc_from_allowed_list_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/cyware_intel_exchange_add_remove_ioc_from_allowed_list_block/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Add-Remove IOC from Allowed List Block for embedded workflow functionality in Cyware Intel Exchange
-    integration_version: 1.0
+    version: 1.0
     item_name: Cyware Intel Exchange - Add-Remove IOC from Allowed List Block
     item_type: Block
     publish_time: '2026-03-03'

--- a/content/playbooks/third_party/partner/cyware_intel_exchange_create_iocs_on_cyware_intel_exchange/release_notes.yaml
+++ b/content/playbooks/third_party/partner/cyware_intel_exchange_create_iocs_on_cyware_intel_exchange/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Create IOCs playbook for automatically creating IOCs associated with cases on Cyware Intel Exchange
-    integration_version: 1.0
+    version: 1.0
     item_name: Cyware Intel Exchange - Create IOCs on Cyware Intel Exchange
     item_type: Playbook
     publish_time: '2026-03-03'

--- a/content/playbooks/third_party/partner/cyware_intel_exchange_dynamic_tags_classification_on_iocs/release_notes.yaml
+++ b/content/playbooks/third_party/partner/cyware_intel_exchange_dynamic_tags_classification_on_iocs/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Dynamic Tags Classification playbook for adding tags to IOCs based on confidence scores in Cyware Intel Exchange
-  integration_version: 1.0
+  version: 1.0
   item_name: Cyware Intel Exchange - Dynamic Tags Classification on IOCs
   item_type: Playbook
   publish_time: '2026-03-03'

--- a/content/playbooks/third_party/partner/cyware_intel_exchange_manual_ioc_jira_issue_creation/release_notes.yaml
+++ b/content/playbooks/third_party/partner/cyware_intel_exchange_manual_ioc_jira_issue_creation/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Manual IOC JIRA Issue Creation playbook for creating JIRA tickets for IOCs requiring manual review in Cyware Intel Exchange
-  integration_version: 1.0
+  version: 1.0
   item_name: Cyware Intel Exchange - Manual IOC - JIRA Issue Creation
   item_type: Playbook
   publish_time: '2026-03-03'

--- a/content/playbooks/third_party/partner/cyware_intel_exchange_manual_ioc_jira_issue_creation_input_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/cyware_intel_exchange_manual_ioc_jira_issue_creation_input_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Manual IOC JIRA Issue Creation Input Block for fetching IOC fields as input for JIRA ticket creation in Cyware Intel Exchange
-  integration_version: 1.0
+  version: 1.0
   item_name: Cyware Intel Exchange - Manual IOC - JIRA Issue Creation Input Block
   item_type: Block
   publish_time: '2026-03-03'

--- a/content/playbooks/third_party/partner/grey_noise_cve_based_network_containment_orchestrator/release_notes.yaml
+++ b/content/playbooks/third_party/partner/grey_noise_cve_based_network_containment_orchestrator/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of CVE-Based Network Containment Orchestrator playbook that automates network containment by querying GreyNoise for malicious IPs associated with CVEs and triggering containment actions
-    integration_version: 1.0
+    version: 1.0
     item_name: GreyNoise - CVE-Based Network Containment Orchestrator
     item_type: Playbook
     publish_time: '2026-03-06'

--- a/content/playbooks/third_party/partner/grey_noise_dynamic_case_naming_from_webhook/release_notes.yaml
+++ b/content/playbooks/third_party/partner/grey_noise_dynamic_case_naming_from_webhook/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Dynamic Case Naming from Webhook playbook that dynamically renames cases based on GreyNoise webhook data and optionally attaches additional playbooks for automated response
-    integration_version: 1.0
+    version: 1.0
     item_name: GreyNoise - Dynamic Case Naming from Webhook
     item_type: Playbook
     publish_time: '2026-03-06'

--- a/content/playbooks/third_party/partner/grey_noise_network_containment_based_on_grey_noise_ip_feed/release_notes.yaml
+++ b/content/playbooks/third_party/partner/grey_noise_network_containment_based_on_grey_noise_ip_feed/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Network Containment Based on GreyNoise IP Feed playbook that automates blocking/unblocking of IPs via Zscaler based on real-time threat intelligence from GreyNoise IP feed
-    integration_version: 1.0
+    version: 1.0
     item_name: GreyNoise - Network Containment Based on GreyNoise IP Feed
     item_type: Playbook
     publish_time: '2026-03-06'

--- a/content/playbooks/third_party/partner/grey_noise_network_containment_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/grey_noise_network_containment_block/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Network Containment Block that queries GreyNoise using CVE identifiers, extracts malicious IPs, creates entities in alerts, and blocks them via Zscaler
-    integration_version: 1.0
+    version: 1.0
     item_name: GreyNoise - Network Containment Block
     item_type: Block
     publish_time: '2026-03-06'

--- a/content/playbooks/third_party/partner/grey_noise_noise_elimination/release_notes.yaml
+++ b/content/playbooks/third_party/partner/grey_noise_noise_elimination/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Initial release of Noise Elimination playbook that enriches IP entities with GreyNoise threat intelligence and adjusts alert priority based on IP classification
-    integration_version: 1.0
+    version: 1.0
     item_name: GreyNoise - Noise Elimination
     item_type: Playbook
     publish_time: '2026-03-06'

--- a/content/playbooks/third_party/partner/rubrik_advanced_ioc_scan/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_advanced_ioc_scan/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Advanced IOC Scan playbook for threat hunting in backup data
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Advanced IOC Scan
   item_type: Playbook
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_advanced_ioc_scan_input_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_advanced_ioc_scan_input_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Advanced IOC Scan Input Block for collecting scan parameters
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Advanced IOC Scan Input Block
   item_type: Block
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_anomaly_analysis/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_anomaly_analysis/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Anomaly Analysis playbook for detecting ransomware and anomalies in backup data
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Anomaly Analysis
   item_type: Playbook
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_anomaly_analysis_input_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_anomaly_analysis_input_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Anomaly Analysis Input Block for collecting analysis parameters
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Anomaly Analysis Input Block
   item_type: Block
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_file_context_analysis/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_file_context_analysis/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik File Context Analysis playbook for investigating file access and modifications using Sonar
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik File Context Analysis
   item_type: Playbook
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_file_context_analysis_input_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_file_context_analysis_input_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik File Context Analysis Input Block for collecting file investigation parameters
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik File Context Analysis Input Block
   item_type: Block
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_sensitive_data_information_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_sensitive_data_information_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Sensitive Data Information Block for retrieving sensitive data hits from Sonar
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Sensitive Data Information Block
   item_type: Block
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_turbo_ioc_scan/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_turbo_ioc_scan/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Turbo IOC Scan playbook for fast threat detection in backup snapshots
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Turbo IOC Scan
   item_type: Playbook
   publish_time: '2026-01-29'

--- a/content/playbooks/third_party/partner/rubrik_turbo_ioc_scan_input_block/release_notes.yaml
+++ b/content/playbooks/third_party/partner/rubrik_turbo_ioc_scan_input_block/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Rubrik Turbo IOC Scan Input Block for collecting turbo scan parameters
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Turbo IOC Scan Input Block
   item_type: Block
   publish_time: '2026-01-29'

--- a/content/response_integrations/google/cisco_orbital/release_notes.yaml
+++ b/content/response_integrations/google/cisco_orbital/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: NEW! Cisco Orbital integration
-    integration_version: 1.0
+    version: 1.0
     item_name: CiscoOrbital
     item_type: Integration
     publish_time: '2020-11-17'
@@ -24,7 +24,7 @@
     removed: false
 -   description: Fixed a bug, where action "Execute Query" was not working correctly,
         due to Cisco Orbital's API changes.
-    integration_version: 2.0
+    version: 2.0
     item_name: Execute Query
     item_type: Action
     publish_time: '2021-06-15'
@@ -34,7 +34,7 @@
     deprecated: false
     removed: false
 -   description: Updated the integration's logo.
-    integration_version: 3.0
+    version: 3.0
     item_name: CiscoOrbital
     item_type: Integration
     publish_time: '2021-08-18'
@@ -44,7 +44,7 @@
     deprecated: false
     removed: false
 -   description: Execute Query - Updated action's timeout flow.
-    integration_version: 4.0
+    version: 4.0
     item_name: Execute Query
     item_type: Action
     publish_time: '2021-09-01'
@@ -55,7 +55,7 @@
     removed: false
 -   description: Cisco Orbital - Integration updates, added ability to configure API
         Root as part of the integration configuration.
-    integration_version: 5.0
+    version: 5.0
     item_name: CiscoOrbital
     item_type: Integration
     publish_time: '2024-08-29'
@@ -67,7 +67,7 @@
 -   description: 'Cisco Orbital integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: CiscoOrbital
     item_type: Integration
     publish_time: '2024-08-29'
@@ -77,7 +77,7 @@
     deprecated: false
     removed: false
 -   description: Execute Query - Added Predefined Widget.
-    integration_version: 6.0
+    version: 6.0
     item_name: Execute Query
     item_type: Widget
     publish_time: '2024-11-27'
@@ -87,7 +87,7 @@
     deprecated: false
     removed: false
 -   description: Execute Query - Updated Predefined Widget.
-    integration_version: 7.0
+    version: 7.0
     item_name: Execute Query
     item_type: Widget
     publish_time: '2026-03-12'
@@ -97,7 +97,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 8.0
+    version: 8.0
     item_name: CiscoOrbital
     item_type: Integration
     publish_time: '2025-10-29'
@@ -109,7 +109,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 9.0
+  version: 9.0
   item_name: CiscoOrbital
   item_type: Integration
   publish_time: '2026-04-21'

--- a/content/response_integrations/google/cyber_x/release_notes.yaml
+++ b/content/response_integrations/google/cyber_x/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 2.0
+    version: 2.0
     item_name: CyberX
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: Fixed a bug where the integration's SVG logo file was causing unexpected
         behaviors in specific cases.
-    integration_version: 3.0
+    version: 3.0
     item_name: CyberX
     item_type: Integration
     publish_time: '2021-04-07'
@@ -37,7 +37,7 @@
 -   description: 'CyberX integration - Important - Updated the integration code to
         work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 4.0
+    version: 4.0
     item_name: CyberX
     item_type: Integration
     publish_time: '2024-07-14'
@@ -47,7 +47,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 5.0
+    version: 5.0
     item_name: CyberX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -59,7 +59,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 6.0
+  version: 6.0
   item_name: CyberX
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/f5_big_iq/release_notes.yaml
+++ b/content/response_integrations/google/f5_big_iq/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 3.0
+    version: 3.0
     item_name: F5BigIQ
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: New Parameter Added - "Verify SSL", allowing users to enable TLS
         validation when using the integration
-    integration_version: 4.0
+    version: 4.0
     item_name: F5BigIQ
     item_type: Integration
     publish_time: '2021-11-10'
@@ -37,7 +37,7 @@
 -   description: 'F5 Big IQ integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: F5BigIQ
     item_type: Integration
     publish_time: '2024-07-14'
@@ -48,7 +48,7 @@
     removed: false
 -   description: Integration - Updated integration action definitions to meet the
         new requirements of IDE.
-    integration_version: 6.0
+    version: 6.0
     item_name: F5BigIQ
     item_type: Integration
     publish_time: '2025-10-29'
@@ -58,7 +58,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 7.0
+    version: 7.0
     item_name: F5BigIQ
     item_type: Integration
     publish_time: '2025-10-29'
@@ -70,7 +70,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 8.0
+  version: 8.0
   item_name: F5BigIQ
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/fire_eye_ex/release_notes.yaml
+++ b/content/response_integrations/google/fire_eye_ex/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: FireEye EX integration
-    integration_version: 1.0
+    version: 1.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2020-06-18'
@@ -25,7 +25,7 @@
 -   description: Added new parameter to actions "Download Alert Artifacts" and "Download
         Quarantined Email", which allow users to define the download path, where the
         action should save the files.
-    integration_version: 2.0
+    version: 2.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2020-10-06'
@@ -36,7 +36,7 @@
     removed: false
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 3.0
+    version: 3.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2020-11-04'
@@ -47,7 +47,7 @@
     removed: false
 -   description: Fixed a bug where the integration's SVG logo file was causing unexpected
         behaviors in specific cases.
-    integration_version: 4.0
+    version: 4.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2021-04-07'
@@ -57,7 +57,7 @@
     deprecated: false
     removed: false
 -   description: Updated the integration's logo.
-    integration_version: 5.0
+    version: 5.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2021-08-18'
@@ -67,7 +67,7 @@
     deprecated: false
     removed: false
 -   description: Security enhancements throughout the integration
-    integration_version: 6.0
+    version: 6.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2021-11-10'
@@ -77,7 +77,7 @@
     deprecated: false
     removed: false
 -   description: Updated Integration's dependencies.
-    integration_version: 7.0
+    version: 7.0
     item_name: FireEye EX
     item_type: Integration
     publish_time: '2022-08-03'
@@ -89,7 +89,7 @@
 -   description: 'Alerts Connector - Updated connector to better support Siemplify''s
         SAAS deployment. Important - Before updating, please make sure to read our
         white paper for stateless connectors here: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/stateless-connectors-white-paper.'
-    integration_version: 8.0
+    version: 8.0
     item_name: FireEyeEXAlertsConnector
     item_type: Connector
     publish_time: '2022-11-09'
@@ -101,7 +101,7 @@
 -   description: 'FireEye EX integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 9.0
+    version: 9.0
     item_name: FireEyeEX
     item_type: Integration
     publish_time: '2024-07-14'
@@ -112,7 +112,7 @@
     removed: false
 -   description: FireEye EX - Alerts Connector  - Improved description for 'Fetch
         Max Hours Backwards' parameter.
-    integration_version: 10.0
+    version: 10.0
     item_name: FireEye EX - Alerts Connector
     item_type: Connector
     publish_time: '2024-08-08'
@@ -123,7 +123,7 @@
     removed: false
 -   description: Download Alert Artifacts, List Quarantined Emails, Download Quarantined
         Email - Added Predefined Widgets.
-    integration_version: 11.0
+    version: 11.0
     item_name: Download Alert Artifacts, List Quarantined Emails, Download Quarantined
         Email
     item_type: Widget
@@ -135,7 +135,7 @@
     removed: false
 -   description: List Quarantined Emails, Download Quarantined Email, Download Alert
         Artifacts - Updated Predefined Widgets.
-    integration_version: 12.0
+    version: 12.0
     item_name: List Quarantined Emails, Download Quarantined Email, Download Alert
         Artifacts
     item_type: Widget
@@ -146,7 +146,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 13.0
+    version: 13.0
     item_name: FireEyeEX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -158,7 +158,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 14.0
+  version: 14.0
   item_name: FireEyeEX
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/hcl_big_fix_inventory/release_notes.yaml
+++ b/content/response_integrations/google/hcl_big_fix_inventory/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: New Integration Added - HCL BigFix Inventory.
-    integration_version: 1.0
+    version: 1.0
     item_name: HCLBigFixInventory
     item_type: Integration
     publish_time: '2022-07-13'
@@ -25,7 +25,7 @@
 -   description: 'HCL BigFix Inventory integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 2.0
+    version: 2.0
     item_name: HCLBigFixInventory
     item_type: Integration
     publish_time: '2024-08-21'
@@ -35,7 +35,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities - Added Predefined Widget.
-    integration_version: 3.0
+    version: 3.0
     item_name: Enrich Entities
     item_type: Widget
     publish_time: '2024-11-05'
@@ -45,7 +45,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 4.0
+    version: 4.0
     item_name: HCLBigFixInventory
     item_type: Integration
     publish_time: '2025-10-29'
@@ -55,7 +55,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities - Updated Predefined Widget.
-    integration_version: 5.0
+    version: 5.0
     item_name: Enrich Entities
     item_type: Widget
     publish_time: '2026-03-27'
@@ -67,7 +67,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 6.0
+  version: 6.0
   item_name: HCLBigFixInventory
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/illusive_networks/release_notes.yaml
+++ b/content/response_integrations/google/illusive_networks/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: New integration "Illusive Networks".
-    integration_version: 1.0
+    version: 1.0
     item_name: IllusiveNetworks
     item_type: Integration
     publish_time: '2021-03-24'
@@ -24,7 +24,7 @@
     removed: false
 -   description: Illusive Networks - Incidents Connector - Improved description for
         'Max Hours Backwards' parameter.
-    integration_version: 2.0
+    version: 2.0
     item_name: IllusiveNetworks
     item_type: Connector
     publish_time: '2024-08-08'
@@ -36,7 +36,7 @@
 -   description: 'Illusive Networks integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 3.0
+    version: 3.0
     item_name: IllusiveNetworks
     item_type: Integration
     publish_time: '2024-09-19'
@@ -46,7 +46,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities, Run Forensic Scan - Added Predefined Widgets.
-    integration_version: 4.0
+    version: 4.0
     item_name: Enrich Entities, Run Forensic Scan
     item_type: Widget
     publish_time: '2024-11-05'
@@ -56,7 +56,7 @@
     deprecated: false
     removed: false
 -   description: List Deceptive Items - Added Predefined Widget.
-    integration_version: 4.0
+    version: 4.0
     item_name: List Deceptive Items
     item_type: Widget
     publish_time: '2024-11-05'
@@ -66,7 +66,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 5.0
+    version: 5.0
     item_name: IllusiveNetworks
     item_type: Integration
     publish_time: '2025-10-29'
@@ -76,7 +76,7 @@
     deprecated: false
     removed: false
 -   description: List Deceptive Items - Updated Predefined Widget.
-    integration_version: 6.0
+    version: 6.0
     item_name: List Deceptive Items
     item_type: Widget
     publish_time: '2026-03-20'
@@ -86,7 +86,7 @@
     deprecated: false
     removed: false
 -   description: Run Forensic Scan, Enrich Entities - Updated Predefined Widgets.
-    integration_version: 7.0
+    version: 7.0
     item_name: Run Forensic Scan, Enrich Entities
     item_type: Widget
     publish_time: '2026-03-27'
@@ -98,7 +98,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 8.0
+  version: 8.0
   item_name: IllusiveNetworks
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/juniper_vsrx/release_notes.yaml
+++ b/content/response_integrations/google/juniper_vsrx/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 2.0
+    version: 2.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 3.0
+    version: 3.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2021-04-07'
@@ -35,7 +35,7 @@
     deprecated: false
     removed: false
 -   description: JuniperVSRX - Security Enhancements.
-    integration_version: 4.0
+    version: 4.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2022-09-21'
@@ -45,7 +45,7 @@
     deprecated: false
     removed: false
 -   description: JuniperVSRX - Security Enhancements.
-    integration_version: 5.0
+    version: 5.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2023-10-11'
@@ -57,7 +57,7 @@
 -   description: 'JuniperVSRX integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 6.0
+    version: 6.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2024-07-14'
@@ -67,7 +67,7 @@
     deprecated: false
     removed: false
 -   description: Updated the integration's dependencies.
-    integration_version: 7.0
+    version: 7.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2024-07-25'
@@ -78,7 +78,7 @@
     removed: false
 -   description: Integration - Updated integration action definitions to meet the
         new requirements of IDE.
-    integration_version: 8.0
+    version: 8.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -88,7 +88,7 @@
     deprecated: false
     removed: false
 -   description: Integration - Updated Dependencies.
-    integration_version: 9.0
+    version: 9.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -98,7 +98,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 10.0
+    version: 10.0
     item_name: JuniperVSRX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -110,7 +110,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 11.0
+  version: 11.0
   item_name: JuniperVSRX
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/lastline/release_notes.yaml
+++ b/content/response_integrations/google/lastline/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: New Lastline integration added.
-    integration_version: 1.0
+    version: 1.0
     item_name: Lastline
     item_type: Integration
     publish_time: '2021-04-07'
@@ -23,7 +23,7 @@
     deprecated: false
     removed: false
 -   description: Updated the "Verify SSL" logic of the integration.
-    integration_version: 2.0
+    version: 2.0
     item_name: Lastline
     item_type: Integration
     publish_time: '2021-09-01'
@@ -33,7 +33,7 @@
     deprecated: false
     removed: false
 -   description: Updated Integration's dependencies.
-    integration_version: 3.0
+    version: 3.0
     item_name: Lastline
     item_type: Integration
     publish_time: '2022-08-03'
@@ -43,7 +43,7 @@
     deprecated: false
     removed: false
 -   description: Security Enhancements.
-    integration_version: 4.0
+    version: 4.0
     item_name: Lastline
     item_type: Integration
     publish_time: '2023-04-27'
@@ -55,7 +55,7 @@
 -   description: 'Lastline integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: Lastline
     item_type: Integration
     publish_time: '2024-08-21'
@@ -65,7 +65,7 @@
     deprecated: false
     removed: false
 -   description: Get Analysis Results - Added Predefined Widget.
-    integration_version: 6.0
+    version: 6.0
     item_name: Get Analysis Results
     item_type: Widget
     publish_time: '2024-11-05'
@@ -76,7 +76,7 @@
     removed: false
 -   description: Search Analysis History, Submit File, Submit URL - Added Predefined
         Widgets.
-    integration_version: 6.0
+    version: 6.0
     item_name: Search Analysis History, Submit File, Submit URL
     item_type: Widget
     publish_time: '2024-11-05'
@@ -86,7 +86,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 7.0
+    version: 7.0
     item_name: Lastline
     item_type: Integration
     publish_time: '2025-10-29'
@@ -97,7 +97,7 @@
     removed: false
 -   description: Search Analysis History, Submit URL, Submit File - Updated Predefined
         Widgets.
-    integration_version: 8.0
+    version: 8.0
     item_name: Search Analysis History, Submit URL, Submit File
     item_type: Widget
     publish_time: '2026-03-20'
@@ -107,7 +107,7 @@
     deprecated: false
     removed: false
 -   description: Get Analysis Results - Updated Predefined Widget.
-    integration_version: 9.0
+    version: 9.0
     item_name: Get Analysis Results
     item_type: Widget
     publish_time: '2026-03-27'
@@ -119,7 +119,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 10.0
+  version: 10.0
   item_name: Lastline
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/mc_afee_active_response/release_notes.yaml
+++ b/content/response_integrations/google/mc_afee_active_response/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: Added action result as json + csv output
-    integration_version: 2.0
+    version: 2.0
     item_name: Search
     item_type: Action
     ticket_number: TIPG-245
@@ -22,7 +22,7 @@
     deprecated: false
     removed: false
 -   description: Added missing Linux dependency.
-    integration_version: 3.0
+    version: 3.0
     item_name: McAfee Active Response
     item_type: Integration
     publish_time: '2019-11-04'
@@ -33,7 +33,7 @@
     removed: false
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 4.0
+    version: 4.0
     item_name: McAfee Active Response
     item_type: Integration
     publish_time: '2020-11-04'
@@ -44,7 +44,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 5.0
+    version: 5.0
     item_name: McAfee Active Response
     item_type: Integration
     publish_time: '2021-04-07'
@@ -54,7 +54,7 @@
     deprecated: false
     removed: false
 -   description: Security Enhancements.
-    integration_version: 6.0
+    version: 6.0
     item_name: McAfee Active Response
     item_type: Integration
     publish_time: '2023-04-27'
@@ -66,7 +66,7 @@
 -   description: 'McAfee Active Response integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 7.0
+    version: 7.0
     item_name: McAfeeActiveResponse
     item_type: Integration
     publish_time: '2024-07-14'
@@ -76,7 +76,7 @@
     deprecated: false
     removed: false
 -   description: Integration - Updated Dependencies.
-    integration_version: 8.0
+    version: 8.0
     item_name: McAfeeActiveResponse
     item_type: Integration
     publish_time: '2024-07-14'
@@ -86,7 +86,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 9.0
+    version: 9.0
     item_name: McAfeeActiveResponse
     item_type: Integration
     publish_time: '2025-10-29'
@@ -98,7 +98,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 10.0
+  version: 10.0
   item_name: McAfeeActiveResponse
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/mc_afee_atd/release_notes.yaml
+++ b/content/response_integrations/google/mc_afee_atd/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: Added support for Threshold parameter for marking URLs as suspicious.
-    integration_version: 4.0
+    version: 4.0
     item_name: Submit URL
     item_type: Action
     ticket_number: TIPG-332
@@ -22,7 +22,7 @@
     deprecated: false
     removed: false
 -   description: Fixed McAfee ATD Get Analayzer Profiles action
-    integration_version: 4.0
+    version: 4.0
     item_name: McAfee ATD Get Analyzer Profile Action
     item_type: Action
     ticket_number: TIPG-1155
@@ -31,7 +31,7 @@
     deprecated: false
     removed: false
 -   description: Added support for binary files submission.
-    integration_version: 5.0
+    version: 5.0
     item_name: Submit File
     item_type: Action
     publish_time: '2020-06-15'
@@ -42,7 +42,7 @@
     removed: false
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 6.0
+    version: 6.0
     item_name: McAfee ATD
     item_type: Integration
     publish_time: '2020-11-04'
@@ -52,7 +52,7 @@
     deprecated: false
     removed: false
 -   description: Get Report, Submit URL - Added optional insight.
-    integration_version: 7.0
+    version: 7.0
     item_name: McAfee ATD
     item_type: Integration
     publish_time: '2021-09-08'
@@ -62,7 +62,7 @@
     deprecated: false
     removed: false
 -   description: Updated the integration's code to work with Python version 3.
-    integration_version: 7.0
+    version: 7.0
     item_name: McAfee ATD
     item_type: Integration
     publish_time: '2021-09-08'
@@ -72,7 +72,7 @@
     deprecated: false
     removed: false
 -   description: Submit URL - Action updated.
-    integration_version: 8.0
+    version: 8.0
     item_name: Submit URL
     item_type: Action
     publish_time: '2022-02-02'
@@ -82,7 +82,7 @@
     deprecated: false
     removed: false
 -   description: Submit URL - Updated the logic of the action.
-    integration_version: 9.0
+    version: 9.0
     item_name: Submit URL
     item_type: Action
     publish_time: '2022-07-06'
@@ -92,7 +92,7 @@
     deprecated: false
     removed: false
 -   description: Updated Integration's dependencies.
-    integration_version: 10.0
+    version: 10.0
     item_name: McAfee ATD
     item_type: Integration
     publish_time: '2022-08-03'
@@ -104,7 +104,7 @@
 -   description: 'McAfee ATD integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions.'
-    integration_version: 11.0
+    version: 11.0
     item_name: McAfeeATD
     item_type: Integration
     publish_time: '2024-08-29'
@@ -114,7 +114,7 @@
     deprecated: false
     removed: false
 -   description: Submit URL - Added Predefined Widget.
-    integration_version: 12.0
+    version: 12.0
     item_name: Submit URL
     item_type: Widget
     publish_time: '2024-11-05'
@@ -124,7 +124,7 @@
     deprecated: false
     removed: false
 -   description: Get Report, Submit File - Added Predefined Widgets.
-    integration_version: 12.0
+    version: 12.0
     item_name: Get Report, Submit File
     item_type: Widget
     publish_time: '2024-11-05'
@@ -134,7 +134,7 @@
     deprecated: false
     removed: false
 -   description: Get Analyzer Profiles - Added Predefined Widget.
-    integration_version: 13.0
+    version: 13.0
     item_name: Get Analyzer Profiles
     item_type: Widget
     publish_time: '2024-11-27'
@@ -144,7 +144,7 @@
     deprecated: false
     removed: false
 -   description: Get Analyzer Profiles - Updated Predefined Widget.
-    integration_version: 14.0
+    version: 14.0
     item_name: Get Analyzer Profiles
     item_type: Widget
     publish_time: '2026-03-12'
@@ -154,7 +154,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 15.0
+    version: 15.0
     item_name: McAfeeATD
     item_type: Integration
     publish_time: '2025-10-29'
@@ -164,7 +164,7 @@
     deprecated: false
     removed: false
 -   description: Get Report, Submit File - Updated Predefined Widgets.
-    integration_version: 16.0
+    version: 16.0
     item_name: Get Report, Submit File
     item_type: Widget
     publish_time: '2026-03-20'
@@ -174,7 +174,7 @@
     deprecated: false
     removed: false
 -   description: Check Hash - Added Predefined Widget.
-    integration_version: 17.0
+    version: 17.0
     item_name: Check Hash
     item_type: Widget
     publish_time: '2026-03-27'
@@ -184,7 +184,7 @@
     deprecated: false
     removed: false
 -   description: Submit URL - Updated Predefined Widget.
-    integration_version: 17.0
+    version: 17.0
     item_name: Submit URL
     item_type: Widget
     publish_time: '2026-03-27'
@@ -196,7 +196,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 18.0
+  version: 18.0
   item_name: McAfeeATD
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/mc_afee_nsm/release_notes.yaml
+++ b/content/response_integrations/google/mc_afee_nsm/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 5.0
+    version: 5.0
     item_name: McAfee NSM
     item_type: Integration
     publish_time: '2020-11-04'
@@ -26,7 +26,7 @@
 -   description: 'McAfeeNSM integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 6.0
+    version: 6.0
     item_name: McAfeeNSM
     item_type: Integration
     publish_time: '2024-07-14'
@@ -36,7 +36,7 @@
     deprecated: false
     removed: false
 -   description: Get Alert Info Data - Added Predefined Widget.
-    integration_version: 7.0
+    version: 7.0
     item_name: Get Alert Info Data
     item_type: Widget
     publish_time: '2024-11-05'
@@ -47,7 +47,7 @@
     removed: false
 -   description: Integration - Updated integration action definitions to meet the
         new requirements of IDE.
-    integration_version: 8.0
+    version: 8.0
     item_name: McAfeeNSM
     item_type: Integration
     publish_time: '2025-10-29'
@@ -57,7 +57,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 9.0
+    version: 9.0
     item_name: McAfeeNSM
     item_type: Integration
     publish_time: '2025-10-29'
@@ -67,7 +67,7 @@
     deprecated: false
     removed: false
 -   description: Get Alert Info Data - Updated Predefined Widget.
-    integration_version: 10.0
+    version: 10.0
     item_name: Get Alert Info Data
     item_type: Widget
     publish_time: '2026-03-20'
@@ -79,7 +79,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 11.0
+  version: 11.0
   item_name: McAfeeNSM
   item_type: Integration
   publish_time: '2026-03-24'

--- a/content/response_integrations/google/micro_focus_itsma/release_notes.yaml
+++ b/content/response_integrations/google/micro_focus_itsma/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 2.0
+    version: 2.0
     item_name: MicroFocusTSMA
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 3.0
+    version: 3.0
     item_name: MicroFocusTSMA
     item_type: Integration
     publish_time: '2021-04-07'
@@ -35,7 +35,7 @@
     deprecated: false
     removed: false
 -   description: Updated the integration's logo.
-    integration_version: 4.0
+    version: 4.0
     item_name: MicroFocusTSMA
     item_type: Integration
     publish_time: '2021-08-18'
@@ -47,7 +47,7 @@
 -   description: 'Micro Focus ITSMA integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: MicroFocusITSMA
     item_type: Integration
     publish_time: '2024-07-14'
@@ -57,7 +57,7 @@
     deprecated: false
     removed: false
 -   description: "Updated integration metadata"
-    integration_version: 6.0
+    version: 6.0
     item_name: MicroFocusITSMA
     item_type: Integration
     publish_time: '2025-10-29'
@@ -69,7 +69,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 7.0
+  version: 7.0
   item_name: MicroFocusITSMA
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/mobile_iron/release_notes.yaml
+++ b/content/response_integrations/google/mobile_iron/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 2.0
+    version: 2.0
     item_name: MobileIron
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 3.0
+    version: 3.0
     item_name: MobileIron
     item_type: Integration
     publish_time: '2021-04-07'
@@ -37,7 +37,7 @@
 -   description: 'MobileIron integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 4.0
+    version: 4.0
     item_name: MobileIron
     item_type: Integration
     publish_time: '2024-07-14'
@@ -47,7 +47,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 5.0
+    version: 5.0
     item_name: MobileIron
     item_type: Integration
     publish_time: '2025-10-29'
@@ -59,7 +59,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 6.0
+  version: 6.0
   item_name: MobileIron
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/observe_it/release_notes.yaml
+++ b/content/response_integrations/google/observe_it/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: NEW! ObserveIT integration
-    integration_version: 1.0
+    version: 1.0
     item_name: ObserveIT
     item_type: Integration
     publish_time: '2020-06-04'
@@ -24,7 +24,7 @@
     removed: false
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 2.0
+    version: 2.0
     item_name: ObserveIT
     item_type: Integration
     publish_time: '2020-11-04'
@@ -36,7 +36,7 @@
 -   description: 'ObserveIT integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 3.0
+    version: 3.0
     item_name: ObserveIT
     item_type: Integration
     publish_time: '2024-07-14'
@@ -47,7 +47,7 @@
     removed: false
 -   description: ObserveIT - Alerts Connector - Improved description for 'Fetch Max
         Hours Backwards' parameter.
-    integration_version: 4.0
+    version: 4.0
     item_name: ObserveIT - Alerts Connector
     item_type: Connector
     publish_time: '2024-08-08'
@@ -57,7 +57,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 5.0
+    version: 5.0
     item_name: ObserveIT
     item_type: Integration
     publish_time: '2025-10-29'
@@ -69,7 +69,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 6.0
+  version: 6.0
   item_name: ObserveIT
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/outpost24/release_notes.yaml
+++ b/content/response_integrations/google/outpost24/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: New Integration Added - Outpost24
-    integration_version: 1.0
+    version: 1.0
     item_name: Outpost24
     item_type: Integration
     publish_time: '2021-10-20'
@@ -23,7 +23,7 @@
     deprecated: false
     removed: false
 -   description: Outpost24 - Security Enhancements.
-    integration_version: 2.0
+    version: 2.0
     item_name: Outpost24
     item_type: Integration
     publish_time: '2022-09-21'
@@ -33,7 +33,7 @@
     deprecated: false
     removed: false
 -   description: Security Enhancements.
-    integration_version: 3.0
+    version: 3.0
     item_name: Outpost24
     item_type: Integration
     publish_time: '2023-04-27'
@@ -44,7 +44,7 @@
     removed: false
 -   description: Outpost24 - Outscan Findings Connector - Improved description for
         'Max Days Backwards' parameter.
-    integration_version: 4.0
+    version: 4.0
     item_name: Outpost24 - Outscan Findings Connector
     item_type: Connector
     publish_time: '2024-08-08'
@@ -56,7 +56,7 @@
 -   description: 'Outpost24 integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: Outpost24
     item_type: Integration
     publish_time: '2024-08-21'
@@ -66,7 +66,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities - Added Predefined Widget.
-    integration_version: 6.0
+    version: 6.0
     item_name: Enrich Entities
     item_type: Widget
     publish_time: '2024-11-05'
@@ -76,7 +76,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 7.0
+    version: 7.0
     item_name: Outpost24
     item_type: Integration
     publish_time: '2025-10-29'
@@ -86,7 +86,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities - Updated Predefined Widget.
-    integration_version: 8.0
+    version: 8.0
     item_name: Enrich Entities
     item_type: Widget
     publish_time: '2026-03-27'
@@ -98,7 +98,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 9.0
+  version: 9.0
   item_name: Outpost24
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/portnox/release_notes.yaml
+++ b/content/response_integrations/google/portnox/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 6.0
+    version: 6.0
     item_name: Portnox
     item_type: Integration
     publish_time: '2020-11-04'
@@ -26,7 +26,7 @@
 -   description: 'Portnox integration - Important - Updated the integration code to
         work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 7.0
+    version: 7.0
     item_name: Portnox
     item_type: Integration
     publish_time: '2024-07-14'
@@ -36,7 +36,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 8.0
+    version: 8.0
     item_name: Portnox
     item_type: Integration
     publish_time: '2025-10-29'
@@ -48,7 +48,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 9.0
+  version: 9.0
   item_name: Portnox
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/reversinglabs_a1000/release_notes.yaml
+++ b/content/response_integrations/google/reversinglabs_a1000/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 5.0
+    version: 5.0
     item_name: ReversinglabsA1000
     item_type: Integration
     publish_time: '2020-11-04'
@@ -26,7 +26,7 @@
 -   description: 'Reversinglabs A1000 integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 6.0
+    version: 6.0
     item_name: ReversinglabsA1000
     item_type: Integration
     publish_time: '2024-07-14'
@@ -36,7 +36,7 @@
     deprecated: false
     removed: false
 -   description: Get Report - Added Predefined Widget.
-    integration_version: 7.0
+    version: 7.0
     item_name: Get Report
     item_type: Widget
     publish_time: '2024-11-05'
@@ -46,7 +46,7 @@
     deprecated: false
     removed: false
 -   description: Upload File - Added Predefined Widget.
-    integration_version: 7.0
+    version: 7.0
     item_name: Upload File
     item_type: Widget
     publish_time: '2024-11-05'
@@ -56,7 +56,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 8.0
+    version: 8.0
     item_name: ReversinglabsA1000
     item_type: Integration
     publish_time: '2025-10-29'
@@ -66,7 +66,7 @@
     deprecated: false
     removed: false
 -   description: Upload File - Updated Predefined Widget.
-    integration_version: 9.0
+    version: 9.0
     item_name: Upload File
     item_type: Widget
     publish_time: '2026-03-20'
@@ -78,7 +78,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 10.0
+  version: 10.0
   item_name: ReversinglabsA1000
   item_type: Integration
   publish_time: '2026-03-24'

--- a/content/response_integrations/google/site24x7/release_notes.yaml
+++ b/content/response_integrations/google/site24x7/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: New integration "Site24x7"
-    integration_version: 1.0
+    version: 1.0
     item_name: Site24x7
     item_type: Integration
     publish_time: '2021-06-02'
@@ -24,7 +24,7 @@
     removed: false
 -   description: Site24x7 - Alerts Log Connector - Improved description for 'Max Days
         Backwards' parameter.
-    integration_version: 2.0
+    version: 2.0
     item_name: Site24x7 - Alerts Log Connector
     item_type: Connector
     publish_time: '2024-08-08'
@@ -36,7 +36,7 @@
 -   description: 'Site24x7 integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 3.0
+    version: 3.0
     item_name: Site24x7
     item_type: Integration
     publish_time: '2024-09-19'
@@ -46,7 +46,7 @@
     deprecated: false
     removed: false
 -   description: Generate Refresh Token - Added Predefined Widget.
-    integration_version: 4.0
+    version: 4.0
     item_name: Generate Refresh Token
     item_type: Widget
     publish_time: '2024-11-05'
@@ -56,7 +56,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 5.0
+    version: 5.0
     item_name: Site24x7
     item_type: Integration
     publish_time: '2025-10-29'
@@ -66,7 +66,7 @@
     deprecated: false
     removed: false
 -   description: Generate Refresh Token - Updated Predefined Widget.
-    integration_version: 6.0
+    version: 6.0
     item_name: Generate Refresh Token
     item_type: Widget
     publish_time: '2026-03-20'
@@ -78,7 +78,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 7.0
+  version: 7.0
   item_name: Site24x7
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/splash/release_notes.yaml
+++ b/content/response_integrations/google/splash/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: New integration "Splash".
-    integration_version: 1.0
+    version: 1.0
     item_name: Splash
     item_type: Integration
     publish_time: '2021-07-27'
@@ -23,7 +23,7 @@
     deprecated: false
     removed: false
 -   description: Improved the integration's visibility in the marketplace.
-    integration_version: 2.0
+    version: 2.0
     item_name: Splash
     item_type: Integration
     publish_time: '2021-07-29'
@@ -33,7 +33,7 @@
     deprecated: false
     removed: false
 -   description: Updated the integration's logo.
-    integration_version: 3.0
+    version: 3.0
     item_name: Splash
     item_type: Integration
     publish_time: '2021-08-11'
@@ -45,7 +45,7 @@
 -   description: 'Splash integration - Important - Updated the integration code to
         work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions.'
-    integration_version: 4.0
+    version: 4.0
     item_name: Splash
     item_type: Integration
     publish_time: '2024-09-12'
@@ -55,7 +55,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities - Added Predefined Widget.
-    integration_version: 5.0
+    version: 5.0
     item_name: Enrich Entities
     item_type: Widget
     publish_time: '2024-11-05'
@@ -65,7 +65,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 6.0
+    version: 6.0
     item_name: Splash
     item_type: Integration
     publish_time: '2025-10-29'
@@ -75,7 +75,7 @@
     deprecated: false
     removed: false
 -   description: Enrich Entities - Updated Predefined Widget.
-    integration_version: 7.0
+    version: 7.0
     item_name: Enrich Entities
     item_type: Widget
     publish_time: '2026-03-27'
@@ -87,7 +87,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 8.0
+  version: 8.0
   item_name: Splash
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/google/stealthwatch_v610/release_notes.yaml
+++ b/content/response_integrations/google/stealthwatch_v610/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 2.0
+    version: 2.0
     item_name: StealthwatchV6-10
     item_type: Integration
     publish_time: '2020-11-04'
@@ -24,7 +24,7 @@
     deprecated: false
     removed: false
 -   description: Updated Integration's dependencies.
-    integration_version: 3.0
+    version: 3.0
     item_name: StealthwatchV6-10
     item_type: Integration
     publish_time: '2022-08-03'
@@ -36,7 +36,7 @@
 -   description: 'Stealthwatch V6.10 integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 4.0
+    version: 4.0
     item_name: StealthwatchV6-10
     item_type: Integration
     publish_time: '2024-07-14'
@@ -46,7 +46,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 5.0
+    version: 5.0
     item_name: StealthwatchV6-10
     item_type: Integration
     publish_time: '2025-10-29'
@@ -58,7 +58,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 6.0
+  version: 6.0
   item_name: StealthwatchV6-10
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/symantec_content_analysis/release_notes.yaml
+++ b/content/response_integrations/google/symantec_content_analysis/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 3.0
+    version: 3.0
     item_name: SymantecContentAnalysis
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 4.0
+    version: 4.0
     item_name: SymantecContentAnalysis
     item_type: Integration
     publish_time: '2021-04-07'
@@ -38,7 +38,7 @@
         integration code to work with Python version 3.11. To ensure compatibility
         and avoid disruptions, follow the upgrade best practices described in the
         following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: SymantecContentAnalysis
     item_type: Integration
     publish_time: '2024-07-14'
@@ -48,7 +48,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 6.0
+    version: 6.0
     item_name: SymantecContentAnalysis
     item_type: Integration
     publish_time: '2025-10-29'
@@ -60,7 +60,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 7.0
+  version: 7.0
   item_name: SymantecContentAnalysis
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/symantec_icdx/release_notes.yaml
+++ b/content/response_integrations/google/symantec_icdx/release_notes.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 -   description: Added non-mandatory Proxy Parameters. Will be used if set (not empty).
-    integration_version: 2.0
+    version: 2.0
     item_name: SymantecICDX query Connector
     item_type: Connector
     publish_time: '2019-11-24'
@@ -24,7 +24,7 @@
     removed: false
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 3.0
+    version: 3.0
     item_name: SymantecICDX
     item_type: Integration
     publish_time: '2020-11-04'
@@ -35,7 +35,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 4.0
+    version: 4.0
     item_name: SymantecICDX
     item_type: Integration
     publish_time: '2021-04-07'
@@ -45,7 +45,7 @@
     deprecated: false
     removed: false
 -   description: Updated Integration's dependencies.
-    integration_version: 5.0
+    version: 5.0
     item_name: SymantecICDX
     item_type: Integration
     publish_time: '2022-08-03'
@@ -57,7 +57,7 @@
 -   description: 'Symantec ICDX integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 6.0
+    version: 6.0
     item_name: SymantecICDX
     item_type: Integration
     publish_time: '2024-07-14'
@@ -68,7 +68,7 @@
     removed: false
 -   description: Integration - Updated integration action definitions to meet the
         new requirements of IDE.
-    integration_version: 7.0
+    version: 7.0
     item_name: SymantecICDX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -78,7 +78,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 8.0
+    version: 8.0
     item_name: SymantecICDX
     item_type: Integration
     publish_time: '2025-10-29'
@@ -90,7 +90,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 9.0
+  version: 9.0
   item_name: SymantecICDX
   item_type: Integration
   publish_time: '2026-03-22'

--- a/content/response_integrations/google/websense/release_notes.yaml
+++ b/content/response_integrations/google/websense/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 6.0
+    version: 6.0
     item_name: Websense
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: New Parameter Added - "Verify SSL", allowing users to enable TLS
         validation when using the integration
-    integration_version: 7.0
+    version: 7.0
     item_name: Websense
     item_type: Integration
     publish_time: '2021-11-17'
@@ -40,7 +40,7 @@
         will be removed from your integration. Please keep that in mind and review
         your playbooks before updating. Please contact your Customer Success Manager
         for more information.
-    integration_version: 7.0
+    version: 7.0
     item_name: Websense
     item_type: Integration
     publish_time: '2021-11-17'
@@ -50,7 +50,7 @@
     deprecated: false
     removed: false
 -   description: Security enhancements throughout the integration.
-    integration_version: 8.0
+    version: 8.0
     item_name: Websense
     item_type: Integration
     publish_time: '2021-12-01'
@@ -60,7 +60,7 @@
     deprecated: false
     removed: false
 -   description: Updated Integration's dependencies.
-    integration_version: 9.0
+    version: 9.0
     item_name: Websense
     item_type: Integration
     publish_time: '2022-08-03'
@@ -70,7 +70,7 @@
     deprecated: false
     removed: false
 -   description: WebSense - Security Enhancements.
-    integration_version: 10.0
+    version: 10.0
     item_name: Websense
     item_type: Integration
     publish_time: '2022-09-21'
@@ -80,7 +80,7 @@
     deprecated: false
     removed: false
 -   description: Security Enhancements.
-    integration_version: 11.0
+    version: 11.0
     item_name: Websense
     item_type: Integration
     publish_time: '2023-04-27'
@@ -92,7 +92,7 @@
 -   description: 'Websense integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 12.0
+    version: 12.0
     item_name: Websense
     item_type: Integration
     publish_time: '2024-07-14'
@@ -102,7 +102,7 @@
     deprecated: false
     removed: false
 -   description: Integration - Updated Dependencies.
-    integration_version: 13.0
+    version: 13.0
     item_name: Websense
     item_type: Integration
     publish_time: '2024-07-14'
@@ -112,7 +112,7 @@
     deprecated: false
     removed: false
 -   description: Updated integration metadata
-    integration_version: 14.0
+    version: 14.0
     item_name: Websense
     item_type: Integration
     publish_time: '2025-10-29'
@@ -124,7 +124,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 15.0
+  version: 15.0
   item_name: Websense
   item_type: Integration
   publish_time: '2026-04-20'

--- a/content/response_integrations/power_ups/connectors/release_notes.yaml
+++ b/content/response_integrations/power_ups/connectors/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: NEW! Connectors integration to power up automation capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Connectors
   item_type: Integration
   publish_time: '2020-10-26'
   ticket_number: xxx
 - description: NEW! "Cron Scheduled Connector" is a connector that will create a dummy
     case based off a cron schedule
-  integration_version: 2.0
+  version: 2.0
   item_name: Cron Scheduled Connector
   item_type: Connector
   publish_time: '2021-09-20'
@@ -14,14 +14,14 @@
   new: true
 - description: Fix! Environmnet handling in Cron Scheduled Connector. Connector will
     send alert to the assigned environemmt, instead of default environment
-  integration_version: 3.0
+  version: 3.0
   item_name: Cron Scheduled Connector
   item_type: Connector
   publish_time: '2024-02-14'
   ticket_number: '323307492'
 - description: Connectors - Updated integration's descriptions to reflect renaming
     to Google SecOps.
-  integration_version: 4.0
+  version: 4.0
   item_name: Connectors
   item_type: Integration
   publish_time: '2024-04-25'
@@ -29,19 +29,19 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: Connectors
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Integration - Updated Dependencies.
-  integration_version: 6.0
+  version: 6.0
   item_name: Connectors
   item_type: Integration
   publish_time: '2026-01-07'
   ticket_number: '467333051'
 - description: Updated integration metadata.
-  integration_version: 7.0
+  version: 7.0
   item_name: Connectors
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/email_utilities/release_notes.yaml
+++ b/content/response_integrations/power_ups/email_utilities/release_notes.yaml
@@ -1,10 +1,10 @@
 - description: NEW! Email Utilities integration to power up playbook capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: EmailUtilities
   item_type: Integration
   ticket_number: xxx
 - description: NEW! Parse Base64 Email action.
-  integration_version: 2.0
+  version: 2.0
   item_name: Parse Base64 Email
   item_type: Action
   publish_time: '2020-11-19'
@@ -13,7 +13,7 @@
     which accepts a Base64 encoded string of an EML or MSG file. The action will parse
     the message and return headers, body content, attachments, and any nested EML
     or MSG files that may be contained within the original Email Message.'
-  integration_version: 3.0
+  version: 3.0
   item_name: Parse Base64 Email
   item_type: Action
   publish_time: '2021-01-17'
@@ -22,7 +22,7 @@
     accepts a JSON object containing a list of email headers and will validate the
     SPF, DMARC, ARC, and DKIM records in the email. It will also check to see if any
     of the relay servers are denylisted by querying multiple RBLs. '
-  integration_version: 3.0
+  version: 3.0
   item_name: Analyze Headers
   item_type: Action
   publish_time: '2021-01-17'
@@ -30,47 +30,47 @@
 - description: '"Parse Base64 Email" action has been updated to improve the parsing
     of observables in the email.  Previous version may have produced incorrect domains,
     urls, or emails.'
-  integration_version: 4.0
+  version: 4.0
   item_name: Parse Base64 Email
   item_type: Action
   publish_time: '2021-05-20'
   ticket_number: xxx
 - description: '"Analyze Headers" action has been updated to fix a bug when parsing
     routes in the header.'
-  integration_version: 5.0
+  version: 5.0
   item_name: Analyze Headers
   item_type: Action
   publish_time: '2021-10-08'
   ticket_number: xxx
 - description: Fixed bug in Analyze Headers.
-  integration_version: 6.0
+  version: 6.0
   item_name: Analyze Headers
   item_type: Action
   publish_time: '2021-10-15'
   ticket_number: xxx
 - description: 'Fixed - Parse Base64 Email: Updated the format of headers from MSG
     files to match the format from EML files.'
-  integration_version: 7.0
+  version: 7.0
   item_name: Parse Base64 Email
   item_type: Action
   publish_time: '2021-12-06'
   ticket_number: xxx
 - description: Update! Analyze Headers - The action will now add geo-location and
     IP whois information to the relay servers.
-  integration_version: 8.0
+  version: 8.0
   item_name: Analyze Headers
   item_type: Action
   publish_time: '2022-02-04'
   ticket_number: xxx
 - description: Code cleanup and removal of unused dependencies.
-  integration_version: 10.0
+  version: 10.0
   item_name: Analyze Headers
   item_type: Action
   publish_time: '2022-02-11'
   ticket_number: xxx
 - description: NEW! "Parse Case Wall Email" action added to Email Utilities. This
     action will parse an EML or MSG file that is on the case wall.
-  integration_version: 11.0
+  version: 11.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2022-02-18'
@@ -78,100 +78,100 @@
   new: true
 - description: Update! "Parse Case Wall Email" Fixed bug that caused some DNS lookups
     to fail.
-  integration_version: 12.0
+  version: 12.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2022-03-30'
   ticket_number: xxx
 - description: Version increase.
-  integration_version: 13.0
+  version: 13.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2022-03-30'
   ticket_number: xxx
 - description: Update! "Parse Case Wall Email" - Added support for rewriting Proofpoint
     URLs and fix for ICS files.
-  integration_version: 14.0
+  version: 14.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2022-05-24'
   ticket_number: xxx
 - description: Update! "Parse Case Wall Email" - Added support for rewriting Microsoft
     Safelink URLs and a fix to incorrect URL extracting.
-  integration_version: 15.0
+  version: 15.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2022-06-14'
   ticket_number: xxx
 - description: Update! "Analyze Headers" - Fixed a bug that caused the action to crash
     when parsing expired DKIM records.
-  integration_version: 16.0
+  version: 16.0
   item_name: Analyse Headers
   item_type: Action
   publish_time: '2022-12-02'
   ticket_number: xxx
 - description: Update! "Parse Case Wall Email" - Fixed a bug causing the action to
     crash when a URL has already been added to the case.
-  integration_version: 17.0
+  version: 17.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2022-12-15'
   ticket_number: xxx
 - description: Fix! "Analyze Headers" - Fixed a bug causing the action to crash when
     an email header was missing a return-path key.
-  integration_version: 18.0
+  version: 18.0
   item_name: Analyze Headers
   item_type: Action
   publish_time: '2023-01-20'
   ticket_number: xxx
 - description: Fix! - Fixed a bug causing the integration to fail to load.
-  integration_version: 19.0
+  version: 19.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2023-02-21'
   ticket_number: xxx
 - description: Update! - Updated an internal library.
-  integration_version: 20.0
+  version: 20.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2023-02-23'
   ticket_number: xxx
 - description: Fixed bug that was causing JSON results not to display.
-  integration_version: 21.0
+  version: 21.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2023-08-21'
   ticket_number: xxx
 - description: Fix! - Fixed a bug that was causing some EML files to fail to parse..
-  integration_version: 22.0
+  version: 22.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2023-11-01'
   ticket_number: xxx
 - description: Parse Case Wall Email - Fixed a bug that was causing some URL to fail
     to parse.
-  integration_version: 23.0
+  version: 23.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-02-21'
   ticket_number: '322127919'
 - description: Parse Case Wall Email - Fixed a bug that was causing entity creation
     with empty identifier
-  integration_version: 24.0
+  version: 24.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-04-04'
   ticket_number: '328665334'
 - description: Parse Case Wall Email - Action improvements for working with attached
     eml files and handling email's display name field.
-  integration_version: 25.0
+  version: 25.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-05-15'
   ticket_number: 335715794, 338638289
 - description: Parse Case Wall Email Action - REGRESSIVE! Action updated to not automatically
     convert entities "Original Identifier" field to upper case.
-  integration_version: 26.0
+  version: 26.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-05-29'
@@ -179,51 +179,51 @@
   regressive: true
 - description: Parse Case Wall Email Action - Updated Entity creation logic to better
     parse all Case Wall Email's URLs.
-  integration_version: 26.0
+  version: 26.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-05-29'
   ticket_number: '331692190'
 - description: Parse Case Wall Email Action - Updated logic for handling of "Original
     EML Only" parameter.
-  integration_version: 27.0
+  version: 27.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-07-31'
   ticket_number: '347007733'
 - description: Parse Case Wall Email - Updated the JSON Result structure.
-  integration_version: 28.0
+  version: 28.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-08-21'
   ticket_number: '351365335'
 - description: Parse Case Wall Email - Updated parser logic.
-  integration_version: 29.0
+  version: 29.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-08-26'
   ticket_number: '351365335'
 - description: Parse Case Wall Email - Updated handling for malformed eml content-type.
-  integration_version: 30.0
+  version: 30.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-09-04'
   ticket_number: '356792519'
 - description: Parse Case Wall Email - Updated handling for exclude regex entity creation.
-  integration_version: 31.0
+  version: 31.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-10-16'
   ticket_number: '362364528'
 - description: Parse Case Wall Email - Action updated to better handle the markdown
     characters.
-  integration_version: 31.0
+  version: 31.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-10-16'
   ticket_number: '359822982'
 - description: Parse Case Wall Email - Action updated to better handle eml parsing.
-  integration_version: 32.0
+  version: 32.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2024-11-27'
@@ -231,92 +231,92 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 33.0
+  version: 33.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Parse Case Wall Email, Analyze Headers - Actions Updates.
-  integration_version: 34.0
+  version: 34.0
   item_name: Parse Case Wall Email, Analyze Headers
   item_type: Action
   publish_time: '2025-02-19'
   ticket_number: 393134934, 393611630
 - description: Parse Case Wall Email - Actions Updates.
-  integration_version: 35.0
+  version: 35.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-06-25'
   ticket_number: '425443762'
 - description: Parse Case Wall Email - Improved entity extraction mechanism.
-  integration_version: 36.0
+  version: 36.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-07-09'
   ticket_number: '426659486'
 - description: Parse Case Wall Email - Updated the logic for IP Address type entity
     creation.
-  integration_version: 37.0
+  version: 37.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-07-16'
   ticket_number: '429253906'
 - description: Parse Case Wall Email - Updated entity processing logic.
-  integration_version: 38.0
+  version: 38.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-08-04'
   ticket_number: '433043714'
 - description: Integration - Updated dependencies.
-  integration_version: 39.0
+  version: 39.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2025-08-13'
   ticket_number: 433361672, 434658560
 - description: Parse Case Wall Email - Updated entity creation logic.
-  integration_version: 40.0
+  version: 40.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-08-20'
   ticket_number: '432241464'
 - description: Parse Case Wall Email - Updated error handling.
-  integration_version: 41.0
+  version: 41.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-10-09'
   ticket_number: '445763034'
 - description: Parse Case Wall Email - Updated entity extraction logic.
-  integration_version: 42.0
+  version: 42.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2025-11-26'
   ticket_number: '460806204'
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 43.0
+  version: 43.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2025-12-24'
   ticket_number: '467643374'
 - description: Parse Case Wall Email - Updated the attachment retrieval logic.
-  integration_version: 44.0
+  version: 44.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2026-01-05'
   ticket_number: '472959485'
 - description: Integration - Updated Dependencies.
-  integration_version: 45.0
+  version: 45.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2026-02-04'
   ticket_number: '477008157'
 - description: Updated integration metadata.
-  integration_version: 46.0
+  version: 46.0
   item_name: EmailUtilities
   item_type: Integration
   publish_time: '2026-03-18'
   ticket_number: ''
 - description: Parse Case Wall Email - Updated error handling around entity processing.
-  integration_version: 47.0
+  version: 47.0
   item_name: Parse Case Wall Email
   item_type: Action
   publish_time: '2026-03-27'

--- a/content/response_integrations/power_ups/enrichment/release_notes.yaml
+++ b/content/response_integrations/power_ups/enrichment/release_notes.yaml
@@ -1,44 +1,44 @@
 - description: NEW! Enrichment integration to power up playbook capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Enrichment
   item_type: Integration
   ticket_number: xxx
 - description: Bug fix in Enrich Entity with field action.
-  integration_version: 2.0
+  version: 2.0
   item_name: Enrich Entity with field
   item_type: Action
   publish_time: '2020-12-16'
   ticket_number: xxx
 - description: Added support for Target Entities parameter in "Enrich Entity with
     field" action.
-  integration_version: 3.0
+  version: 3.0
   item_name: Enrich Entity with field
   item_type: Action
   publish_time: '2021-01-08'
   ticket_number: xxx
 - description: Siemplify API Key was added to the integration parameter and is required
     for "Enrich Entity from Explorer Attributes" action.
-  integration_version: 4.0
+  version: 4.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2021-01-17'
   ticket_number: xxx
 - description: NEW! "Enrich Entity from Explorer Attributes" action added to Enrichment.
     Can be used to enrich an entity with historic enrichment data.
-  integration_version: 4.0
+  version: 4.0
   item_name: Enrich Entity from Explorer Attributes
   item_type: Action
   publish_time: '2021-01-17'
   ticket_number: xxx
 - description: Update! "Enrich Entity from JSON" bug fix with target entities.
-  integration_version: 5.0
+  version: 5.0
   item_name: Enrich Entity From Json
   item_type: Action
   publish_time: '2021-07-08'
   ticket_number: xxx
 - description: NEW! "Enrich FileName Entity with Path" action added to Enrichment.
     This action will parse out path, filename, and extension from an entity.
-  integration_version: 7.0
+  version: 7.0
   item_name: Enrich FileName Entity with Path
   item_type: Action
   publish_time: '2021-08-05'
@@ -46,7 +46,7 @@
   new: true
 - description: NEW! "Enrich Entities from List with Field" action added to Enrichment.
     This action will enrich a list of entities with a field and value.
-  integration_version: 8.0
+  version: 8.0
   item_name: Enrich FileName Entity with Path
   item_type: Action
   publish_time: '2021-10-26'
@@ -54,14 +54,14 @@
   new: true
 - description: NEW! "Mark Entity as Suspicious" action added to Enrichment. This action
     will mark the entities in the scope as suspicious.
-  integration_version: 9.0
+  version: 9.0
   item_name: Mark Entity as Suspicious
   item_type: Action
   publish_time: '2021-11-02'
   ticket_number: xxx
   new: true
 - description: Updated SVG.
-  integration_version: 10.0
+  version: 10.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2021-11-24'
@@ -69,21 +69,21 @@
   new: true
 - description: New Action! Enrich Source and Destinations.  This action will add the
     source and destination links to IPs and hostnames in the alert.
-  integration_version: 11.0
+  version: 11.0
   item_name: Enrich Source and Destinations
   item_type: Integration
   publish_time: '2021-11-30'
   ticket_number: xxx
   new: true
 - description: Update! Enrich Source and Destinations.  Supports version 6.0
-  integration_version: 12.0
+  version: 12.0
   item_name: Enrich Source and Destinations
   item_type: Integration
   publish_time: '2021-12-09'
   ticket_number: xxx
   new: true
 - description: Update! Enrich Entities from List with Field.  Bug Fix
-  integration_version: 13.0
+  version: 13.0
   item_name: Enrich Entities from List with Field
   item_type: Integration
   publish_time: '2021-12-10'
@@ -91,35 +91,35 @@
   new: true
 - description: New Item! "Whois" - Enriches URLS, Usernames, Domains and IPs with
     information from WHOIS servers.
-  integration_version: 14.0
+  version: 14.0
   item_name: Whois
   item_type: Action
   publish_time: '2021-12-21'
   ticket_number: xxx
   new: true
 - description: Whois - Bugfix.
-  integration_version: 15.0
+  version: 15.0
   item_name: Whois
   item_type: Action
   publish_time: '2021-12-22'
   ticket_number: xxx
   new: true
 - description: New Feature! "Whois" - Support for FR domains
-  integration_version: 19.0
+  version: 19.0
   item_name: Whois
   item_type: Action
   publish_time: '2022-05-06'
   ticket_number: xxx
   new: true
 - description: New Feature! "Whois" - Now performs Geo Lookup on IP addresses
-  integration_version: 20.0
+  version: 20.0
   item_name: Whois
   item_type: Action
   publish_time: '2022-06-15'
   ticket_number: xxx
   new: true
 - description: Fix! Whois - Syntax error.
-  integration_version: 21.0
+  version: 21.0
   item_name: Whois
   item_type: Action
   publish_time: '2022-06-16'
@@ -127,34 +127,34 @@
   new: true
 - description: 'Update! Enrich Entity from Explorer Attributes - Now supports: enriching
     all entity fields, denylists, and multiple entities.'
-  integration_version: 22.0
+  version: 22.0
   item_name: Enrich Entity from Explorer Attributes
   item_type: Action
   publish_time: '2022-09-30'
   ticket_number: xxx
   new: true
 - description: Fix! Whois - Support for .BE domains added.
-  integration_version: 23.0
+  version: 23.0
   item_name: Whois
   item_type: Action
   publish_time: '2022-11-14'
   ticket_number: xxx
 - description: Fix! Updated dependency that caused installation failures.
-  integration_version: 24.0
+  version: 24.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2023-02-22'
   ticket_number: xxx
 - description: Fix! Enrich Entity from Explorer Attributes - better support for entities
     with same identifier.
-  integration_version: 25.0
+  version: 25.0
   item_name: Enrich Entity from Explorer Attributes
   item_type: Integration
   publish_time: '2023-12-06'
   ticket_number: xxx
 - description: Vulnerability fix - Enable server certificate validation on this SSL/TLS
     connection.
-  integration_version: 26.0
+  version: 26.0
   item_name: Enrich Entity from Explorer Attributes
   item_type: Action
   publish_time: '2024-01-05'
@@ -162,43 +162,43 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 27.0
+  version: 27.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Enrich Entity from JSON - Updated input handling logic.
-  integration_version: 28.0
+  version: 28.0
   item_name: Enrich Entity From Json
   item_type: Action
   publish_time: '2025-04-23'
   ticket_number: '405213338'
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 29.0
+  version: 29.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2025-07-16'
   ticket_number: '430477875'
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 30.0
+  version: 30.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2025-12-24'
   ticket_number: '469573044'
 - description: Integration - Updated Dependencies.
-  integration_version: 31.0
+  version: 31.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2026-01-07'
   ticket_number: '467333051'
 - description: Integration - Updated Dependencies.
-  integration_version: 32.0
+  version: 32.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2026-02-04'
   ticket_number: '477008157'
 - description: Updated integration metadata.
-  integration_version: 33.0
+  version: 33.0
   item_name: Enrichment
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/file_utilities/release_notes.yaml
+++ b/content/response_integrations/power_ups/file_utilities/release_notes.yaml
@@ -1,89 +1,89 @@
 - description: NEW! File Utilities integration to power up playbook capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2020-10-07'
   ticket_number: xxx
 - description: Fixed a bug in the "Get Attachment" action where the parameters for
     Name and Description were switched.
-  integration_version: 2.0
+  version: 2.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2020-10-07'
   ticket_number: xxx
 - description: NEW! Extract and Create Archive Actions.
-  integration_version: 3.0
+  version: 3.0
   item_name: FileUtilities
   item_type: Action
   publish_time: '2020-12-10'
   ticket_number: xxx
 - description: NEW! Get Files as Base64 action.
-  integration_version: 4.0
+  version: 4.0
   item_name: FileUtilities
   item_type: Action
   publish_time: '2021-01-08'
   ticket_number: xxx
 - description: Fixed bug in "Save Base64 to File" action where the file extensions
     parameter would not accept an empty value.
-  integration_version: 4.0
+  version: 4.0
   item_name: Save Base64 to File
   item_type: Action
   publish_time: '2021-01-08'
   ticket_number: xxx
 - description: Fixed bug in "Save Base64 to File" action.
-  integration_version: 5.0
+  version: 5.0
   item_name: Save Base64 to File
   item_type: Action
   publish_time: '2021-01-11'
   ticket_number: xxx
 - description: 'UPDATE: "Save Base64 to File" now supports saving on agents.'
-  integration_version: 6.0
+  version: 6.0
   item_name: Save Base64 to File
   item_type: Action
   publish_time: '2021-06-16'
   ticket_number: xxx
 - description: 'UPDATE: "Add Entity to File" bugfix, added timeout variable.'
-  integration_version: 7.0
+  version: 7.0
   item_name: Add Entity to File
   item_type: Action
   publish_time: '2021-07-06'
   ticket_number: xxx
 - description: 'UPDATE: "Remove Entity from File" bugfix, added timeout variable.'
-  integration_version: 7.0
+  version: 7.0
   item_name: Add Entity to File
   item_type: Action
   publish_time: '2021-07-06'
   ticket_number: xxx
 - description: 'UPDATE: "Get Files as Base64" Now supports files with commas in the
     name.'
-  integration_version: 8.0
+  version: 8.0
   item_name: Get Files as Base64
   item_type: Action
   publish_time: '2021-12-13'
   ticket_number: xxx
 - description: 'NEW! Extract Zip Files: Extracts files from ZIP files and creates
     entities out of extracted files.'
-  integration_version: 9.0
+  version: 9.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2022-02-18'
   ticket_number: xxx
 - description: 'NEW! Create Hash From Base64: Creates hash values from base64 strings.'
-  integration_version: 10.0
+  version: 10.0
   item_name: Create Hash From Base64
   item_type: Action
   publish_time: '2023-01-20'
   ticket_number: xxx
   new: true
 - description: FIX! Get Attachment - fixed API endpoint.
-  integration_version: 11.0
+  version: 11.0
   item_name: Get Attachment
   item_type: Action
   publish_time: '2023-03-06'
   ticket_number: xxx
   new: true
 - description: FIX! Get Files as Base64 - Fixed emtpy script result
-  integration_version: 12.0
+  version: 12.0
   item_name: Get Files as Base64
   item_type: Action
   publish_time: '2023-04-20'
@@ -91,7 +91,7 @@
   new: true
 - description: FIX! Save Base64 to File - Added support for extensions with dot (.)
     prefix.
-  integration_version: 13.0
+  version: 13.0
   item_name: Save Base64 to File
   item_type: Action
   publish_time: '2023-10-04'
@@ -99,20 +99,20 @@
   new: true
 - description: Vulnerability fix - Enable server certificate validation on this SSL/TLS
     connection.
-  integration_version: 14.0
+  version: 14.0
   item_name: Get Attachment, Add Attachment
   item_type: Action
   publish_time: '2024-01-05'
   ticket_number: 318190701,318191191
 - description: FileUtilities - Security Enhancements.
-  integration_version: 15.0
+  version: 15.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2024-02-08'
   ticket_number: '315941503'
 - description: FileUtilities - Updated integration's descriptions to reflect renaming
     to Google SecOps.
-  integration_version: 16.0
+  version: 16.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2024-04-25'
@@ -120,43 +120,43 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 17.0
+  version: 17.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Add Attachment - Updated error handling.
-  integration_version: 18.0
+  version: 18.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2025-10-15'
   ticket_number: '405127010'
 - description: Extract Zip Files - Updated folder handling.
-  integration_version: 19.0
+  version: 19.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2025-12-3'
   ticket_number: '461326893'
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 20.0
+  version: 20.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2025-12-24'
   ticket_number: '432162908'
 - description: Get Attachment - Updated the attachment retrieval logic.
-  integration_version: 21.0
+  version: 21.0
   item_name: Get Attachment
   item_type: Action
   publish_time: '2026-01-12'
   ticket_number: '474550397, 474643232'
 - description: Integration - Updated Dependencies.
-  integration_version: 22.0
+  version: 22.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2026-02-04'
   ticket_number: '477008157'
 - description: Updated integration metadata.
-  integration_version: 23.0
+  version: 23.0
   item_name: FileUtilities
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/functions/release_notes.yaml
+++ b/content/response_integrations/power_ups/functions/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! Functions integration to power up playbook capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Functions
   item_type: Integration
   publish_time: '2020-08-01'
   ticket_number: xxx
 - description: NEW! Convert Time Format Action added to Functions.
-  integration_version: 2.0
+  version: 2.0
   item_name: Convert Time Format
   item_type: Action
   publish_time: '2020-10-27'
   ticket_number: xxx
 - description: NEW! EncodeBase64 and DecodeBase64 Actions added to Functions.
-  integration_version: 3.0
+  version: 3.0
   item_name: EncodeBase64 and DecodeBase64
   item_type: Action
   publish_time: '2021-01-08'
@@ -19,46 +19,46 @@
 - description: NEW! "Run JSONPath Query" action added to Functions. Runs a JSONPath
     Query on a given json and extracts values according to the expression.  View https://github.com/h2non/jsonpath-ng
     for more information on JSONPath
-  integration_version: 4.0
+  version: 4.0
   item_name: Run JSONPath Query
   item_type: Action
   publish_time: '2021-01-17'
   ticket_number: xxx
 - description: Added "RemoveNewLines" function to "String Functions" action which
     will remove any nested newlines from within a string.
-  integration_version: 4.0
+  version: 4.0
   item_name: String Functions
   item_type: Action
   publish_time: '2021-01-17'
   ticket_number: xxx
 - description: NEW! IP to Integer action.
-  integration_version: 5.0
+  version: 5.0
   item_name: IP to Integer
   item_type: Action
   publish_time: '2021-05-16'
   ticket_number: xxx
 - description: Added LogicOperators which will add AND or OR to comma separated list.
-  integration_version: 5.0
+  version: 5.0
   item_name: String Functions
   item_type: Action
   publish_time: '2021-05-16'
   ticket_number: xxx
 - description: 'Fix: Run JSONPath Query was using an incorrect parameter name.'
-  integration_version: 6.0
+  version: 6.0
   item_name: Run JSONPath Query
   item_type: Action
   publish_time: '2021-05-20'
   ticket_number: xxx
 - description: 'NEW!: Create Thumbnail - Will create a thumbnail out of a image encoded
     as base64.'
-  integration_version: 7.0
+  version: 7.0
   item_name: Create Thumbnail
   item_type: Action
   publish_time: '2021-06-14'
   ticket_number: xxx
   new: true
 - description: 'Fix!: Create Thumbnail - Locked action.'
-  integration_version: 8.0
+  version: 8.0
   item_name: Create Thumbnail
   item_type: Action
   publish_time: '2021-06-14'
@@ -66,7 +66,7 @@
 - description: NEW! "Time Duration Calculator" action added to Functions. The Time
     Duration Calculator will calculate the time that has elapsed/difference between
     two dates with time.
-  integration_version: 9.0
+  version: 9.0
   item_name: Time Duration Calculator
   item_type: Action
   publish_time: '2021-06-18'
@@ -74,7 +74,7 @@
   new: true
 - description: 'BUG FIX!: "Math Arithmetic" - Addition of integers now creates an
     integer.'
-  integration_version: 10.0
+  version: 10.0
   item_name: Time Duration Calculator
   item_type: Action
   publish_time: '2021-06-23'
@@ -83,7 +83,7 @@
     parse it according to the HTML5 parsing algorithm and sanitize any disallowed
     tags or attributes. This algorithm also takes care of things like unclosed and
     (some) misnested tags.'
-  integration_version: 11.0
+  version: 11.0
   item_name: SanitizeHTML
   item_type: Action
   publish_time: '2021-07-13'
@@ -91,49 +91,49 @@
   new: true
 - description: 'UPDATE!: "Time Duration Calculator" - Made the now variable timezone
     aware.'
-  integration_version: 13.0
+  version: 13.0
   item_name: Time Duration Calculator
   item_type: Action
   publish_time: '2021-07-14'
   ticket_number: xxx
 - description: 'UPDATE!: "Time Duration Calculator" - Bugfix for timezones.'
-  integration_version: 14.0
+  version: 14.0
   item_name: Time Duration Calculator
   item_type: Action
   publish_time: '2021-07-15'
   ticket_number: xxx
 - description: Updated SVG.
-  integration_version: 15.0
+  version: 15.0
   item_name: Time Duration Calculator
   item_type: Action
   publish_time: '2021-11-24'
   ticket_number: xxx
 - description: Added Split method.
-  integration_version: 16.0
+  version: 16.0
   item_name: String Functions
   item_type: Action
   publish_time: '2022-02-04'
   ticket_number: xxx
 - description: Fix for String Functions.  Added Split to options.
-  integration_version: 17.0
+  version: 17.0
   item_name: String Functions
   item_type: Action
   publish_time: '2022-04-22'
   ticket_number: xxx
 - description: Added base64 encode and decode to String Functions action.
-  integration_version: 18.0
+  version: 18.0
   item_name: String Functions
   item_type: Action
   publish_time: '2022-07-10'
   ticket_number: xxx
 - description: Fix parameters description in Convert Time Format action.
-  integration_version: 18.0
+  version: 18.0
   item_name: Convert Time Format
   item_type: Action
   publish_time: '2022-07-10'
   ticket_number: xxx
 - description: New Action! - XMLtoJSON
-  integration_version: 19.0
+  version: 19.0
   item_name: XMLtoJSON
   item_type: Action
   publish_time: '2022-10-14'
@@ -141,7 +141,7 @@
   new: true
 - description: 'NEW! Detect Hash Type: This action detects the most likely hash type
     of entities. Supported types are SHA256, MD5, SHA1, SHA-512.'
-  integration_version: 20.0
+  version: 20.0
   item_name: Detect Hash TYpe
   item_type: Action
   publish_time: '2023-01-20'
@@ -149,7 +149,7 @@
   new: true
 - description: 'NEW! Detect IP Type: This action checks if an IP is an IPv4 address
     or IPv6 address.  IP Address entities will be enriched with IPType field.'
-  integration_version: 20.0
+  version: 20.0
   item_name: Detect IP Type
   item_type: Action
   publish_time: '2023-01-20'
@@ -157,7 +157,7 @@
   new: true
 - description: 'NEW! Extract IOCs: This action extracts IPs, domains, emails, and
     URLs from an input string.'
-  integration_version: 21.0
+  version: 21.0
   item_name: Extract IOCs
   item_type: Action
   publish_time: '2023-09-28'
@@ -165,27 +165,27 @@
   new: true
 - description: 'Update! Extract IOCs: Fixed bug which caused action to crash when
     URL had an ampersand character.'
-  integration_version: 22.0
+  version: 22.0
   item_name: Extract IOCs
   item_type: Action
   publish_time: '2023-10-27'
   ticket_number: '308063187'
 - description: 'Update! String Functions: DecodeBase64 and EncodeBase64 now support
     encoding type as param_1.'
-  integration_version: 23.0
+  version: 23.0
   item_name: String Functions
   item_type: Action
   publish_time: '2023-11-21'
   ticket_number: ''
 - description: Functions - Updated integration's descriptions to reflect renaming
     to Google SecOps.
-  integration_version: 24.0
+  version: 24.0
   item_name: Functions
   item_type: Integration
   publish_time: '2024-04-25'
   ticket_number: '332545706'
 - description: String Functions Action - Action updates.
-  integration_version: 25.0
+  version: 25.0
   item_name: String Functions
   item_type: Action
   publish_time: '2024-07-24'
@@ -193,25 +193,25 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 26.0
+  version: 26.0
   item_name: Functions
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: SanitizeHTML - Refactored the code.
-  integration_version: 27.0
+  version: 27.0
   item_name: Sanitize HTML
   item_type: Action
   publish_time: '2025-02-19'
   ticket_number: '393215713'
 - description: Extract IOCs - Refactored the code.
-  integration_version: 28.0
+  version: 28.0
   item_name: Extrac Iocs
   item_type: Action
   publish_time: '2025-04-23'
   ticket_number: '411096892'
 - description: Functions - minor fixes to DDL parameters.
-  integration_version: 29.0
+  version: 29.0
   item_name: Functions
   item_type: Integration
   publish_time: '2025-07-07'
@@ -219,38 +219,38 @@
 - description: 'Update! String Functions: Replace and Regex Replace now recognize
     the placeholder code _SPACE_ in the pattern and replacement fields. It automatically
     converts this code into a standard space before performing the replacement.'
-  integration_version: 30.0
+  version: 30.0
   item_name: String Functions
   item_type: Action
   publish_time: '2025-11-20'
   ticket_number: '434644419'
 - description: 'New Action Added - Calculate Timestamp.'
-  integration_version: 31.0
+  version: 31.0
   item_name: Calculate Timestamp
   item_type: Action
   publish_time: '2025-11-19'
   ticket_number: '446641892'
   new: true
 - description: 'Create Thumbnail, IP to Integer, Run JSONPath Query, Time Duration Calculator, XMLtoJson - Updated actions to show the available JSON Result.'
-  integration_version: 32.0
+  version: 32.0
   item_name: 'Create Thumbnail, IP to Integer, Run JSONPath Query, Time Duration Calculator, XMLtoJson'
   item_type: Action
   publish_time: '2025-11-26'
   ticket_number: '460792395'
 - description: 'New Action Added - Defang Text.'
-  integration_version: 33.0
+  version: 33.0
   item_name: Defang Text
   item_type: Action
   publish_time: '2025-12-04'
   new: true
 - description: 'String Functions - Updated actions to show the available JSON Result.'
-  integration_version: 34.0
+  version: 34.0
   item_name: 'String Functions'
   item_type: Action
   publish_time: '2025-12-24'
   ticket_number: '469679105'
 - description: Updated integration metadata.
-  integration_version: 35.0
+  version: 35.0
   item_name: Functions
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/git_sync/release_notes.yaml
+++ b/content/response_integrations/power_ups/git_sync/release_notes.yaml
@@ -1,208 +1,208 @@
 - description: NEW! GitSync integration to allow the syncing of Siemplify integrations,
     playbooks, and settings to GitHub or BitBucket.
-  integration_version: 3.0
+  version: 3.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-09-30'
   ticket_number: xxx
 - description: 'Added: README.md file in the root directory of the repo, specifying
     it''s contents.'
-  integration_version: 4.0
+  version: 4.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-11-14'
   ticket_number: xxx
 - description: 'Fixed: Issue when pulling a connector and the integration is not installed.'
-  integration_version: 4.0
+  version: 4.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-11-14'
   ticket_number: xxx
 - description: 'Fixed: Commit author must be set even when it''s not mandatory. Added
     validation to correct format when set.'
-  integration_version: 4.0
+  version: 4.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-11-14'
   ticket_number: xxx
 - description: 'Fixed: Error when pulling an environment and it already exists in
     the system.'
-  integration_version: 4.0
+  version: 4.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-11-14'
   ticket_number: xxx
 - description: 'Fixed: Integration actions readme description was added twice.'
-  integration_version: 4.0
+  version: 4.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-11-14'
   ticket_number: xxx
 - description: Updated SVG
-  integration_version: 5.0
+  version: 5.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-11-24'
   ticket_number: xxx
 - description: 'Added: Git SSL verification parameter'
-  integration_version: 6.0
+  version: 6.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-12-26'
   ticket_number: xxx
 - description: 'Added: Support for GitLab'
-  integration_version: 6.0
+  version: 6.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-12-26'
   ticket_number: xxx
 - description: 'Added: Support for empty remote repositories (The integration will
     work even when no file is committed to the remote repository)'
-  integration_version: 6.0
+  version: 6.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-12-26'
   ticket_number: xxx
 - description: 'Updated: Code improvements'
-  integration_version: 6.0
+  version: 6.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-12-26'
   ticket_number: xxx
 - description: 'Updated: Integration Dependencies'
-  integration_version: 6.0
+  version: 6.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2021-12-26'
   ticket_number: xxx
 - description: Added support for proxy allowlist
-  integration_version: 7.0
+  version: 7.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2022-02-08'
   ticket_number: xxx
 - description: 'IMPORTANT NOTICE: Push and Pull Environment name was changed to push
     and pull content'
-  integration_version: 8.0
+  version: 8.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2022-05-25'
   ticket_number: xxx
 - description: 'Updated: Support for the new BlockList API'
-  integration_version: 8.0
+  version: 8.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2022-05-25'
   ticket_number: xxx
 - description: 'Updated: Better SSH Support'
-  integration_version: 8.0
+  version: 8.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2022-05-25'
   ticket_number: xxx
 - description: 'Updated: Dependencies - (dulwich, urllib3, cryptography, paramiko
     and jinja)'
-  integration_version: 8.0
+  version: 8.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2022-05-25'
   ticket_number: xxx
 - description: Fix for pushing and pulling playbooks
-  integration_version: 9.0
+  version: 9.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2022-10-26'
   ticket_number: xxx
 - description: 'Fixed: Pushing content will no longer creates unnecessary commits
     because of timestamps changes'
-  integration_version: 10.0
+  version: 10.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-01-15'
   ticket_number: xxx
 - description: 'Fixed: Allow adding files to the Integration directory'
-  integration_version: 10.0
+  version: 10.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-01-15'
   ticket_number: xxx
 - description: 'Updated: Parameter descriptions'
-  integration_version: 10.0
+  version: 10.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-01-15'
   ticket_number: xxx
 - description: 'Updated: Improved branch handling when switching branches or working
     outside remote HEAD'
-  integration_version: 10.0
+  version: 10.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-01-15'
   ticket_number: xxx
 - description: 'Updated: Dependencies - (dulwich: 0.20.45, paramiko: 2.12.0, jinja2:
     3.1.2, packaging: 23.0)'
-  integration_version: 10.0
+  version: 10.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-01-15'
   ticket_number: xxx
 - description: 'Updated: Under the hood improvements'
-  integration_version: 10.0
+  version: 10.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-01-15'
   ticket_number: xxx
 - description: 'Fixed: Pulling playbooks with similar name'
-  integration_version: 11.0
+  version: 11.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-03-13'
   ticket_number: xxx
 - description: 'Fixed: Pulling playbooks with missing folders'
-  integration_version: 11.0
+  version: 11.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-03-13'
   ticket_number: xxx
 - description: 'Added: Support for parallel actions'
-  integration_version: 11.0
+  version: 11.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-03-13'
   ticket_number: xxx
 - description: 'Updated: Removed unused APIs'
-  integration_version: 11.0
+  version: 11.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-03-13'
   ticket_number: xxx
 - description: 'Fixed: Issue when pulling playbooks'
-  integration_version: 12.0
+  version: 12.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-06-06'
   ticket_number: xxx
 - description: 'Fixed: Pulling actions and jobs with the same name'
-  integration_version: 12.0
+  version: 12.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-06-06'
   ticket_number: xxx
 - description: 'Fixed: Support for entity selection within parallel actions'
-  integration_version: 12.0
+  version: 12.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-06-06'
   ticket_number: xxx
 - description: 'Fixed: Broken root and playbooks README.md when changing branches'
-  integration_version: 12.0
+  version: 12.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-06-06'
   ticket_number: xxx
 - description: 'Updated: Readme addons for playbooks is now based on playbook name
     and not identifier'
-  integration_version: 12.0
+  version: 12.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-06-06'
@@ -210,120 +210,120 @@
 - description: 'Fixed: Added an option to include involved blocks when pushing or
     pulling a playbook. To guarantee a link between playbooks and blocks, It is recommended
     to only specify the playbook name and set this flag to True'
-  integration_version: 13.0
+  version: 13.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-07-15'
   ticket_number: xxx
 - description: 'Fixed: Pull Content stops when pulling playbooks'
-  integration_version: 14.0
+  version: 14.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-07-19'
   ticket_number: xxx
 - description: 'Added: Support for simulated cases'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Added: Option to override the commit author from all pushing jobs'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Added: Option to disable the automatic update of the root README file
     (Available from the metadata file)'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Fixed: Commits were authored and committed with a different name'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Fixed: Pulled playbook steps are missing an integration instance'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Fixed: Custom code from commercial integrations is not updated if
     py file is directly edited'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Updated: system_version is written to the metadata file on every push
     operation'
-  integration_version: 15.0
+  version: 15.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-15'
   ticket_number: xxx
 - description: 'Fixed: Hotfix for commit author in push jobs'
-  integration_version: 16.0
+  version: 16.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-08-21'
   ticket_number: xxx
 - description: 'Fixed: Performance issues when working with large repositories'
-  integration_version: 17.0
+  version: 17.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2023-10-25'
   ticket_number: xxx
 - description: 'Fixed: Mismatching playbook step ids when pulling playbooks'
-  integration_version: 18.0
+  version: 18.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-02-06'
   ticket_number: '321093992'
 - description: 'Fixed: Pull Content resets case title settings'
-  integration_version: 18.0
+  version: 18.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-02-06'
   ticket_number: '311180239'
 - description: 'Fixed: Ping action fails when the remote repository is empty'
-  integration_version: 18.0
+  version: 18.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-02-06'
   ticket_number: xxx
 - description: 'Updated: A local user is no longer required to run GitSync'
-  integration_version: 18.0
+  version: 18.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-02-06'
   ticket_number: '311180086'
 - description: 'Updated: Verify SSL is now set to True by default'
-  integration_version: 18.0
+  version: 18.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-02-06'
   ticket_number: xxx
 - description: 'Fixed: Issue when pulling playbooks'
-  integration_version: 19.0
+  version: 19.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-02-12'
   ticket_number: xxx
 - description: GitSync - Updated integration's descriptions to reflect renaming to
     Google SecOps.
-  integration_version: 20.0
+  version: 20.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-04-25'
   ticket_number: '332545706'
 - description: 'Updated: Instead of cloning the entire repository, GitSync now creates
     a shallow clone with a depth of 1'
-  integration_version: 21.0
+  version: 21.0
   item_name: GitManager
   item_type: Manager
   publish_time: '2024-07-07'
@@ -331,26 +331,26 @@
 - description: 'GitSync - Important - Updated the integration code to work with Python
     version 3.11. To ensure compatibility and avoid disruptions, follow the upgrade
     best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 22.0
+  version: 22.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-07-07'
   ticket_number: ''
 - description: GitSync Integration - Integration logic improvements for better handling
     of playbooks and blocks updates.
-  integration_version: 23.0
+  version: 23.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-07-07'
   ticket_number: '365514107'
 - description: GitSync Integration - Updated handling of local repository.
-  integration_version: 24.0
+  version: 24.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-11-13'
   ticket_number: '375644653'
 - description: GitSync Integration - Support Playbooks with Environment Groups
-  integration_version: 24.0
+  version: 24.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-11-13'
@@ -358,135 +358,135 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 25.0
+  version: 25.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Fixed SSH authentication issue
-  integration_version: 26.0
+  version: 26.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-01-05'
   ticket_number: ''
 - description: Integration - Added ability to provide SOAR Username and Password parameters
     for restricted SOAR playbook access.
-  integration_version: 27.0
+  version: 27.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-04-02'
   ticket_number: '401298415'
 - description: Integration - Improved Bitbucket token authorization handling.
-  integration_version: 28.0
+  version: 28.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-04-16'
   ticket_number: '407526909'
 - description: Improvements and bug fixes.
-  integration_version: 29.0
+  version: 29.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-06-04'
   ticket_number: '422166168'
 - description: Pull Content, Push Content, Pull Playbook, Push Playbook - Updated
     logic to save playbooks with instance name.
-  integration_version: 30.0
+  version: 30.0
   item_name: Pull Content, Push Content, Pull Playbook, Push Playbook
   item_type: Jobs
   publish_time: '2025-06-30'
   ticket_number: '418743078'
 - description: Git push Bug fix.
-  integration_version: 31.0
+  version: 31.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-07-08'
   ticket_number: '430005872'
 - description: Git pull bug for playbooks with loops
-  integration_version: 32.0
+  version: 32.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-07-16'
   ticket_number: '428703982'
 - description: Minor dependency fixes
-  integration_version: 33.0
+  version: 33.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-07-20'
   ticket_number: '432139863'
 - description: dependency cleanup on close
-  integration_version: 34.0
+  version: 34.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-07-31'
   ticket_number: xxx
 - description: Bug Fix in Push Integration action
-  integration_version: 35.0
+  version: 35.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-08-03'
   ticket_number: '434972629'
 - description: Update dependency
-  integration_version: 36.0
+  version: 36.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-08-04'
   ticket_number: '432139863'
 - description: Bug fix in fetching integration instance id by name
-  integration_version: 37.0
+  version: 37.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-08-06'
   ticket_number: '436327198'
 - description: Log improvement
-  integration_version: 38.0
+  version: 38.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2025-08-13'
   ticket_number: xxx
 - description: Integration - Redact values or password type parameters in readmes.
-  integration_version: 39.0
+  version: 39.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-08-29'
   ticket_number: '441711132'
 - description: Bug fix - now failing job in case of git push failure
-  integration_version: 40.0
+  version: 40.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-09-14'
   ticket_number: '438790199'
 - description: Bug fix - Fix errors in pull playbook containing parallel steps when name is similar to parent container
-  integration_version: 41.0
+  version: 41.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-10-09'
   ticket_number: '445445375'
 - description: Bug fix - Add fingerprint checks for git server
-  integration_version: 42.0
+  version: 42.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2025-10-15'
   ticket_number: '442360175'
 - description: Push Playbook Job - Updated the description management logic.
-  integration_version: 43.0
+  version: 43.0
   item_name: GitSync
   item_type: Jobs
   publish_time: '2026-01-07'
   ticket_number: '463991564'
 - description: Updated integration metadata.
-  integration_version: 44.0
+  version: 44.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2026-03-18'
   ticket_number: ''
 - description: Pull Playbook - Updated fallback assignment mechanism.
-  integration_version: 45.0
+  version: 45.0
   item_name: Pull Playbook
   item_type: Jobs
   publish_time: '2026-04-22'
   ticket_number: '461900756'
 - description: Remap playbook view roles by name to destination IDs in jobs.
-  integration_version: 46.0
+  version: 46.0
   item_name: GitSync
   item_type: Integration
   publish_time: '2026-04-27'

--- a/content/response_integrations/power_ups/image_utilities/release_notes.yaml
+++ b/content/response_integrations/power_ups/image_utilities/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: New Integration Added - Image Utilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Image Utilities
   item_type: Integration
   new: true
   publish_time: '2025-12-10'
   ticket_number: '446642561, 446642280'
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Image Utilities
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/insights/release_notes.yaml
+++ b/content/response_integrations/power_ups/insights/release_notes.yaml
@@ -1,23 +1,23 @@
 - description: NEW! Insights integration to power up playbook capabilities.
-  integration_version: 2.0
+  version: 2.0
   item_name: Insights
   item_type: Integration
   ticket_number: xxx
 - description: Update! Create Entity Insight From JSON - Brackets have been removed
     from output and insights are enabled.
-  integration_version: 2.0
+  version: 2.0
   item_name: Insights
   item_type: Integration
   ticket_number: xxx
 - description: Update! Create Entity Insight From Enrichment - Now pulls additional
     enrichment data.
-  integration_version: 3.0
+  version: 3.0
   item_name: Create Entity Insight from Enrichment
   item_type: Action
   ticket_number: xxx
 - description: Insights - Updated integration's descriptions to reflect renaming to
     Google SecOps.
-  integration_version: 4.0
+  version: 4.0
   item_name: Insights
   item_type: Integration
   publish_time: '2024-04-25'
@@ -25,13 +25,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: Insights
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: Insights
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/lists/release_notes.yaml
+++ b/content/response_integrations/power_ups/lists/release_notes.yaml
@@ -1,29 +1,29 @@
 - description: NEW! Lists integration to facilitate managing custom lists within Siemplify.
-  integration_version: 1.0
+  version: 1.0
   item_name: Lists
   item_type: Integration
   ticket_number: xxx
 - description: UPDATE! Now supports all Siemplify versions.
-  integration_version: 2.0
+  version: 2.0
   item_name: Is String In Custom List
   item_type: Action
   publish_time: '2021-06-09'
   ticket_number: xxx
 - description: UPDATE! Now supports all Siemplify versions.
-  integration_version: 2.0
+  version: 2.0
   item_name: Remove String from Custom List
   item_type: Action
   publish_time: '2021-06-09'
   ticket_number: xxx
 - description: UPDATE! Now supports all Siemplify versions.
-  integration_version: 2.0
+  version: 2.0
   item_name: Add String to Custom List
   item_type: Action
   publish_time: '2021-06-09'
   ticket_number: xxx
 - description: New! Search Custom List - Search for a string in a custom list or get
     all custom list values if no search query is provided.
-  integration_version: 3.0
+  version: 3.0
   item_name: Search Custom List
   item_type: Action
   publish_time: '2023-01-25'
@@ -31,21 +31,21 @@
   new: true
 - description: New! Search Environment Custom List - Search for a string in an environment's
     custom list or get all custom list values if no search query is provided.
-  integration_version: 4.0
+  version: 4.0
   item_name: Search Environment Custom List
   item_type: Action
   publish_time: '2023-08-28'
   ticket_number: xxx
   new: true
 - description: Lists - Security Enhancements.
-  integration_version: 5.0
+  version: 5.0
   item_name: Lists
   item_type: Integration
   publish_time: '2024-02-08'
   ticket_number: '315941503'
 - description: Lists - Updated integration's descriptions to reflect renaming to Google
     SecOps.
-  integration_version: 6.0
+  version: 6.0
   item_name: Lists
   item_type: Integration
   publish_time: '2024-04-25'
@@ -53,43 +53,43 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 7.0
+  version: 7.0
   item_name: Lists
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 8.0
+  version: 8.0
   item_name: Lists
   item_type: Integration
   publish_time: '2025-07-16'
   ticket_number: '430251231'
 - description: Integration - TIPCommon update.
-  integration_version: 9.0
+  version: 9.0
   item_name: Lists
   item_type: Integration
   publish_time: '2025-11-05'
   ticket_number: '448073014'
 - description: Fix - Behaviour of Search Custom Lists from exact match to contains.
-  integration_version: 10.0
+  version: 10.0
   item_name: Lists
   item_type: Integration
   publish_time: '2025-12-09'
   ticket_number: ''
 - description: Add String to Custom List, Remove String from Custom List - Refactored the code to work with updated API.
-  integration_version: 11.0
+  version: 11.0
   item_name: Lists
   item_type: Integration
   publish_time: '2025-12-24'
   ticket_number: '458248675'
 - description: Integration - Updated Dependencies.
-  integration_version: 12.0
+  version: 12.0
   item_name: Lists
   item_type: Integration
   publish_time: '2026-02-04'
   ticket_number: '477008157'
 - description: Updated integration metadata.
-  integration_version: 13.0
+  version: 13.0
   item_name: Lists
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/template_engine/release_notes.yaml
+++ b/content/response_integrations/power_ups/template_engine/release_notes.yaml
@@ -1,7 +1,7 @@
 - description: ' Added a new parameter named "Jinja" to "Render Template" action.
     This parameter can be used instead of the Template parameter to store the Jinja
     code that will be rendered.'
-  integration_version: 3.0
+  version: 3.0
   item_name: Render Template
   item_type: Action
   publish_time: '2021-01-17'
@@ -9,70 +9,70 @@
 - description: ' Added a new parameter named "Include Case Data" to "Render Template"
     action. When enabled, adds entity attributes and event data to the input_json
     object.'
-  integration_version: 4.0
+  version: 4.0
   item_name: Render Template
   item_type: Action
   publish_time: '2021-05-04'
   ticket_number: xxx
 - description: Fixed bug in Render Template Action.
-  integration_version: 5.0
+  version: 5.0
   item_name: Render Template
   item_type: Action
   publish_time: '2021-05-06'
   ticket_number: xxx
 - description: 'Entity Insight now supports all the filters Render Template supports.
     Added support for {{ entity.ATTRIBUTE }}. '
-  integration_version: 6.0
+  version: 6.0
   item_name: Entity Insight
   item_type: Action
   publish_time: '2021-05-16'
   ticket_number: xxx
 - description: UPDATE! Support for removing all HTML br tags from the rendered template.  Support
     for disabling the creation of insights.
-  integration_version: 8.0
+  version: 8.0
   item_name: Entity Insight
   item_type: Action
   publish_time: '2021-06-09'
   ticket_number: xxx
 - description: Locked Render Template action.
-  integration_version: 9.0
+  version: 9.0
   item_name: Render Template
   item_type: Action
   publish_time: '2021-06-09'
   ticket_number: xxx
 - description: Updated Jinja2 to 3.0.1
-  integration_version: 10.0
+  version: 10.0
   item_name: Render Template
   item_type: Action
   publish_time: '2021-06-30'
   ticket_number: xxx
 - description: Updated dependencies
-  integration_version: 11.0
+  version: 11.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2021-07-03'
   ticket_number: xxx
 - description: Updated Filters
-  integration_version: 12.0
+  version: 12.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2021-10-29'
   ticket_number: xxx
 - description: Updated SVG
-  integration_version: 13.0
+  version: 13.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2021-11-24'
   ticket_number: xxx
 - description: Added support for list entity results
-  integration_version: 14.0
+  version: 14.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2022-02-23'
   ticket_number: xxx
 - description: New Action! Render Template from Array.  The action will loop through
     a list and apply the template to each item.
-  integration_version: 15.0
+  version: 15.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2022-12-15'
@@ -81,13 +81,13 @@
     CustomFilters, it will load in those filters and make them available within the
     template.  A manager named CustomJinjaFilters has been included and can be used
     as a template. '
-  integration_version: 15.0
+  version: 15.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2022-12-15'
   ticket_number: xxx
 - description: Fixed Render Template - Include case data parameter description
-  integration_version: 16.0
+  version: 16.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2023-08-15'
@@ -95,31 +95,31 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 17.0
+  version: 17.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration dependencies.
-  integration_version: 18.0
+  version: 18.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2025-04-24'
   ticket_number: '413275498,409615534'
 - description: Render Template, Render Template from Array - Added Predefined widgets.
-  integration_version: 19.0
+  version: 19.0
   item_name: Render Template, Render Template from Array
   item_type: Widget
   publish_time: '2025-12-10'
   ticket_number: '448058502'
 - description: Integration - Updated Dependencies.
-  integration_version: 20.0
+  version: 20.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2026-01-07'
   ticket_number: '467333051'
 - description: Updated integration metadata.
-  integration_version: 21.0
+  version: 21.0
   item_name: TemplateEngine
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/power_ups/tools/release_notes.yaml
+++ b/content/response_integrations/power_ups/tools/release_notes.yaml
@@ -1,150 +1,150 @@
 - description: NEW! Tools integration to power up playbook capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Tools
   item_type: Integration
   ticket_number: xxx
 - description: New! Update Case description action.
-  integration_version: 2.0
+  version: 2.0
   item_name: Update Case Description
   item_type: Action
   publish_time: '2020-11-05'
   ticket_number: xxx
 - description: New! Get Siemplify users action.
-  integration_version: 2.0
+  version: 2.0
   item_name: Get Siemplify Users
   item_type: Action
   publish_time: '2020-11-05'
   ticket_number: xxx
 - description: New! Create Entities with Separator action.
-  integration_version: 3.0
+  version: 3.0
   item_name: Create Entities with Separator
   item_type: Action
   publish_time: '2020-11-19'
   ticket_number: xxx
 - description: Bug fixed in Create Entities with Separator.
-  integration_version: 4.0
+  version: 4.0
   item_name: Create Entities with Separator
   item_type: Action
   publish_time: '2020-11-19'
   ticket_number: xxx
 - description: Bug fixed in Create Entities with Separator.
-  integration_version: 5.0
+  version: 5.0
   item_name: Create Entities with Separator
   item_type: Action
   publish_time: '2020-11-19'
   ticket_number: xxx
 - description: New! Lock Playbook action that will cause the playbook to pause until
     all playbooks from the previous alert are complete.
-  integration_version: 6.0
+  version: 6.0
   item_name: Lock Playbook
   item_type: Action
   publish_time: '2021-02-03'
   ticket_number: xxx
 - description: New! Create Entity with Relationships action.
-  integration_version: 7.0
+  version: 7.0
   item_name: Create Entity with Relationships
   item_type: Action
   publish_time: '2021-02-17'
   ticket_number: xxx
 - description: Bug fix in the Create Entity with Relationships action.
-  integration_version: 8.0
+  version: 8.0
   item_name: Create Entity with Relationships
   item_type: Action
   publish_time: '2021-02-21'
   ticket_number: xxx
 - description: Bug fix in Get Case Data Action - Fixes issue in 5.5.3 / 5.6 where
     insights are truncated at 2k characters.
-  integration_version: 9.0
+  version: 9.0
   item_name: Get Case Data
   item_type: Action
   publish_time: '2021-02-22'
   ticket_number: xxx
 - description: Bug fix in Lock Playbook Action.
-  integration_version: 10.0
+  version: 10.0
   item_name: Lock Playbook
   item_type: Action
   publish_time: '2021-03-29'
   ticket_number: xxx
 - description: Bug fix in Create Entity Relationships.
-  integration_version: 11.0
+  version: 11.0
   item_name: Create Entity Relationships
   item_type: Action
   publish_time: '2021-04-08'
   ticket_number: xxx
 - description: New! Close Case Based on Search job.
-  integration_version: 11.0
+  version: 11.0
   item_name: Close Case Based on Search
   item_type: Job
   publish_time: '2021-04-08'
   ticket_number: xxx
 - description: New! Get Email Templates action. Returns all of the email templates
     from the system.
-  integration_version: 12.0
+  version: 12.0
   item_name: Get Email Templates
   item_type: Action
   publish_time: '2021-05-04'
   ticket_number: xxx
 - description: New! Get Integration Instances. Gets all the defined integrations for
     an environment.
-  integration_version: 12.0
+  version: 12.0
   item_name: Get Integration Instances
   item_type: Action
   publish_time: '2021-05-04'
   ticket_number: xxx
 - description: New! Update Alert Score action. Used to keep track of the score of
     the alert.
-  integration_version: 13.0
+  version: 13.0
   item_name: Update Alert Score
   item_type: Action
   publish_time: '2021-05-16'
   ticket_number: xxx
 - description: Update - Create Siemplify Task to support Siemplify 6.0
-  integration_version: 14.0
+  version: 14.0
   item_name: Create Siemplify Task
   item_type: Action
   publish_time: '2021-05-26'
   ticket_number: xxx
 - description: New Action - Get Certificate Details
-  integration_version: 15.0
+  version: 15.0
   item_name: Get Certificate Details
   item_type: Action
   publish_time: '2021-07-14'
   ticket_number: xxx
 - description: New! DNS Lookup - Will perform DNS lookups on IPs and hostnames.
-  integration_version: 16.0
+  version: 16.0
   item_name: 'Get Certificate Details '
   item_type: Action
   publish_time: '2021-07-14'
   ticket_number: xxx
   new: true
 - description: Fixed Action - Get Certificate Details
-  integration_version: 17.0
+  version: 17.0
   item_name: Get Certificate Details
   item_type: Action
   publish_time: '2021-07-18'
   ticket_number: xxx
 - description: Added Dependency 'pyOpenSSL' to Tool
-  integration_version: 18.0
+  version: 18.0
   item_name: Tools
   item_type: Integration
   publish_time: '2021-07-18'
   ticket_number: xxx
 - description: 'Bug Fix: Create Entities with Separator did not respect the separator
     field.'
-  integration_version: 19.0
+  version: 19.0
   item_name: Create Entities with Separator
   item_type: Action
   publish_time: '2021-10-08'
   ticket_number: xxx
 - description: 'New! Delay Playbook V2: Now supports a CRON schedule.'
-  integration_version: 20.0
+  version: 20.0
   item_name: Delay Playbook V2
   item_type: Action
   publish_time: '2021-10-13'
   ticket_number: xxx
   new: true
 - description: 'New! Attach Playbook to Alert: Attach a playbook or block by a placeholder.'
-  integration_version: 21.0
+  version: 21.0
   item_name: Attach Playbook to Alert
   item_type: Action
   publish_time: '2021-10-27'
@@ -152,63 +152,63 @@
   new: true
 - description: 'New! Wait for Playbook to Complete: Pause a playbook until another
     playbook or block finishes.'
-  integration_version: 21.0
+  version: 21.0
   item_name: Wait for Playbook to Complete
   item_type: Action
   publish_time: '2021-10-27'
   ticket_number: xxx
   new: true
 - description: Update! Extract URL Domain fixed to return valid domains.
-  integration_version: 22.0
+  version: 22.0
   item_name: Extract URL Domain
   item_type: Action
   publish_time: '2021-10-28'
   ticket_number: xxx
 - description: Bug Fix! Extract URL Domain Fixed to add correct source_entity_type
-  integration_version: 23.0
+  version: 23.0
   item_name: Extract URL Domain
   item_type: Action
   publish_time: '2021-10-29'
   ticket_number: xxx
 - description: Update! Create Entity Relationships - Now supports adding enrichment.
-  integration_version: 24.0
+  version: 24.0
   item_name: Create Entity Relationships
   item_type: Action
   publish_time: '2021-11-02'
   ticket_number: xxx
 - description: Update! Update Alert Score - Updated to match platform SDK.
-  integration_version: 25.0
+  version: 25.0
   item_name: Update Alert Score
   item_type: Action
   publish_time: '2021-11-29'
   ticket_number: xxx
 - description: Update! Set Context Values - Support for Global values.
-  integration_version: 26.0
+  version: 26.0
   item_name: Set Context Values
   item_type: Action
   publish_time: '2021-12-14'
   ticket_number: xxx
 - description: Update! Get Context Values - Support for Global values.
-  integration_version: 26.0
+  version: 26.0
   item_name: Get Context Values
   item_type: Action
   publish_time: '2021-12-14'
   ticket_number: xxx
 - description: Update! Get Context Values - Fix for missing keys.
-  integration_version: 27.0
+  version: 27.0
   item_name: Get Context Values
   item_type: Action
   publish_time: '2021-12-22'
   ticket_number: xxx
 - description: Update! Find First Alert - Support now for Siemplify 6.x
-  integration_version: 28.0
+  version: 28.0
   item_name: Find First Alert
   item_type: Action
   publish_time: '2022-01-14'
   ticket_number: xxx
 - description: New Action! Spell Check String - Checks the spelling of all words in
     a string and returns the accuracy.
-  integration_version: 30.0
+  version: 30.0
   item_name: Spell Check String
   item_type: Action
   publish_time: '2022-01-25'
@@ -216,7 +216,7 @@
   new: true
 - description: New Action! Look-A-Like Domains - Compare domain entities against the
     list of domains defined for the environment.
-  integration_version: 30.0
+  version: 30.0
   item_name: Look-A-Like Domains
   item_type: Action
   publish_time: '2022-01-25'
@@ -224,7 +224,7 @@
   new: true
 - description: Update Action! Create Entity Relationships - Added a new parameter
     'Separator' for separating multiple Entity Identifiers and Target Entity Identifiers.
-  integration_version: 30.0
+  version: 30.0
   item_name: Create Entity Relationships
   item_type: Action
   publish_time: '2022-01-25'
@@ -232,7 +232,7 @@
 - description: New Action! Add Alert Scoring Information - This action will add an
     entry to the alert scoring database. The scores can be used to determine overall
     severity of an alert. Optional tag added to case.
-  integration_version: 31.0
+  version: 31.0
   item_name: Add Alert Scoring Information
   item_type: Action
   publish_time: '2022-02-04'
@@ -241,7 +241,7 @@
 - description: New Action! Search Text - Search for the 'Search For' parameter in
     the input text or loop through the 'Search For Regex' list and find matches in
     the input text.
-  integration_version: 31.0
+  version: 31.0
   item_name: Search Text
   item_type: Action
   publish_time: '2022-02-04'
@@ -249,85 +249,85 @@
   new: true
 - description: FIX! Spell Check String - Fix to fail cleanly when input string is
     empty.
-  integration_version: 31.0
+  version: 31.0
   item_name: Spell Check String
   item_type: Action
   publish_time: '2022-01-25'
   ticket_number: xxx
 - description: FIX! Update Alert Score - Fix to work properly with an alert with existing
     score.
-  integration_version: 32.0
+  version: 32.0
   item_name: Update Alert Score
   item_type: Action
   publish_time: '2022-02-23'
   ticket_number: xxx
 - description: New Action! Check List Subset - Check if one list is a subset of another
     list.
-  integration_version: 33.0
+  version: 33.0
   item_name: Update Alert Score
   item_type: Action
   publish_time: '2022-02-23'
   ticket_number: xxx
 - description: Align Async actions to Siemplify 6.1
-  integration_version: 34.0
+  version: 34.0
   item_name: Update Alert Score
   item_type: Action
   publish_time: '2022-07-10'
   ticket_number: xxx
 - description: Update! Close Cases Based On Search - Support for SaaS.
-  integration_version: 35.0
+  version: 35.0
   item_name: Close Cases Based On Search
   item_type: Job
   publish_time: '2022-09-23'
   ticket_number: xxx
 - description: New Action! Append to Context Value
-  integration_version: 36.0
+  version: 36.0
   item_name: Append to Context Value
   item_type: action
   publish_time: '2022-10-14'
   ticket_number: xxx
 - description: Fix! Delay Playbook and Delay Playbook V2 updated to support platform
     changes.
-  integration_version: 37.0
+  version: 37.0
   item_name: Delay Playbook
   item_type: action
   publish_time: '2022-10-28'
   ticket_number: xxx
 - description: Fix! Delay Playbook and Delay Playbook V2 updated to support additional
     time formats.
-  integration_version: 38.0
+  version: 38.0
   item_name: Delay Playbook
   item_type: action
   publish_time: '2022-11-09'
   ticket_number: xxx
 - description: New Action! Attach a playbook to all alerts in the case.
-  integration_version: 39.0
+  version: 39.0
   item_name: Attach Playbook to All Case Alerts
   item_type: action
   publish_time: '2023-01-16'
   ticket_number: xxx
 - description: Fix! Append to Context Value - fixed bug when Scope set to 'Global'.
-  integration_version: 40.0
+  version: 40.0
   item_name: Append to Context Value
   item_type: action
   publish_time: '2023-02-07'
   ticket_number: xxx
 - description: Fix! Change Case Name - Would run on last alert if 'Only if First Alert'
     selected.  Fix to run correctly on first alert.
-  integration_version: 41.0
+  version: 41.0
   item_name: Change Case Name
   item_type: action
   publish_time: '2023-02-10'
   ticket_number: xxx
 - description: Fix! Newer API for Close cases based on search
-  integration_version: 42.0
+  version: 42.0
   item_name: Close Cases Based On Search
   item_type: job
   publish_time: '2023-04-20'
   ticket_number: xxx
 - description: New! Convert into Simulated case - Converts a case into a simulated
     case that can be loaded into the SOAR platform.
-  integration_version: 43.0
+  version: 43.0
   item_name: Convert into Simulated Case
   item_type: action
   publish_time: '2023-05-16'
@@ -335,68 +335,68 @@
   new: true
 - description: New! Tag Untouched Cases - Tags cases that have not been modified within
     a threshold.
-  integration_version: 44.0
+  version: 44.0
   item_name: Tag Untouched Cases
   item_type: job
   publish_time: '2023-05-17'
   ticket_number: xxx
   new: true
 - description: Update! DNS Lookup now supports looking up multiple DNS record types.
-  integration_version: 45.0
+  version: 45.0
   item_name: DNS Lookup
   item_type: action
   publish_time: '2023-05-18'
   ticket_number: xxx
 - description: Update! Create Entity Relationships now works with lowercase target
     entities.
-  integration_version: 46.0
+  version: 46.0
   item_name: Create Entity Relationships
   item_type: action
   publish_time: '2023-06-05'
   ticket_number: xxx
 - description: Update! Convert Into Simulated Case - Fixed bug that pushed all simulated
     cases to the case wall.
-  integration_version: 47.0
+  version: 47.0
   item_name: Convert Into Simulated Case
   item_type: action
   publish_time: '2023-07-31'
   ticket_number: xxx
 - description: Update! Find First Alert - Change from using alert.detected_time to
     alert.creation_time to determine first alert.
-  integration_version: 48.0
+  version: 48.0
   item_name: Find First Alert
   item_type: action
   publish_time: '2023-08-22'
   ticket_number: xxx
 - description: New! Get Case SLA - Gets the Case SLA and critical SLA in multiple
     formats.
-  integration_version: 49.0
+  version: 49.0
   item_name: Get Case SLA
   item_type: action
   publish_time: '2023-11-26'
   ticket_number: xxx
   new: true
 - description: Get Case Data - Added support for Case Fields Filter parameter.
-  integration_version: 50.0
+  version: 50.0
   item_name: Get Case Data
   item_type: Action
   publish_time: '2024-01-01'
   ticket_number: '317348943'
 - description: Fix! Create Entity Relationships - fix handling for case with 0 target
     entities
-  integration_version: 51.0
+  version: 51.0
   item_name: Create Entity Relationships
   item_type: Action
   publish_time: '2024-01-05'
   ticket_number: '318191155'
 - description: Get Case Data - Fields Filter fixes and improvements.
-  integration_version: 52.0
+  version: 52.0
   item_name: Get Case Data
   item_type: Action
   publish_time: '2024-01-11'
   ticket_number: '317348943'
 - description: New Action Added - Unflatten JSON.
-  integration_version: 53.0
+  version: 53.0
   item_name: Unflatten JSON
   item_type: Action
   publish_time: '2024-01-15'
@@ -404,40 +404,40 @@
   new: true
 - description: Append To Context Value - Fixed repeated values when appending to a
     case scope
-  integration_version: 54.0
+  version: 54.0
   item_name: Append To Context Value
   item_type: Action
   publish_time: '2024-02-29'
   ticket_number: '296349335'
 - description: Create Siemplify Task - Replace deprecated get_system_info usage
-  integration_version: 55.0
+  version: 55.0
   item_name: Create Siemplify Task
   item_type: Action
   publish_time: '2024-04-10'
   ticket_number: '329632417'
 - description: Create Siemplify Task - Fixed an issue when marking task as done in
     the case wall
-  integration_version: 55.0
+  version: 55.0
   item_name: Create Siemplify Task
   item_type: Action
   publish_time: '2024-04-10'
   ticket_number: '327072293'
 - description: Add Alert Scoring Information - Removed unused case tag parameter
-  integration_version: 55.0
+  version: 55.0
   item_name: Add Alert Scoring Information
   item_type: Action
   publish_time: '2024-04-10'
   ticket_number: '308220041'
 - description: Create Entity Relationships - REGRESSIVE! - Action was updated to ignore
     case while creating entity relationship.
-  integration_version: 56.0
+  version: 56.0
   item_name: Create Entity Relationships
   item_type: Action
   publish_time: '2024-06-13'
   ticket_number: '307830012'
   regressive: true
 - description: Lock Playbook, Wait for Playbook to Complete - Action updates.
-  integration_version: 57.0
+  version: 57.0
   item_name: Lock Playbook, Wait for Playbook to Complete
   item_type: Action
   publish_time: '2024-09-25'
@@ -445,32 +445,32 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 58.0
+  version: 58.0
   item_name: Tools
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Tools Integration - New action added - Delay Playbook Synchronous
-  integration_version: 59.0
+  version: 59.0
   item_name: Delay Playbook Synchronous
   item_type: Action
   publish_time: '2025-01-22'
   ticket_number: '389857373'
   new: true
 - description: Attach Playbook To Alert - Expanded capabilities of the action.
-  integration_version: 60.0
+  version: 60.0
   item_name: Attach Playbook to Alert
   item_type: Action
   publish_time: '2025-02-05'
   ticket_number: '371570812'
 - description: Spell Check String - Updated input handling.
-  integration_version: 61.0
+  version: 61.0
   item_name: Spell Check String
   item_type: Action
   publish_time: '2025-02-19'
   ticket_number: '395041566'
 - description: Get Certificate Details - Updated support for TLS.
-  integration_version: 62.0
+  version: 62.0
   item_name: Get Certificate Details
   item_type: Action
   publish_time: '2025-03-19'
@@ -479,33 +479,33 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 63.0
+  version: 63.0
   item_name: Tools
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Extract URL Domain - Fixed Extract URL domain with subdomains
-  integration_version: 64.0
+  version: 64.0
   item_name: Extract URL Domain
   item_type: Action
   publish_time: '2025-04-16'
   ticket_number: '404951078'
 - description: Extract URL Domain - Updated handling of domains.
-  integration_version: 65.0
+  version: 65.0
   item_name: Extract URL Domain
   item_type: Action
   publish_time: '2025-06-18'
   ticket_number: '419113107'
 - description: Set Context Value, Get Context Value - Fix issues with parameters DDL
     values.
-  integration_version: 66.0
+  version: 66.0
   item_name: Set Context Value, Get Context Value
   item_type: Action
   publish_time: '2025-06-26'
   ticket_number: '426240792'
 - description: REGRESSIVE! Get Original Alert Json - Updated sample json values.
-  integration_version: 67.0
+  version: 67.0
   item_name: Get Original Alert Json
   item_type: Action
   publish_time: '2025-08-13'
@@ -513,80 +513,80 @@
   regressive: true
 - description: Get Certificate Details - Security and Reliability Update for SSL Certificate
     Handling.
-  integration_version: 68.0
+  version: 68.0
   item_name: Get Certificate Details
   item_type: Action
   publish_time: '2025-08-03'
   ticket_number: '435106563'
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 68.0
+  version: 68.0
   item_name: Tools
   item_type: Integration
   publish_time: '2025-09-03'
   ticket_number: '432162390'
 - description: Get Integration Instances - Refactored the action.
-  integration_version: 70.0
+  version: 70.0
   item_name: Get Integration Instances
   item_type: Action
   publish_time: '2025-12-10'
   ticket_number: '464366166'
 - description: Create Siemplify Task - Added ability to provide explicit due date.
-  integration_version: 70.0
+  version: 70.0
   item_name: Tools
   item_type: Action
   publish_time: '2025-12-10'
   ticket_number: '462389325'
 - description: Lock Playbook, Wait for Playbook to Complete - Updated playbook status tracking mechanism.
-  integration_version: 70.0
+  version: 70.0
   item_name: Tools
   item_type: Action
   publish_time: '2025-12-10'
   ticket_number: '461424633'
 - description: Re-Attach Playbook - Refactored the action.
-  integration_version: 71.0
+  version: 71.0
   item_name: Tools
   item_type: Action
   publish_time: '2025-12-11'
   ticket_number: '467831438'
 - description: Integration - Refactored the code to work with updated API.
-  integration_version: 72.0
+  version: 72.0
   item_name: Tools
   item_type: Integration
   publish_time: '2025-12-24'
   ticket_number: '458248341'
 - description: REGRESSIVE! Get Case Data - Refactored the code to work with updated API.
-  integration_version: 73.0
+  version: 73.0
   item_name: Get Case Data
   item_type: Action
   publish_time: '2026-01-07'
   ticket_number: '455834066'
   regressive: true
 - description: Integration - Updated Dependencies.
-  integration_version: 74.0
+  version: 74.0
   item_name: Tools
   item_type: Integration
   publish_time: '2026-02-04'
   ticket_number: '477008157'
 - description: Close Cases Based On Search - Removed legacy parameters from the job configuration.
-  integration_version: 75.0
+  version: 75.0
   item_name: Close Cases Based On Search
   item_type: Job
   publish_time: '2026-02-25'
   ticket_number: '481318522'
 - description: Updated integration metadata.
-  integration_version: 76.0
+  version: 76.0
   item_name: Tools
   item_type: Integration
   publish_time: '2026-03-18'
   ticket_number: ''
 - description: Get Email Templates - Updated the logic of templates processing.
-  integration_version: 77.0
+  version: 77.0
   item_name: Get Email Templates
   item_type: Action
   publish_time: '2026-03-26'
   ticket_number: '489654885'
 - description: Get Case Data - Added tags to the case data response.
-  integration_version: 78.0
+  version: 78.0
   item_name: Get Case Data
   item_type: Action
   publish_time: '2026-04-01'

--- a/content/response_integrations/third_party/community/abuse_ipdb/release_notes.yaml
+++ b/content/response_integrations/third_party/community/abuse_ipdb/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! Abuse IPDB Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Abuse IPDB
   item_type: Integration
   publish_time: '2020-12-17'
@@ -9,13 +9,13 @@
 
     - Fixed a bug due to not parsing create insight parameter as a bool, which caused
     the check to always return true.'
-  integration_version: 2.0
+  version: 2.0
   item_name: Abuse IPDB
   item_type: Integration
   publish_time: '2021-08-27'
   ticket_number: xxx
 - description: Updated Integration SVG
-  integration_version: 3.0
+  version: 3.0
   item_name: Abuse IPDB
   item_type: Integration
   publish_time: '2021-11-01'
@@ -23,13 +23,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: AbuseIPDB
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: AbuseIPDB
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/air_table/release_notes.yaml
+++ b/content/response_integrations/third_party/community/air_table/release_notes.yaml
@@ -1,47 +1,47 @@
 - description: NEW! Airtable Connector added to the integration.
-  integration_version: 9.0
+  version: 9.0
   item_name: AirTable Connector
   item_type: Connector
   publish_time: '2020-10-26'
   ticket_number: xxx
 - description: NEW! Delete All Records added to the Airtable integration.
-  integration_version: 9.0
+  version: 9.0
   item_name: Delete All Records
   item_type: Action
   publish_time: '2020-10-26'
   ticket_number: xxx
 - description: NEW! Get All Records added to the Airtable integration.
-  integration_version: 9.0
+  version: 9.0
   item_name: Get All Records
   item_type: Action
   publish_time: '2020-10-26'
   ticket_number: xxx
 - description: Fixed bug in Airtable Connector
-  integration_version: 10.0
+  version: 10.0
   item_name: AirTable Connector
   item_type: Connector
   publish_time: '2020-10-28'
   ticket_number: xxx
 - description: 'Added new Action: ''AddOrUpdate''.'
-  integration_version: 11.0
+  version: 11.0
   item_name: AirTable Action
   item_type: Action
   publish_time: '2021-07-08'
   ticket_number: xxx
 - description: Updated Airtable connector - added airtable record fields to event
-  integration_version: 12.0
+  version: 12.0
   item_name: Airtable connector
   item_type: Action
   publish_time: '2021-07-18'
   ticket_number: xxx
 - description: Updated the SVG Image
-  integration_version: 13.0
+  version: 13.0
   item_name: AirTable
   item_type: Integration
   publish_time: '2021-07-19'
   ticket_number: xxx
 - description: Fixed Bug in AddOrUpdate Action
-  integration_version: 14.0
+  version: 14.0
   item_name: AirTable
   item_type: Integration
   publish_time: '2021-08-09'
@@ -49,13 +49,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 15.0
+  version: 15.0
   item_name: AirTable
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 16.0
+  version: 16.0
   item_name: AirTable
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/arcanna_ai/release_notes.yaml
+++ b/content/response_integrations/third_party/community/arcanna_ai/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! ArcannaAI
-  integration_version: 1.0
+  version: 1.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2022-10-10'
   ticket_number: xxx
 - description: Logo updated
-  integration_version: 2.0
+  version: 2.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2022-10-14'
   ticket_number: xxx
 - description: REGRESSIVE! ArcannaAI - Revamp Integration
-  integration_version: 3.0
+  version: 3.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-06-23'
@@ -20,7 +20,7 @@
 - description: ArcannaAI - New Actions - Export full event, Get AI Job decision set,
     Trigger AI Model training, Send event to Arcanna, Get Arcanna decision, Update
     alert priority
-  integration_version: 3.0
+  version: 3.0
   item_name: Export full event, Get AI Job decision set, Trigger AI Model training,
     Send event to Arcanna, Get Arcanna decision, Update alert priority
   item_type: Action
@@ -29,7 +29,7 @@
   new: true
 - description: REMOVED! ArcannaAI - Removed Actions - Send Case To Arcanna, Await
     Arcanna Inference, Get Arcanna Case Response
-  integration_version: 3.0
+  version: 3.0
   item_name: Send Case To Arcanna, Await Arcanna Inference, Get Arcanna Case Response
   item_type: Action
   publish_time: '2024-06-23'
@@ -37,14 +37,14 @@
   removed: true
 - description: 'Removed the deprecated ''Send Event'' function and added three new
     ones: Send Case, Send Active Alert, and Send JSON Document.'
-  integration_version: 4.0
+  version: 4.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-11-04'
   ticket_number: xxx
   removed: true
 - description: Added accurate JSON samples for all functions.
-  integration_version: 4.0
+  version: 4.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-11-04'
@@ -52,14 +52,14 @@
   removed: true
 - description: Refactored the arcanna_client Manager to support the latest Arcanna
     REST API calls and clean up duplicated code.
-  integration_version: 4.0
+  version: 4.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-11-04'
   ticket_number: xxx
   removed: true
 - description: Added a new utils Manager for commonly used functions.
-  integration_version: 4.0
+  version: 4.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-11-04'
@@ -67,7 +67,7 @@
   removed: true
 - description: Fixed the issue with the SSL_Verification flag so it's now properly
     used in the requests.
-  integration_version: 4.0
+  version: 4.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-11-04'
@@ -76,7 +76,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2024-12-26'
@@ -85,20 +85,20 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 6.0
+  version: 6.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: ArcannaAI - Security Bug Fixes.
-  integration_version: 7.0
+  version: 7.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2025-04-09'
   ticket_number: '405144847'
 - description: Updated integration metadata.
-  integration_version: 8.0
+  version: 8.0
   item_name: ArcannaAI
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/asana/release_notes.yaml
+++ b/content/response_integrations/third_party/community/asana/release_notes.yaml
@@ -1,23 +1,23 @@
 - description: NEW! Asana Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Asana
   item_type: Integration
   publish_time: '2020-10-12'
   ticket_number: xxx
 - description: Fixed integration Manager.
-  integration_version: 2.0
+  version: 2.0
   item_name: Asana
   item_type: Manager
   publish_time: '2021-05-18'
   ticket_number: xxx
 - description: Fixed integration parameters.
-  integration_version: 3.0
+  version: 3.0
   item_name: Asana
   item_type: Integration
   publish_time: '2021-05-20'
   ticket_number: xxx
 - description: Fixed integration Manager + Mandatory Params
-  integration_version: 4.0
+  version: 4.0
   item_name: Asana
   item_type: Integration
   publish_time: '2021-09-20'
@@ -25,13 +25,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: Asana
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: Asana
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/aws_ec2/release_notes.yaml
+++ b/content/response_integrations/third_party/community/aws_ec2/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! AWS - EC2 Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: AWS - EC2
   item_type: Integration
   publish_time: '2020-12-28'
@@ -7,13 +7,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: AWS - EC2
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: AWS - EC2
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/azure_devops/release_notes.yaml
+++ b/content/response_integrations/third_party/community/azure_devops/release_notes.yaml
@@ -1,30 +1,30 @@
 - description: NEW! Azure DevOps Integration
-  integration_version: 1.0
+  version: 1.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2021-08-03'
   ticket_number: xxx
 - description: Fixed Azure DevOps Integration Actions Definitions
-  integration_version: 2.0
+  version: 2.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2021-08-08'
   ticket_number: xxx
 - description: Fixed Azure DevOps Integration Actions Definitions - IsAsync
-  integration_version: 3.0
+  version: 3.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2022-08-02'
   ticket_number: xxx
 - description: 'Security enhancements: Added request timeouts so the script wouldn''t
     stuck in case of server-side problems, code refactoring'
-  integration_version: 4.0
+  version: 4.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2022-12-12'
   ticket_number: xxx
 - description: Updated the publisher name
-  integration_version: 5.0
+  version: 5.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2023-01-09'
@@ -32,13 +32,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 6.0
+  version: 6.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 7.0
+  version: 7.0
   item_name: Azure DevOps
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/bandura_cyber/release_notes.yaml
+++ b/content/response_integrations/third_party/community/bandura_cyber/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! Bandura Cyber Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Bandura Cyber
   item_type: Integration
   publish_time: '2021-07-12'
   ticket_number: xxx
 - description: Update SVG Bandura Cyber Integration.
-  integration_version: 2.0
+  version: 2.0
   item_name: Bandura Cyber
   item_type: Integration
   publish_time: '2021-07-20'
   ticket_number: xxx
 - description: Update SVG Bandura Cyber Integration.
-  integration_version: 3.0
+  version: 3.0
   item_name: Bandura Cyber
   item_type: Integration
   publish_time: '2021-11-01'
@@ -19,7 +19,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Bandura Cyber
   item_type: Integration
   publish_time: '2024-12-26'
@@ -28,14 +28,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 5.0
+  version: 5.0
   item_name: Bandura Cyber
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: Bandura Cyber
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/be_secure/release_notes.yaml
+++ b/content/response_integrations/third_party/community/be_secure/release_notes.yaml
@@ -1,7 +1,7 @@
 - description: 'Updated the integration''s categories.
 
     '
-  integration_version: 8.0
+  version: 8.0
   item_name: beSECURE
   item_type: Integration
   publish_time: '2021-08-27'
@@ -9,13 +9,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 9.0
+  version: 9.0
   item_name: beSECURE
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 10.0
+  version: 10.0
   item_name: beSECURE
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/bitdefender_gravity_zone/release_notes.yaml
+++ b/content/response_integrations/third_party/community/bitdefender_gravity_zone/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Bitdefender GravityZone integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Bitdefender GravityZone
   item_type: Integration
   publish_time: '2021-03-31'
   ticket_number: xxx
 - description: Updated Integration SVG.
-  integration_version: 2.0
+  version: 2.0
   item_name: Bitdefender GravityZone
   item_type: Integration
   publish_time: '2021-11-01'
@@ -13,7 +13,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: Bitdefender GravityZone
   item_type: Integration
   publish_time: '2024-12-26'
@@ -22,14 +22,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 4.0
+  version: 4.0
   item_name: Bitdefender GravityZone
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Bitdefender GravityZone
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/chronicle_support_tools/release_notes.yaml
+++ b/content/response_integrations/third_party/community/chronicle_support_tools/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: New integration added - ChronicleSupportTools.
-  integration_version: 1.0
+  version: 1.0
   item_name: ChronicleSupportTools
   item_type: Integration
   publish_time: '2024-07-16'
   ticket_number: '340223061'
   new: true
 - description: Improvements and bug fixes.
-  integration_version: 2.0
+  version: 2.0
   item_name: ChronicleSupportTools
   item_type: Integration
   publish_time: '2024-09-04'
@@ -14,7 +14,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: ChronicleSupportTools
   item_type: Integration
   publish_time: '2024-12-26'
@@ -23,20 +23,20 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 4.0
+  version: 4.0
   item_name: ChronicleSupportTools
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Update Integration Display images.
-  integration_version: 5.0
+  version: 5.0
   item_name: ChronicleSupportTools
   item_type: Integration
   publish_time: '2025-07-23'
   ticket_number: '433768611'
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: ChronicleSupportTools
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/country_flags/release_notes.yaml
+++ b/content/response_integrations/third_party/community/country_flags/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - CountryFlags.
-  integration_version: 6.0
+  version: 6.0
   item_name: CountryFlags
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 7.0
+  version: 7.0
   item_name: CountryFlags
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,14 +17,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 8.0
+  version: 8.0
   item_name: CountryFlags
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 9.0
+  version: 9.0
   item_name: CountryFlags
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/cybersixgill_actionable_alerts/release_notes.yaml
+++ b/content/response_integrations/third_party/community/cybersixgill_actionable_alerts/release_notes.yaml
@@ -1,39 +1,39 @@
 - description: NEW! Cybersixgill Actionable Alerts.
-  integration_version: 1.0
+  version: 1.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2022-08-31'
   ticket_number: xxx
 - description: IsCustom set to false
-  integration_version: 2.0
+  version: 2.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2022-09-05'
   ticket_number: xxx
 - description: The latest edition includes the ability to consume alerts for MSSPs
     and multi-tenant organizations.
-  integration_version: 3.0
+  version: 3.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2022-11-14'
   ticket_number: xxx
 - description: Connector updated, dependencies bumped to the last versions, minor
     code refactoring
-  integration_version: 4.0
+  version: 4.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2023-01-16'
   ticket_number: xxx
 - description: Updated an internal pip version of sixgill client, allowing passing
     organization id to the integration
-  integration_version: 5.0
+  version: 5.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2023-02-28'
   ticket_number: xxx
 - description: Cybersixgill Actionable Alerts - Updated integration's descriptions
     to reflect renaming to Google SecOps.
-  integration_version: 6.0
+  version: 6.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2024-04-25'
@@ -41,13 +41,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 7.0
+  version: 7.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 8.0
+  version: 8.0
   item_name: Cybersixgill Actionable Alerts
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/cybersixgill_darkfeed/release_notes.yaml
+++ b/content/response_integrations/third_party/community/cybersixgill_darkfeed/release_notes.yaml
@@ -1,24 +1,24 @@
 - description: NEW! Cybersixgill Darkfeed Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2021-05-25'
   ticket_number: xxx
 - description: Updated SVG of Cybersixgill Darkfeed Integration.
-  integration_version: 2.0
+  version: 2.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2021-07-20'
   ticket_number: xxx
 - description: Updated SVG of Cybersixgill Darkfeed Integration.
-  integration_version: 3.0
+  version: 3.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2021-11-01'
   ticket_number: xxx
 - description: Cybersixgill Darkfeed - Updated integration's descriptions to reflect
     renaming to Google SecOps.
-  integration_version: 4.0
+  version: 4.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2024-04-25'
@@ -26,7 +26,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2024-12-26'
@@ -35,14 +35,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 6.0
+  version: 6.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 7.0
+  version: 7.0
   item_name: Cybersixgill Darkfeed
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/cybersixgill_darkfeed_enrichment/release_notes.yaml
+++ b/content/response_integrations/third_party/community/cybersixgill_darkfeed_enrichment/release_notes.yaml
@@ -1,18 +1,18 @@
 - description: NEW! Cybersixgill Darkfeed Enrichment.
-  integration_version: 1.0
+  version: 1.0
   item_name: Cybersixgill Darkfeed Enrichment
   item_type: Integration
   publish_time: '2021-10-21'
   ticket_number: xxx
 - description: Updated Integration SVG.
-  integration_version: 2.0
+  version: 2.0
   item_name: Cybersixgill Darkfeed Enrichment
   item_type: Integration
   publish_time: '2021-11-01'
   ticket_number: xxx
 - description: Cybersixgill Darkfeed Enrichment - Updated integration's descriptions
     to reflect renaming to Google SecOps.
-  integration_version: 3.0
+  version: 3.0
   item_name: Cybersixgill Darkfeed Enrichment
   item_type: Integration
   publish_time: '2024-04-25'
@@ -20,13 +20,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Cybersixgill Darkfeed Enrichment
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Cybersixgill Darkfeed Enrichment
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/cybersixgill_dve_enrichment/release_notes.yaml
+++ b/content/response_integrations/third_party/community/cybersixgill_dve_enrichment/release_notes.yaml
@@ -1,24 +1,24 @@
 - description: NEW! Cybersixgill DVE Enrichment Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Cybersixgill DVE Enrichment
   item_type: Integration
   publish_time: '2021-05-25'
   ticket_number: xxx
 - description: Fixed the enrichment action - Enrich CVE.
-  integration_version: 2.0
+  version: 2.0
   item_name: Cybersixgill DVE Enrichment
   item_type: Integration
   publish_time: '2021-09-09'
   ticket_number: xxx
 - description: Updated Integration SVG.
-  integration_version: 3.0
+  version: 3.0
   item_name: Cybersixgill DVE Enrichment
   item_type: Integration
   publish_time: '2021-11-01'
   ticket_number: xxx
 - description: Cybersixgill DVE Enrichment - Updated integration's descriptions to
     reflect renaming to Google SecOps.
-  integration_version: 4.0
+  version: 4.0
   item_name: Cybersixgill DVE Enrichment
   item_type: Integration
   publish_time: '2024-04-25'
@@ -26,13 +26,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: Cybersixgill DVE Enrichment
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: Cybersixgill DVE Enrichment
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/cybersixgill_dve_feed/release_notes.yaml
+++ b/content/response_integrations/third_party/community/cybersixgill_dve_feed/release_notes.yaml
@@ -1,18 +1,18 @@
 - description: NEW! Cybersixgill DVE Feed Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Cybersixgill DVE Feed
   item_type: Integration
   publish_time: '2021-05-25'
   ticket_number: xxx
 - description: Updated Integration SVG.
-  integration_version: 2.0
+  version: 2.0
   item_name: Cybersixgill DVE Feed
   item_type: Integration
   publish_time: '2021-11-01'
   ticket_number: xxx
 - description: Cybersixgill DVE Feed - Updated integration's descriptions to reflect
     renaming to Google SecOps.
-  integration_version: 3.0
+  version: 3.0
   item_name: Cybersixgill DVE Feed
   item_type: Integration
   publish_time: '2024-04-25'
@@ -20,7 +20,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Cybersixgill DVE Feed
   item_type: Integration
   publish_time: '2024-12-26'
@@ -29,14 +29,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 5.0
+  version: 5.0
   item_name: Cybersixgill DVE Feed
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: Cybersixgill DVE Feed
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/data_dog/release_notes.yaml
+++ b/content/response_integrations/third_party/community/data_dog/release_notes.yaml
@@ -1,41 +1,41 @@
 - description: NEW! DataDog Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: DataDog
   item_type: Integration
   publish_time: '2021-02-01'
   ticket_number: xxx
 - description: Default timestamp has been updated in the Connector.
-  integration_version: 2.0
+  version: 2.0
   item_name: DataDog Connector
   item_type: Connector
   publish_time: '2021-02-02'
   ticket_number: xxx
 - description: Bug fixed in the Connector.
-  integration_version: 3.0
+  version: 3.0
   item_name: DataDog Connector
   item_type: Connector
   publish_time: '2021-02-10'
   ticket_number: xxx
 - description: Bug fixed in the Connector test run.
-  integration_version: 4.0
+  version: 4.0
   item_name: DataDog Connector
   item_type: Connector
   publish_time: '2021-03-03'
   ticket_number: xxx
 - description: NEW! Get Event Details Action.
-  integration_version: 5.0
+  version: 5.0
   item_name: Get Event Details
   item_type: Action
   publish_time: '2021-03-03'
   ticket_number: xxx
 - description: Removed Manager.
-  integration_version: 6.0
+  version: 6.0
   item_name: Utils
   item_type: Manager
   publish_time: '2021-03-08'
   ticket_number: xxx
 - description: Fixed bug in the connector.
-  integration_version: 7.0
+  version: 7.0
   item_name: Datadog Connector
   item_type: Connector
   publish_time: '2021-06-17'
@@ -43,13 +43,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 8.0
+  version: 8.0
   item_name: DataDog
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 9.0
+  version: 9.0
   item_name: DataDog
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/docker_hub/release_notes.yaml
+++ b/content/response_integrations/third_party/community/docker_hub/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - Docker Hub.
-  integration_version: 11.0
+  version: 11.0
   item_name: Docker Hub
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 12.0
+  version: 12.0
   item_name: Docker Hub
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,14 +17,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 13.0
+  version: 13.0
   item_name: Docker Hub
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 14.0
+  version: 14.0
   item_name: Docker Hub
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/duo/release_notes.yaml
+++ b/content/response_integrations/third_party/community/duo/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! DUO integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: DUO
   item_type: Integration
   publish_time: '2021-09-09'
@@ -8,7 +8,7 @@
     from DUO's Authentication Logs that may not be present in all DUO tenants such
     as "access_device" which previously caused the action to fail if the value was
     missing.
-  integration_version: 2.0
+  version: 2.0
   item_name: DUO
   item_type: Integration
   publish_time: '2021-11-03'
@@ -16,13 +16,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: DUO
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: DUO
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/eclectic_iq/release_notes.yaml
+++ b/content/response_integrations/third_party/community/eclectic_iq/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New integration added - EclecticIQ.
-  integration_version: 1.0
+  version: 1.0
   item_name: EclecticIQ
   item_type: Integration
   publish_time: '2024-09-04'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: EclecticIQ
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,14 +17,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 3.0
+  version: 3.0
   item_name: EclecticIQ
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: EclecticIQ
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/flashpoint/release_notes.yaml
+++ b/content/response_integrations/third_party/community/flashpoint/release_notes.yaml
@@ -1,47 +1,47 @@
 - description: NEW! Flashpoint integratiom.
-  integration_version: 1.0
+  version: 1.0
   item_name: Flashpoint
   item_type: Integration
   publish_time: '2020-12-01'
   ticket_number: xxx
 - description: Bug fix in the query in the Flashpoint Connector.
-  integration_version: 2.0
+  version: 2.0
   item_name: Flashpoint - Compromised Credential Connector
   item_type: Connector
   publish_time: '2021-02-02'
   ticket_number: xxx
 - description: Limit result parameter has been added in the Flashpoint Connector.
-  integration_version: 3.0
+  version: 3.0
   item_name: Flashpoint - Compromised Credential Connector
   item_type: Connector
   publish_time: '2021-02-10'
   ticket_number: xxx
 - description: Bug fix in Event Priority in the Flashpoint Connector.
-  integration_version: 4.0
+  version: 4.0
   item_name: Flashpoint - Compromised Credential Connector
   item_type: Connector
   publish_time: '2021-02-10'
   ticket_number: xxx
 - description: Bug fix in script timeout error.
-  integration_version: 5.0
+  version: 5.0
   item_name: Flashpoint - Compromised Credential Connector
   item_type: Connector
   publish_time: '2021-04-05'
   ticket_number: xxx
 - description: Bug fix to support Proxy.
-  integration_version: 6.0
+  version: 6.0
   item_name: Flashpoint - Compromised Credential Connector
   item_type: Connector
   publish_time: '2021-05-20'
   ticket_number: xxx
 - description: Fixed Category
-  integration_version: 7.0
+  version: 7.0
   item_name: Flashpoint
   item_type: Integration
   publish_time: '2021-08-23'
   ticket_number: xxx
 - description: Fixed Category
-  integration_version: 8.0
+  version: 8.0
   item_name: Flashpoint
   item_type: Integration
   publish_time: '2021-08-23'
@@ -49,7 +49,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 9.0
+  version: 9.0
   item_name: Flashpoint
   item_type: Integration
   publish_time: '2024-12-26'
@@ -58,7 +58,7 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 10.0
+  version: 10.0
   item_name: Flashpoint
   item_type: Integration
   publish_time: '2025-03-24'
@@ -66,13 +66,13 @@
   regressive: true
 - description: Flashpoint - Compromised Credential Connector - Updated connector.def
     file.
-  integration_version: 11.0
+  version: 11.0
   item_name: Flashpoint - Compromised Credential Connector
   item_type: Connector
   publish_time: '2026-02-11'
   ticket_number: '479921578'
 - description: Updated integration metadata.
-  integration_version: 12.0
+  version: 12.0
   item_name: Flashpoint
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/full_contact/release_notes.yaml
+++ b/content/response_integrations/third_party/community/full_contact/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: SVG updated in Full Contact integration.
-  integration_version: 6.0
+  version: 6.0
   item_name: Full Contact
   item_type: Integration
   publish_time: '2021-07-29'
   ticket_number: xxx
 - description: Vulnerability fix - Enable server certificate validation on this SSL/TLS
     connection.
-  integration_version: 7.0
+  version: 7.0
   item_name: Enrich Entities, Ping
   item_type: Action
   publish_time: '2024-01-05'
@@ -14,7 +14,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 8.0
+  version: 8.0
   item_name: Full Contact
   item_type: Integration
   publish_time: '2024-12-26'
@@ -23,14 +23,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 9.0
+  version: 9.0
   item_name: Full Contact
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 10.0
+  version: 10.0
   item_name: Full Contact
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/google_docs/release_notes.yaml
+++ b/content/response_integrations/third_party/community/google_docs/release_notes.yaml
@@ -1,29 +1,29 @@
 - description: NEW! Google Docs Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2020-10-08'
   ticket_number: xxx
 - description: Fixed the Integration Manager in Google Docs
-  integration_version: 2.0
+  version: 2.0
   item_name: Google Docs
   item_type: Manager
   publish_time: '2021-04-29'
   ticket_number: xxx
 - description: Fixed the Category
-  integration_version: 3.0
+  version: 3.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2021-08-23'
   ticket_number: xxx
 - description: Fixed the Category
-  integration_version: 4.0
+  version: 4.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2021-08-29'
   ticket_number: xxx
 - description: Updated Integration SVG
-  integration_version: 5.0
+  version: 5.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2021-11-01'
@@ -31,19 +31,19 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 6.0
+  version: 6.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Fix a bug in integration initialization
-  integration_version: 7.0
+  version: 7.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2026-03-05'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 8.0
+  version: 8.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/google_drive/release_notes.yaml
+++ b/content/response_integrations/third_party/community/google_drive/release_notes.yaml
@@ -1,23 +1,23 @@
 - description: NEW! Google Drive Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Drive
   item_type: Integration
   publish_time: '2020-10-11'
   ticket_number: xxx
 - description: Fixed bug in Integration Manager
-  integration_version: 2.0
+  version: 2.0
   item_name: Google Drive
   item_type: Integration
   publish_time: '2020-11-30'
   ticket_number: xxx
 - description: Json credentials parameter was changed to password
-  integration_version: 3.0
+  version: 3.0
   item_name: Google Drive
   item_type: Integration
   publish_time: '2021-03-03'
   ticket_number: xxx
 - description: Changed Category
-  integration_version: 4.0
+  version: 4.0
   item_name: Google Drive
   item_type: Integration
   publish_time: '2021-08-23'
@@ -25,19 +25,19 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: Google Drive
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Fix a bug in integration initialization
-  integration_version: 6.0
+  version: 6.0
   item_name: Google Docs
   item_type: Integration
   publish_time: '2026-03-05'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 7.0
+  version: 7.0
   item_name: Google Drive
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/google_safe_browsing/release_notes.yaml
+++ b/content/response_integrations/third_party/community/google_safe_browsing/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! Google Safe Browsing Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Safe Browsing
   item_type: Integration
   publish_time: '2020-10-08'
   ticket_number: xxx
 - description: Updated SVG of Google Safe Browsing Integration.
-  integration_version: 2.0
+  version: 2.0
   item_name: Google Safe Browsing
   item_type: Integration
   publish_time: '2021-07-20'
   ticket_number: xxx
 - description: Updated SVG of Google Safe Browsing Integration.
-  integration_version: 3.0
+  version: 3.0
   item_name: Google Safe Browsing
   item_type: Integration
   publish_time: '2021-11-01'
@@ -19,13 +19,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Google Safe Browsing
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Google Safe Browsing
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/google_sheets/release_notes.yaml
+++ b/content/response_integrations/third_party/community/google_sheets/release_notes.yaml
@@ -1,66 +1,66 @@
 - description: NEW! Google Sheets Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Google Sheets
   item_type: Integration
   publish_time: '2020-10-13'
   ticket_number: xxx
 - description: Updated Ping action.
-  integration_version: 2.0
+  version: 2.0
   item_name: Ping
   item_type: Action
   publish_time: '2020-10-18'
   ticket_number: xxx
 - description: NEW! Add or Update Rows action.
-  integration_version: 3.0
+  version: 3.0
   item_name: Add or Update Rows
   item_type: Action
   publish_time: '2020-11-10'
   ticket_number: xxx
 - description: NEW! Update Rows action.
-  integration_version: 4.0
+  version: 4.0
   item_name: Update Rows
   item_type: Action
   publish_time: '2020-11-15'
   ticket_number: xxx
 - description: Fixed bug
-  integration_version: 5.0
+  version: 5.0
   item_name: Google Sheets
   item_type: Integration
   publish_time: '2020-12-01'
   ticket_number: xxx
 - description: New! Google Sheets connector
-  integration_version: 6.0
+  version: 6.0
   item_name: Google Sheet Connector
   item_type: Connector
   publish_time: '2021-05-05'
   ticket_number: xxx
 - description: Google Sheets connector
-  integration_version: 7.0
+  version: 7.0
   item_name: Google Sheet Connector
   item_type: Connector
   publish_time: '2021-06-30'
   ticket_number: xxx
 - description: Google Sheets update
-  integration_version: 8.0
+  version: 8.0
   item_name: Google Sheet New Action 'Get All'
   item_type: Action
   publish_time: '2021-07-08'
   ticket_number: xxx
 - description: Fixed Category
-  integration_version: 10.0
+  version: 10.0
   item_name: Google Sheet New Action 'Get All'
   item_type: Action
   publish_time: '2021-08-23'
   ticket_number: xxx
 - description: 'Action improvements: file system based authentication was replaced
     with in-memory'
-  integration_version: 11.0
+  version: 11.0
   item_name: Google Sheet New Action 'Get All'
   item_type: Action
   publish_time: '2023-02-27'
   ticket_number: xxx
 - description: Updated the handling of integration credentials.
-  integration_version: 12.0
+  version: 12.0
   item_name: Google Sheets
   item_type: Integration
   publish_time: '2024-07-10'
@@ -68,13 +68,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 13.0
+  version: 13.0
   item_name: Google Sheets
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 14.0
+  version: 14.0
   item_name: Google Sheets
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/goqr/release_notes.yaml
+++ b/content/response_integrations/third_party/community/goqr/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: New Integration Added - GOQR.
-  integration_version: 1.0
+  version: 1.0
   item_name: GOQR
   item_type: Integration
   publish_time: '2026-02-25'
   ticket_number: '439959400'
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: GOQR
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/hibob/release_notes.yaml
+++ b/content/response_integrations/third_party/community/hibob/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! Hibob integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Hibob
   item_type: Integration
   publish_time: '2020-08-30'
   ticket_number: xxx
 - description: Fixed description for action parameters
-  integration_version: 2.0
+  version: 2.0
   item_name: Hibob
   item_type: Integration
   publish_time: '2020-08-30'
   ticket_number: xxx
 - description: Updated Integration SVG
-  integration_version: 3.0
+  version: 3.0
   item_name: Hibob
   item_type: Integration
   publish_time: '2021-11-01'
@@ -19,13 +19,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Hibob
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Hibob
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/imgbb/release_notes.yaml
+++ b/content/response_integrations/third_party/community/imgbb/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Imgbb integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Imgbb
   item_type: Integration
   publish_time: '2020-10-04'
   ticket_number: xxx
 - description: Added SSL verification.
-  integration_version: 2.0
+  version: 2.0
   item_name: Imgbb
   item_type: Integration
   publish_time: '2020-10-04'
@@ -13,7 +13,7 @@
 - description: 'Updated the integration''s categories.
 
     '
-  integration_version: 3.0
+  version: 3.0
   item_name: Imgbb
   item_type: Integration
   publish_time: '2021-08-29'
@@ -21,13 +21,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Imgbb
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Imgbb
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/ipqs_fraud_and_risk_scoring/release_notes.yaml
+++ b/content/response_integrations/third_party/community/ipqs_fraud_and_risk_scoring/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! IPQS Fraud and Risk Scoring
-  integration_version: 2.0
+  version: 2.0
   item_name: IPQS Fraud and Risk Scoring
   item_type: Integration
   publish_time: '2022-06-30'
   ticket_number: xxx
 - description: Fix is_suspicious behaviour
-  integration_version: 3.0
+  version: 3.0
   item_name: IPQS Fraud and Risk Scoring
   item_type: Integration
   publish_time: '2023-08-22'
@@ -13,19 +13,19 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: IPQS Fraud and Risk Scoring
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Integration - Updated actions to show the available JSON Result.
-  integration_version: 5.0
+  version: 5.0
   item_name: IPQS Fraud and Risk Scoring
   item_type: Integration
   publish_time: '2025-11-03'
   ticket_number: '452989717'
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: IPQS Fraud and Risk Scoring
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/lacework/release_notes.yaml
+++ b/content/response_integrations/third_party/community/lacework/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! Lacework Integration
-  integration_version: 1.0
+  version: 1.0
   item_name: Lacework
   item_type: Integration
   publish_time: '2022-07-07'
@@ -7,13 +7,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: Lacework
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: Lacework
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/logzio/release_notes.yaml
+++ b/content/response_integrations/third_party/community/logzio/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Logz.io integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Logzio
   item_type: Integration
   publish_time: '2021-03-03'
   ticket_number: xxx
 - description: Updated the integration's categories.
-  integration_version: 2.0
+  version: 2.0
   item_name: Logzio
   item_type: Integration
   publish_time: '2021-08-27'
@@ -13,13 +13,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: Logzio
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: Logzio
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/luminar_iocs_and_leaked_credentials/release_notes.yaml
+++ b/content/response_integrations/third_party/community/luminar_iocs_and_leaked_credentials/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Luminar IOCs and Leaked Credentials integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Luminar IOCs and Leaked Credentials
   item_type: Integration
   publish_time: '2023-01-16'
   ticket_number: xxx
 - description: Publisher name updated
-  integration_version: 2.0
+  version: 2.0
   item_name: Luminar IOCs and Leaked Credentials
   item_type: Integration
   publish_time: '2023-01-16'
@@ -13,13 +13,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: Luminar IOCs and Leaked Credentials
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: Luminar IOCs and Leaked Credentials
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/marketo/release_notes.yaml
+++ b/content/response_integrations/third_party/community/marketo/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: New Actions - Marketo Integrations
-  integration_version: 13.0
+  version: 13.0
   item_name: Marketo
   item_type: Integration
   publish_time: '2021-08-05'
   ticket_number: xxx
 - description: Bug fix - Marketo Integrations
-  integration_version: 14.0
+  version: 14.0
   item_name: Marketo
   item_type: Integration
   publish_time: '2021-08-05'
   ticket_number: xxx
 - description: Bug fix - Request Campaign Action
-  integration_version: 15.0
+  version: 15.0
   item_name: Marketo
   item_type: Integration
   publish_time: '2021-08-22'
@@ -19,19 +19,19 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 16.0
+  version: 16.0
   item_name: Marketo
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Integration - Updated Dependencies.
-  integration_version: 17.0
+  version: 17.0
   item_name: Marketo
   item_type: Integration
   publish_time: '2026-01-07'
   ticket_number: '467333051'
 - description: Updated integration metadata.
-  integration_version: 18.0
+  version: 18.0
   item_name: Marketo
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/microsoft_graph_security_tools/release_notes.yaml
+++ b/content/response_integrations/third_party/community/microsoft_graph_security_tools/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Microsoft Graph Security Tools Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: MicrosoftGraphSecurityTools
   item_type: Integration
   publish_time: '2020-12-23'
   ticket_number: xxx
 - description: Fix! Add ability to use certificate auth.
-  integration_version: 2.0
+  version: 2.0
   item_name: MicrosoftGraphSecurityTools
   item_type: Integration
   publish_time: '2024-01-05'
@@ -13,13 +13,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: MicrosoftGraphSecurityTools
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: MicrosoftGraphSecurityTools
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/nucleon_cyber/release_notes.yaml
+++ b/content/response_integrations/third_party/community/nucleon_cyber/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! NucleonCyber integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: NucleonCyber
   item_type: Integration
   publish_time: '2021-05-04'
@@ -7,7 +7,7 @@
 - description: 'Updated the integration''s categories.
 
     '
-  integration_version: 2.0
+  version: 2.0
   item_name: NucleonCyber
   item_type: Integration
   publish_time: '2021-08-27'
@@ -15,7 +15,7 @@
 - description: 'Updated the integration''s categories.
 
     '
-  integration_version: 2.0
+  version: 2.0
   item_name: NucleonCyber
   item_type: Integration
   publish_time: '2021-08-29'
@@ -23,7 +23,7 @@
 - description: 'Fixed the action enablement .
 
     '
-  integration_version: 3.0
+  version: 3.0
   item_name: NucleonCyber
   item_type: Integration
   publish_time: '2021-10-19'
@@ -31,13 +31,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: NucleonCyber
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: NucleonCyber
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/pager_duty/release_notes.yaml
+++ b/content/response_integrations/third_party/community/pager_duty/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! PagerDuty.
-  integration_version: 12.0
+  version: 12.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2022-11-14'
   ticket_number: xxx
 - description: Fixed the version alignment
-  integration_version: 13.0
+  version: 13.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2022-11-16'
@@ -13,7 +13,7 @@
 - description: 'Added the following actions: Get User By Email, List Incidents, Filtered
     Incident List, Get User By ID, List All OnCall, List Users, Get Incident By ID,
     Snooze Incident, Create Incident, Run Response Play'
-  integration_version: 14.0
+  version: 14.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2022-11-16'
@@ -21,7 +21,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 15.0
+  version: 15.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2024-12-26'
@@ -30,54 +30,54 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 16.0
+  version: 16.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Create Ticket - Updated exception handling
-  integration_version: 17.0
+  version: 17.0
   item_name: PagerDuty
   item_type: Action
   publish_time: '2025-04-16'
   ticket_number: '406216953'
 - description: Integration - Fixed SDK compatibility
-  integration_version: 18.0
+  version: 18.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2025-09-02'
   ticket_number: '442405312'
 - description: Filtered Incident List, Get Incident By ID, List Users, Snooze Incident
     - Refactored actions.
-  integration_version: 19.0
+  version: 19.0
   item_name: Filtered Incident List, Get Incident By ID, List Users, Snooze Incident
   item_type: Action
   publish_time: '2025-11-05'
   ticket_number: '442541838'
 - description: Run Response Play - Deprecated action.
-  integration_version: 19.0
+  version: 19.0
   item_name: Run Response Play
   item_type: Action
   deprecated: true
   publish_time: '2025-11-05'
   ticket_number: '442541838'
 - description: Ping - New action added.
-  integration_version: 19.0
+  version: 19.0
   item_name: Ping
   item_type: Action
   deprecated: false
   publish_time: '2025-11-05'
   ticket_number: '442541838'
 - description: Missing JSON results on multiple actions - Fixed.
-  integration_version: 20.0
+  version: 20.0
   item_name: FilteredIncidentList, GetUserByEmail, GetUserById, ListAllOnCall, ListIncidents,
     ListUsers, Ping, RunResponsePlay, SnoozeIncident
   item_type: Action
   publish_time: '2025-12-17'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 21.0
+  version: 21.0
   item_name: PagerDuty
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/perimeter_x/release_notes.yaml
+++ b/content/response_integrations/third_party/community/perimeter_x/release_notes.yaml
@@ -1,38 +1,38 @@
 - description: NEW! PerimeterX Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2021-01-07'
   ticket_number: xxx
 - description: Updated Integration SVG.
-  integration_version: 2.0
+  version: 2.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2021-11-01'
   ticket_number: xxx
 - description: Updated Integration PNG.
-  integration_version: 3.0
+  version: 3.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2021-11-07'
   ticket_number: xxx
 - description: Vulnerability fix - Enable server certificate validation on this SSL/TLS
     connection.
-  integration_version: 4.0
+  version: 4.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2024-01-05'
   ticket_number: '318191170'
 - description: Fix! Slack Connector For Code Defender - fix set new timestamp when
     no new alerts enriched.
-  integration_version: 4.0
+  version: 4.0
   item_name: Slack Connector For Code Defender
   item_type: Connector
   publish_time: '2024-01-05'
   ticket_number: '318191120'
 - description: PerimeterX - Updated integration's descriptions to reflect renaming
     to Google SecOps.
-  integration_version: 5.0
+  version: 5.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2024-04-25'
@@ -40,13 +40,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 6.0
+  version: 6.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 7.0
+  version: 7.0
   item_name: PerimeterX
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/philips_hue/release_notes.yaml
+++ b/content/response_integrations/third_party/community/philips_hue/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! PhilipsHUE Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: PhilipsHUE
   item_type: Integration
   publish_time: '2021-10-13'
   ticket_number: xxx
 - description: Added alert effect functionality in Turn On Light and Color Action
-  integration_version: 2.0
+  version: 2.0
   item_name: PhilipsHUE
   item_type: Integration
   publish_time: '2021-10-27'
   ticket_number: xxx
 - description: Changed requests protocol to https and set timeouts for more security
-  integration_version: 3.0
+  version: 3.0
   item_name: PhilipsHUE
   item_type: Integration
   publish_time: '2023-01-11'
@@ -19,13 +19,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: PhilipsHUE
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: PhilipsHUE
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/phish_tank/release_notes.yaml
+++ b/content/response_integrations/third_party/community/phish_tank/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - PhishTank.
-  integration_version: 8.0
+  version: 8.0
   item_name: PhishTank
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,13 +8,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 9.0
+  version: 9.0
   item_name: PhishTank
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 10.0
+  version: 10.0
   item_name: PhishTank
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/pulsedive/release_notes.yaml
+++ b/content/response_integrations/third_party/community/pulsedive/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! Pulsedive integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Pulsedive
   item_type: Integration
   publish_time: '2021-02-24'
   ticket_number: xxx
 - description: Fixed output message.
-  integration_version: 2.0
+  version: 2.0
   item_name: Pulsedive
   item_type: Integration
   publish_time: '2021-02-25'
   ticket_number: xxx
 - description: Fix! raise NotImplementedError on non implemented methods.
-  integration_version: 3.0
+  version: 3.0
   item_name: Pulsedive
   item_type: Integration
   publish_time: '2024-01-05'
@@ -19,13 +19,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: Pulsedive
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Pulsedive
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/sample_integration/release_notes.yaml
+++ b/content/response_integrations/third_party/community/sample_integration/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: New Integration Added - Sample Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Sample Integration
   item_type: Integration
   publish_time: '2025-08-20'
   ticket_number: '429552537'
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: SampleIntegration
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/send_grid/release_notes.yaml
+++ b/content/response_integrations/third_party/community/send_grid/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - SendGrid.
-  integration_version: 30.0
+  version: 30.0
   item_name: SendGrid
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 31.0
+  version: 31.0
   item_name: SendGrid
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,20 +17,20 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 32.0
+  version: 32.0
   item_name: SendGrid
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Integration - Updated Dependencies.
-  integration_version: 33.0
+  version: 33.0
   item_name: SendGrid
   item_type: Integration
   publish_time: '2026-01-07'
   ticket_number: '467333051'
 - description: Updated integration metadata.
-  integration_version: 34.0
+  version: 34.0
   item_name: SendGrid
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/signal_sciences/release_notes.yaml
+++ b/content/response_integrations/third_party/community/signal_sciences/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: "New Integration Added - Signal Sciences."
-  integration_version: 1.0
+  version: 1.0
   item_name: Signal Sciences
   item_type: Integration
   publish_time: '2026-03-25'

--- a/content/response_integrations/third_party/community/spell_checker/release_notes.yaml
+++ b/content/response_integrations/third_party/community/spell_checker/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - Spell Checker.
-  integration_version: 6.0
+  version: 6.0
   item_name: Spell Checker
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,13 +8,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 7.0
+  version: 7.0
   item_name: Spell Checker
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 8.0
+  version: 8.0
   item_name: Spell Checker
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/superna_zero_trust/release_notes.yaml
+++ b/content/response_integrations/third_party/community/superna_zero_trust/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! SupernaZeroTrust integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: SupernaZeroTrust
   item_type: Integration
   publish_time: '2024-06-23'
@@ -8,13 +8,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: SupernaZeroTrust
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: SupernaZeroTrust - Added SSL Support.
-  integration_version: 3.0
+  version: 3.0
   item_name: SupernaZeroTrust
   item_type: Integration
   publish_time: '2025-03-19'
@@ -23,14 +23,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 4.0
+  version: 4.0
   item_name: SupernaZeroTrust
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: SupernaZeroTrust
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/team_cymru_scout/release_notes.yaml
+++ b/content/response_integrations/third_party/community/team_cymru_scout/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New integration added - Team Cymru Scout.
-  integration_version: 1.0
+  version: 1.0
   item_name: Team Cymru Scout
   item_type: Integration
   publish_time: '2024-12-19'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: TeamCymruScout
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,14 +17,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 3.0
+  version: 3.0
   item_name: TeamCymruScout
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: TeamCymruScout
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/telegram/release_notes.yaml
+++ b/content/response_integrations/third_party/community/telegram/release_notes.yaml
@@ -1,36 +1,36 @@
 - description: NEW! Telegram Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2020-11-24'
   ticket_number: xxx
 - description: New actions Send_Document and Wait_for_poll_results, and bug fixes
-  integration_version: 2.0
+  version: 2.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2022-02-03'
   ticket_number: xxx
 - description: Connector fixed and a new Utils Manager added
-  integration_version: 3.0
+  version: 3.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2022-02-15'
   ticket_number: xxx
 - description: Updated connector script and description
-  integration_version: 4.0
+  version: 4.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2022-02-17'
   ticket_number: xxx
 - description: 'Security enhancements: Added request timeouts so the script wouldn''t
     stop in case of telegram-side problems, refactoring applied'
-  integration_version: 5.0
+  version: 5.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2022-12-12'
   ticket_number: xxx
 - description: Publisher name added
-  integration_version: 6.0
+  version: 6.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2023-01-09'
@@ -38,25 +38,25 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 7.0
+  version: 7.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Telegram Connector - Updated the messages processing logic.
-  integration_version: 8.0
+  version: 8.0
   item_name: TelegramConnector
   item_type: Connector
   publish_time: '2025-03-19'
   ticket_number: '397948759'
 - description: Telegram - Adding unit-tests.
-  integration_version: 9.0
+  version: 9.0
   item_name: TelegramConnector
   item_type: Integration
   publish_time: '2025-06-11'
   ticket_number: xxx
 - description: Updated integration metadata.
-  integration_version: 10.0
+  version: 10.0
   item_name: Telegram
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/vanilla_forums/release_notes.yaml
+++ b/content/response_integrations/third_party/community/vanilla_forums/release_notes.yaml
@@ -1,47 +1,47 @@
 - description: NEW! Vanilla integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2021-08-16'
   ticket_number: xxx
 - description: Fixed Bugs in Vanilla integration.
-  integration_version: 2.0
+  version: 2.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2021-08-19'
   ticket_number: xxx
 - description: Fixed Bugs in Vanilla Manager.
-  integration_version: 3.0
+  version: 3.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2021-08-19'
   ticket_number: xxx
 - description: Fixed Bugs in Vanilla Manager.
-  integration_version: 4.0
+  version: 4.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2021-08-19'
   ticket_number: xxx
 - description: Fixed Bugs in Vanilla Manager.
-  integration_version: 5.0
+  version: 5.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2021-08-19'
   ticket_number: xxx
 - description: Fixed Bugs in Vanilla Integration.
-  integration_version: 6.0
+  version: 6.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2021-09-05'
   ticket_number: xxx
 - description: Added action Generate Password and updated action Add User .
-  integration_version: 7.0
+  version: 7.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2022-03-17'
   ticket_number: xxx
 - description: Updated Generate Password and Add User.
-  integration_version: 8.0
+  version: 8.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2022-03-17'
@@ -49,13 +49,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 9.0
+  version: 9.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 10.0
+  version: 10.0
   item_name: VanillaForums
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/vectra_qux/release_notes.yaml
+++ b/content/response_integrations/third_party/community/vectra_qux/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New integration added - Vectra QUX
-  integration_version: 1.0
+  version: 1.0
   item_name: VectraQUX
   item_type: Integration
   publish_time: '2025-02-03'
@@ -9,7 +9,7 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 2.0
+  version: 2.0
   item_name: VectraQUX
   item_type: Integration
   publish_time: '2025-03-24'
@@ -17,7 +17,7 @@
   regressive: true
 - description: Update the integration to use _doc_modified_ts for last_timestamp -
     Vectra QUX
-  integration_version: 3.0
+  version: 3.0
   item_name: VectraQUX
   item_type: Integration
   publish_time: '2026-01-28'
@@ -27,7 +27,7 @@
   deprecated: false
   removed: false
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: VectraQUX
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/vectra_rux/release_notes.yaml
+++ b/content/response_integrations/third_party/community/vectra_rux/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New integration added - Vectra QUX
-  integration_version: 1.0
+  version: 1.0
   item_name: VectraRUX
   item_type: Integration
   publish_time: '2025-02-03'
@@ -9,14 +9,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 2.0
+  version: 2.0
   item_name: VectraRUX
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: VectraRUX
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/vorlon/release_notes.yaml
+++ b/content/response_integrations/third_party/community/vorlon/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! Vorlon integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Vorlon
   item_type: Integration
   publish_time: '2024-06-23'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: Vorlon
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,20 +17,20 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 3.0
+  version: 3.0
   item_name: Vorlon
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Vorlon - Security Bug Fixes.
-  integration_version: 4.0
+  version: 4.0
   item_name: Vorlon
   item_type: Integration
   publish_time: '2025-04-09'
   ticket_number: 401033116, 401033613
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: Vorlon
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/webhook/release_notes.yaml
+++ b/content/response_integrations/third_party/community/webhook/release_notes.yaml
@@ -1,29 +1,29 @@
 - description: NEW! Webhook integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2021-09-09'
   ticket_number: xxx
 - description: Fixed Get Webhook Response action.
-  integration_version: 2.0
+  version: 2.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2021-12-22'
   ticket_number: xxx
 - description: Changed Get Webhook Response action's name.
-  integration_version: 3.0
+  version: 3.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2022-01-02'
   ticket_number: xxx
 - description: Fixed Get Webhook Response action.
-  integration_version: 4.0
+  version: 4.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2022-03-22'
   ticket_number: xxx
 - description: JSON sample fixed.
-  integration_version: 5.0
+  version: 5.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2022-11-02'
@@ -31,13 +31,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 6.0
+  version: 6.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 7.0
+  version: 7.0
   item_name: Webhook
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/whois_xml_api/release_notes.yaml
+++ b/content/response_integrations/third_party/community/whois_xml_api/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - WHOIS XML API.
-  integration_version: 3.0
+  version: 3.0
   item_name: WHOIS XML API
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,7 +8,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 4.0
+  version: 4.0
   item_name: WHOIS XML API
   item_type: Integration
   publish_time: '2024-12-26'
@@ -17,14 +17,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 5.0
+  version: 5.0
   item_name: WHOIS XML API
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: WHOIS XML API
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/workflow_tools/release_notes.yaml
+++ b/content/response_integrations/third_party/community/workflow_tools/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! Workflow Tools integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Workflow Tools
   item_type: Integration
   publish_time: '2021-07-15'
@@ -7,7 +7,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: Workflow Tools
   item_type: Integration
   publish_time: '2024-12-26'
@@ -16,14 +16,14 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 3.0
+  version: 3.0
   item_name: Workflow Tools
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: Workflow Tools
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/community/zoom/release_notes.yaml
+++ b/content/response_integrations/third_party/community/zoom/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Zoom integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Zoom
   item_type: Integration
   publish_time: '2020-10-07'
   ticket_number: xxx
 - description: Zoom OAuth added! Update your authentication method
-  integration_version: 2.0
+  version: 2.0
   item_name: Zoom
   item_type: Integration
   publish_time: '2022-09-05'
@@ -13,13 +13,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 11.0
+  version: 11.0
   item_name: Zoom
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 12.0
+  version: 12.0
   item_name: Zoom
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/anyrun_sandbox/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/anyrun_sandbox/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! ANYRUN Sandbox Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: ANYRUN Sandbox
   item_type: Integration
   publish_time: '2025-10-20'
   ticket_number: xxx
 - description: Fixed import error. Removed DataTables integration. Update analysis options names.
-  integration_version: 2.0
+  version: 2.0
   item_name: ANYRUN Sandbox
   item_type: Integration
   publish_time: '2025-12-16'
   ticket_number: xxx
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: ANYRUN Sandbox
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/anyrun_ti_feeds/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/anyrun_ti_feeds/release_notes.yaml
@@ -1,22 +1,22 @@
 - description: NEW! ANYRUN TI Feeds.
-  integration_version: 1.0
+  version: 1.0
   item_name: ANYRUN TI Feeds
   item_type: Integration
   publish_time: '2025-10-20'
   ticket_number: xxx
 - description: Fixed import error.
-  integration_version: 2.0
+  version: 2.0
   item_name: ANYRUN TI Feeds
   item_type: Integration
   publish_time: '2025-12-16'
   ticket_number: xxx
 - description: Updated authorization workflow. Update SDK version.
-  integration_version: 3.0
+  version: 3.0
   item_name: ANYRUN TI Feeds
   item_type: Integration
   publish_time: '2026-01-21'
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: ANYRUN TI Feeds
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/anyrun_ti_lookup/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/anyrun_ti_lookup/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: NEW! ANYRUN TI Lookup.
-  integration_version: 1.0
+  version: 1.0
   item_name: ANYRUN TI Lookup
   item_type: Integration
   publish_time: '2025-10-20'
   ticket_number: xxx
 - description: Fixed import error. Fixed action context parameters.
-  integration_version: 2.0
+  version: 2.0
   item_name: ANYRUN TI Lookup
   item_type: Integration
   publish_time: '2025-12-16'
   ticket_number: xxx
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: ANYRUN TI Lookup
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/censys/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/censys/release_notes.yaml
@@ -1,17 +1,17 @@
 - description: 'New Integration'
-  integration_version: 1.0
+  version: 1.0
   item_name: Censys
   item_type: Integration
   publish_time: '2026-03-06'
   ticket_number: No ticket
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Censys
   item_type: Integration
   publish_time: '2026-03-18'
   ticket_number: ''
 - description: NEW! Related Infrastructure actions.
-  integration_version: 3.0
+  version: 3.0
   item_name: Censys
   item_type: Action
   publish_time: '2026-04-09'

--- a/content/response_integrations/third_party/partner/clarotyxdome/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/clarotyxdome/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: NEW! Claroty xDome.
-  integration_version: 1.0
+  version: 1.0
   item_name: Claroty xDome
   item_type: Integration
   publish_time: '2025-08-12'
   ticket_number: xxx
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Claroty xDome
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/cyjax_threat_intelligence/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/cyjax_threat_intelligence/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: 'Initial release of CYJAX Threat Intelligence integration for Google SecOps SOAR. The CYJAX Threat Intelligence Integration for Google SecOps SOAR enables security teams to leverage CYJAX’s threat intelligence capabilities directly within automated investigation and response workflows. This integration enhances visibility into external threats by providing actionable intelligence on indicators, domains, and data exposure risks.'
-    integration_version: 1.0
+    version: 1.0
     item_name: CYJAXThreatIntelligence
     item_type: Integration
     publish_time: '2026-03-06'

--- a/content/response_integrations/third_party/partner/cylusone/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/cylusone/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: Initial release of the CylusOne integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: CylusOne
   item_type: Integration
   publish_time: '2025-09-01'
   ticket_number: ''
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: CylusOne
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/cyware_intel_exchange/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/cyware_intel_exchange/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Initial release of Cyware Intel Exchange integration for Google SecOps SOAR. Strengthen your cyber threat detection and response capabilities by integrating Cyware Intel Exchange (Cyware Threat Intelligence Platform) with Google SecOps SOAR. This integration enables seamless ingestion, enrichment, and operationalization of threat intelligence across your security ecosystem.
-  integration_version: 1.0
+  version: 1.0
   item_name: CywareIntelExchange
   item_type: Integration
   publish_time: '2026-03-03'
@@ -8,7 +8,7 @@
   deprecated: false
   removed: false
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: CywareIntelExchange
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/darktrace/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/darktrace/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New integration "Darktrace".
-  integration_version: 1.0
+  version: 1.0
   item_name: Darktrace
   item_type: Integration
   publish_time: '2021-04-20'
@@ -10,7 +10,7 @@
   removed: false
 - description: Enrich Entities - Added an ability to optionally fetch information
     about the connections.
-  integration_version: 2.0
+  version: 2.0
   item_name: Enrich Entities
   item_type: Action
   publish_time: '2022-04-06'
@@ -20,7 +20,7 @@
   deprecated: false
   removed: false
 - description: New Action Added - Execute Custom Search.
-  integration_version: 2.0
+  version: 2.0
   item_name: Execute Custom Search
   item_type: Action
   publish_time: '2022-04-06'
@@ -30,7 +30,7 @@
   deprecated: false
   removed: false
 - description: New Action Added - List Similar Devices.
-  integration_version: 2.0
+  version: 2.0
   item_name: List Similar Devices
   item_type: Action
   publish_time: '2022-04-06'
@@ -40,7 +40,7 @@
   deprecated: false
   removed: false
 - description: New Action Added - Add Comment To Model Breach.
-  integration_version: 3.0
+  version: 3.0
   item_name: Add Comment To Model Breach
   item_type: Action
   publish_time: '2022-12-21'
@@ -50,7 +50,7 @@
   deprecated: false
   removed: false
 - description: Integration - New OOTB mapping.
-  integration_version: 3.0
+  version: 3.0
   item_name: Darktrace
   item_type: Integration
   publish_time: '2022-12-21'
@@ -60,7 +60,7 @@
   deprecated: false
   removed: false
 - description: Integration - Updated description and logos.
-  integration_version: 3.0
+  version: 3.0
   item_name: Darktrace
   item_type: Integration
   publish_time: '2022-12-21'
@@ -70,7 +70,7 @@
   deprecated: false
   removed: false
 - description: List Similar Devices - Added Predefined Widgets.
-  integration_version: 4.0
+  version: 4.0
   item_name: List Similar Devices
   item_type: Action
   publish_time: '2023-04-04'
@@ -80,7 +80,7 @@
   deprecated: false
   removed: false
 - description: Security Enhancements.
-  integration_version: 5.0
+  version: 5.0
   item_name: Darktrace
   item_type: Integration
   publish_time: '2023-04-27'
@@ -91,7 +91,7 @@
   removed: false
 - description: Model Breaches Connector - Added support for "Behavior Visibility"
     filter.
-  integration_version: 6.0
+  version: 6.0
   item_name: Model Breaches Connector
   item_type: Connector
   publish_time: '2023-06-07'
@@ -102,7 +102,7 @@
   removed: false
 - description: Model Breaches Connector - Added MITRE techniques to the default
     mapping.
-  integration_version: 6.0
+  version: 6.0
   item_name: Model Breaches Connector
   item_type: Connector
   publish_time: '2023-06-07'
@@ -112,7 +112,7 @@
   deprecated: false
   removed: false
 - description: Darktrace - Model Breaches Connector - Improved edge cases handling.
-  integration_version: 7.0
+  version: 7.0
   item_name: Model Breaches Connector
   item_type: Connector
   publish_time: '2023-08-02'
@@ -122,7 +122,7 @@
   deprecated: false
   removed: false
 - description: List Similar Devices - Updated Predefined Widgets.
-  integration_version: 8.0
+  version: 8.0
   item_name: List Similar Devices
   item_type: Action
   publish_time: '2023-10-18'
@@ -132,7 +132,7 @@
   deprecated: false
   removed: false
 - description: New Connector Added - AI Incident Connector.
-  integration_version: 9.0
+  version: 9.0
   item_name: AI Incident Connector
   item_type: Connector
   publish_time: '2023-11-22'
@@ -142,7 +142,7 @@
   deprecated: false
   removed: false
 - description: Darktrace - Model Breaches Connector - Upgrade TIPCommon
-  integration_version: 9.0
+  version: 9.0
   item_name: Model Breaches Connector
   item_type: Connector
   publish_time: '2023-11-22'
@@ -152,7 +152,7 @@
   deprecated: false
   removed: false
 - description: AI Incident Connector - Updated time handling logic.
-  integration_version: 10.0
+  version: 10.0
   item_name: AI Incident Connector
   item_type: Connector
   publish_time: '2024-01-04'
@@ -162,7 +162,7 @@
   deprecated: false
   removed: false
 - description: List Similar Devices - Updated Predefined Widget.
-  integration_version: 11.0
+  version: 11.0
   item_name: List Similar Devices
   item_type: Widget
   publish_time: '2024-01-10'
@@ -173,7 +173,7 @@
   removed: false
 - description: Darktrace - AI Incident Events Connector, Darktrace - Model Breaches
     Connector - Improved description for 'Max Hours Backwards' parameter.
-  integration_version: 12.0
+  version: 12.0
   item_name: Darktrace - AI Incident Events Connector, Darktrace - Model Breaches
     Connector
   item_type: Connector
@@ -184,7 +184,7 @@
   deprecated: false
   removed: false
 - description: Execute Custom Query - Updated error handling.
-  integration_version: 13.0
+  version: 13.0
   item_name: Execute Custom Search
   item_type: Action
   publish_time: '2024-08-21'
@@ -196,7 +196,7 @@
 - description: 'Darktrace integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions.'
-  integration_version: 14.0
+  version: 14.0
   item_name: Darktrace
   item_type: Integration
   publish_time: '2024-09-19'
@@ -206,7 +206,7 @@
   deprecated: false
   removed: false
 - description: List Endpoint Events, Enrich Entities - Added Predefined Widgets.
-  integration_version: 15.0
+  version: 15.0
   item_name: List Endpoint Events, Enrich Entities
   item_type: Widget
   publish_time: '2024-11-05'
@@ -217,7 +217,7 @@
   removed: false
 - description: Execute Custom Search, Add Comment To Model Breach - Added Predefined
     Widgets.
-  integration_version: 15.0
+  version: 15.0
   item_name: Execute Custom Search, Add Comment To Model Breach
   item_type: Widget
   publish_time: '2024-11-05'
@@ -227,7 +227,7 @@
   deprecated: false
   removed: false
 - description: List Similar Devices - Updated Predefined Widget.
-  integration_version: 16.0
+  version: 16.0
   item_name: List Similar Devices
   item_type: Widget
   publish_time: '2024-11-27'
@@ -237,7 +237,7 @@
   deprecated: false
   removed: false
 - description: Model Breaches Connector - Added "Padding Time" parameter.
-  integration_version: 17.0
+  version: 17.0
   item_name: Model Breaches Connector
   item_type: Connector
   publish_time: '2025-01-08'
@@ -248,7 +248,7 @@
   removed: false
 - description: Darktrace - Model Breaches Connector - Added ability to filter model
     breaches by priority.
-  integration_version: 18.0
+  version: 18.0
   item_name: Darktrace - Model Breaches Connector
   item_type: Connector
   publish_time: '2025-06-11'
@@ -258,7 +258,7 @@
   deprecated: false
   removed: false
 - description: Updated integration metadata.
-  integration_version: 19.0
+  version: 19.0
   item_name: Darktrace
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/domain_tools/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/domain_tools/release_notes.yaml
@@ -1,6 +1,6 @@
 - description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-  integration_version: 4.0
+  version: 4.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2020-11-04'
@@ -10,7 +10,7 @@
   deprecated: false
   removed: false
 - description: Security Enhancements.
-  integration_version: 5.0
+  version: 5.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2023-04-27'
@@ -20,7 +20,7 @@
   deprecated: false
   removed: false
 - description: DomainTools - Get Domain Profile - Action updates.
-  integration_version: 6.0
+  version: 6.0
   item_name: Get Domain Profile
   item_type: Action
   publish_time: '2023-12-06'
@@ -32,7 +32,7 @@
 - description: 'DomainTools integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 7.0
+  version: 7.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2024-07-14'
@@ -42,7 +42,7 @@
   deprecated: false
   removed: false
 - description: Get Domain Risk - Extended action capabilities.
-  integration_version: 8.0
+  version: 8.0
   item_name: Get Domain Risk
   item_type: Action
   publish_time: '2025-10-23'
@@ -53,7 +53,7 @@
   removed: false
 - description: Get Domain Risk, Get Domain Profile, Reverse Domain - Added support
     for domain entity type.
-  integration_version: 8.0
+  version: 8.0
   item_name: Get Domain Risk, Get Domain Profile, Reverse Domain
   item_type: Action
   publish_time: '2025-10-23'
@@ -64,7 +64,7 @@
   removed: false
 - description: Integration - Updated integration action definitions to meet the
     new requirements of IDE.
-  integration_version: 9.0
+  version: 9.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2025-11-12'
@@ -74,7 +74,7 @@
   deprecated: false
   removed: false
 - description: Integration - moved to GithHub.
-  integration_version: 10.0
+  version: 10.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2025-02-01'
@@ -83,13 +83,13 @@
   deprecated: false
   removed: false
 - description: Updated integration metadata.
-  integration_version: 11.0
+  version: 11.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2026-03-18'
   ticket_number: ''
 - description: Integration - Updated integration actions.
-  integration_version: 12.0
+  version: 12.0
   item_name: DomainTools
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/doppel_vision/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/doppel_vision/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration - DoppelVision.
-  integration_version: 1.0
+  version: 1.0
   item_name: DoppelVision
   item_type: Integration
   publish_time: '2024-12-26'
@@ -8,25 +8,25 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 2.0
+  version: 2.0
   item_name: DoppelVision
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: 'Feature: Updated Doppel API auth headers and entity/queue state parameters.'
-  integration_version: 3.0
+  version: 3.0
   item_name: DoppelVision
   item_type: Integration
   publish_time: '2026-01-05'
   ticket_number: ''
 - description: 'Bug Fix: Resolved conflicting parameter names in Doppel Vision actions'
-  integration_version: 4.0
+  version: 4.0
   item_name: DoppelVision
   item_type: Integration
   publish_time: '2026-01-21'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: DoppelVision
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/grey_noise/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/grey_noise/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: NEW! GreyNoise integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2021-02-17'
@@ -7,7 +7,7 @@
 - description: "Fixed incorrect visualizer link in Context IP Lookup Command. \n Added\
     \ support for new Quick Lookup endpoint or codes. \n Added new Action for Community\
     \ IP Lookup, which allows for IP lookups via the free Community API"
-  integration_version: 2.0
+  version: 2.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2021-06-24'
@@ -15,7 +15,7 @@
 - description: 'Updated the integration''s categories.
 
     '
-  integration_version: 3.0
+  version: 3.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2021-08-29'
@@ -26,7 +26,7 @@
     \ sample for Quick IP Lookup \n - Added better handling for non-routable/invalid\
     \ IPs \n - Small tweaks made to RIOT and Context Entity insights \n - Improved\
     \ error handling on all actions.\n"
-  integration_version: 4.0
+  version: 4.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2023-08-29'
@@ -34,7 +34,7 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 5.0
+  version: 5.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2024-12-26'
@@ -43,21 +43,21 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 6.0
+  version: 6.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2025-03-24'
   ticket_number: '405144847'
   regressive: true
 - description: "Integration: Updated GreyNoise SDK to version 3.0.1.\n\nThe following new action has been added:\n\n- Get CVE Details\n\nAdded the following parameters to the Execute GNQL Query action:\n\n- Exclude Raw\n- Quick\n\nUpdated parameters in the IP Timeline Lookup action:\n\n- Removed: Limit\n- Added: Field\n- Added: Granularity\n\nRemoved the following deprecated actions:\n\n- Community IP Lookup (use IP Lookup action instead)\n- RIOT IP Lookup (use IP Lookup action instead)\n- IP Similarity Lookup\n- Full IP Lookup (use IP Lookup action instead)"
-  integration_version: 7.0
+  version: 7.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2026-02-06'
   ticket_number: ''
   regressive: true
 - description: Updated integration metadata.
-  integration_version: 8.0
+  version: 8.0
   item_name: GreyNoise
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/group_ib_drp/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/group_ib_drp/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: "New connector: DRP Typosquatting. Ingests typosquatting   detections as SOAR cases. New job: DRP Deduplication. Scheduled reconciliation of open DRP cases sharing the same violation UID, via `merge` (default) or `close`. DRP Violations Connector: additional filter options for finer control over what gets ingested. New action: Get Violation Details. Enriches `DestinationURL` entities with full violation metadata from the DRP API."
-    integration_version: 1.0
+    version: 1.0
     item_name: Group-IB-DRP
     item_type: Integration
     publish_time: '2026-04-24'

--- a/content/response_integrations/third_party/partner/group_ib_ti/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/group_ib_ti/release_notes.yaml
@@ -2,14 +2,14 @@
     the Google Chronicle platform. It automatically ingests threat feeds from GIB
     TI and transforms them into rich Chronicle alerts, populated with corresponding
     entities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Group-IB TI
   item_type: Integration
   publish_time: '2025-09-01'
   ticket_number: ''
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Group-IB TI
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/houdin_io/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/houdin_io/release_notes.yaml
@@ -1,18 +1,18 @@
 - description: NEW! Houdin.io Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Houdin-io
   item_type: Integration
   publish_time: '2025-08-13'
   ticket_number: xxx
   new: true
 - description: Updated integration dependencies
-  integration_version: 2.0
+  version: 2.0
   item_name: Houdin-io
   item_type: Integration
   publish_time: '2025-08-18'
   ticket_number: xxx
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: Houdin-io
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/infoblox_nios/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/infoblox_nios/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: NEW! Infoblox NIOS Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Infoblox NIOS
   item_type: Integration
   publish_time: '2025-09-17'
   ticket_number: ''
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Infoblox NIOS
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/infoblox_threat_defense_with_ddi/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/infoblox_threat_defense_with_ddi/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: NEW! Infoblox Threat Defense with DDI Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Infoblox Threat Defense with DDI
   item_type: Integration
   publish_time: '2025-07-28'
   ticket_number: ''
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Infoblox Threat Defense with DDI
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/ip_info/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/ip_info/release_notes.yaml
@@ -14,7 +14,7 @@
 
 -   description: ' Added integration support for the Playbook Simulator feature, allowing
         you to build, test and edit your workflow logic in a pre-production environment.'
-    integration_version: 3.0
+    version: 3.0
     item_name: IPInfo
     item_type: Integration
     publish_time: '2020-11-04'
@@ -25,7 +25,7 @@
     removed: false
 -   description: ' Fixed a bug where the integration''s SVG logo file was causing
         unexpected behaviors in specific cases.'
-    integration_version: 4.0
+    version: 4.0
     item_name: IPInfo
     item_type: Integration
     publish_time: '2021-04-07'
@@ -37,7 +37,7 @@
 -   description: 'IPInfo integration - Important - Updated the integration code to
         work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-    integration_version: 5.0
+    version: 5.0
     item_name: IPInfo
     item_type: Integration
     publish_time: '2024-07-14'
@@ -47,7 +47,7 @@
     deprecated: false
     removed: false
 -   description: Get IP Information, Get Domain Information - Added Predefined Widgets.
-    integration_version: 6.0
+    version: 6.0
     item_name: Get IP Information, Get Domain Information
     item_type: Widget
     publish_time: '2024-11-05'
@@ -59,7 +59,7 @@
 
 - description: 'Integration - Source code for the integration is now available publicly
     on Github. Link to repo: https://github.com/chronicle/content-hub'
-  integration_version: 7.0
+  version: 7.0
   item_name: IPInfo
   item_type: Integration
   publish_time: '2026-03-16'

--- a/content/response_integrations/third_party/partner/jamf/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/jamf/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: NEW! Jamf integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Jamf
   item_type: Integration
   publish_time: '2025-09-08'
   ticket_number: xxx
   new: true
 - description: NEW! Ping action for testing connectivity to Jamf API.
-  integration_version: 1.0
+  version: 1.0
   item_name: Ping
   item_type: Action
   publish_time: '2025-09-08'
@@ -14,7 +14,7 @@
   new: true
 - description: NEW! List Computer Groups action for listing computer groups from Jamf
     Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: List Computer Groups
   item_type: Action
   publish_time: '2025-09-08'
@@ -22,7 +22,7 @@
   new: true
 - description: NEW! Get Device Information action for retrieving computer information
     from Jamf Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Get Device Information
   item_type: Action
   publish_time: '2025-09-08'
@@ -30,7 +30,7 @@
   new: true
 - description: NEW! Get Device Group Membership action for retrieving computer group membership
     from Jamf Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Get Device Group Membership
   item_type: Action
   publish_time: '2025-09-08'
@@ -38,7 +38,7 @@
   new: true
 - description: NEW! Get Computer Inventory action for retrieving computer inventory
     from Jamf Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Get Computer Inventory
   item_type: Action
   publish_time: '2025-09-08'
@@ -46,7 +46,7 @@
   new: true
 - description: NEW! Assign Computer to Group action for assigning computers to groups
     in Jamf Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Assign to Group
   item_type: Action
   publish_time: '2025-09-08'
@@ -54,7 +54,7 @@
   new: true
 - description: NEW! Remote Lock Managed Device action for remotely locking managed
     computers in Jamf Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Remote Lock Managed Device
   item_type: Action
   publish_time: '2025-09-08'
@@ -62,7 +62,7 @@
   new: true
 - description: NEW! Wipe Managed Device action for wiping managed computers in Jamf
     Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Wipe Managed Device
   item_type: Action
   publish_time: '2025-09-08'
@@ -70,56 +70,56 @@
   new: true
 - description: NEW! Update Extension Attribute action for updating extension attributes
     in Jamf Pro.
-  integration_version: 1.0
+  version: 1.0
   item_name: Update Extension Attribute
   item_type: Action
   publish_time: '2025-09-08'
   ticket_number: xxx
   new: true
 - description: NEW! Get Mobile Device Inventory action for retrieving mobile device inventory from Jamf Pro.
-  integration_version: 2.0
+  version: 2.0
   item_name: Get Mobile Device Inventory
   item_type: Action
   publish_time: '2025-10-27'
   ticket_number: xxx
   new: true
 - description: NEW! Remote Lock Mobile Device action for remotely locking managed mobile devices in Jamf Pro.
-  integration_version: 2.0
+  version: 2.0
   item_name: Remote Lock Mobile Device
   item_type: Action
   publish_time: '2025-10-27'
   ticket_number: xxx
   new: true
 - description: NEW! Wipe Mobile Device action for wiping managed mobile devices in Jamf Pro.
-  integration_version: 2.0
+  version: 2.0
   item_name: Wipe Mobile Device
   item_type: Action
   publish_time: '2025-10-27'
   ticket_number: xxx
   new: true
 - description: NEW! Update Protect Prevent List action for updating prevent lists in Jamf Protect.
-  integration_version: 2.0
+  version: 2.0
   item_name: Update Protect Prevent List
   item_type: Action
   publish_time: '2025-10-27'
   ticket_number: ''
   new: true
 - description: Updated Get Device Information widget to fix issue preventing multiple instances from loading in the same playbook.
-  integration_version: 3.0
+  version: 3.0
   item_name: Get Device Information
   item_type: Widget
   publish_time: '2025-11-13'
   ticket_number: ''
   new: false
 - description: Updated Get Computer Inventory widget to fix issue preventing multiple instances from loading in the same playbook.
-  integration_version: 3.0
+  version: 3.0
   item_name: Get Computer Inventory
   item_type: Widget
   publish_time: '2025-11-13'
   ticket_number: ''
   new: false
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: Jamf
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/netappransomwareresilience/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/netappransomwareresilience/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: 'NEW! NetApp Ransomware Resilience Integration.'
-  integration_version: 1.0
+  version: 1.0
   item_name: netapp-ransomware-resilience
   item_type: Integration
   publish_time: '2026-03-20'
   ticket_number: No ticket
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: netapp-ransomware-resilience
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/netenrich_connect/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/netenrich_connect/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: New integration - Netenrich Connect
-  integration_version: 1.0
+  version: 1.0
   item_name: Netenrich Connect
   item_type: Integration
   publish_time: '2025-06-16'
   ticket_number: '409501626'
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: netenrich-connect
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/orca_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/orca_security/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New Integration Added - Orca Security.
-  integration_version: 1.0
+  version: 1.0
   item_name: OrcaSecurity
   item_type: Integration
   publish_time: '2022-05-18'
@@ -10,7 +10,7 @@
   removed: false
 - description: Get Vulnerability Details - Added an ability to return data as CSV
     file.
-  integration_version: 2.0
+  version: 2.0
   item_name: Get Vulnerability Details
   item_type: Action
   publish_time: '2022-09-08'
@@ -21,7 +21,7 @@
   removed: false
 - description: Get Vulnerability Details - Added an ability to return only certain
     fields.
-  integration_version: 2.0
+  version: 2.0
   item_name: Get Vulnerability Details
   item_type: Action
   publish_time: '2022-09-08'
@@ -31,7 +31,7 @@
   deprecated: false
   removed: false
 - description: Integration - Added support for authentication via API Token.
-  integration_version: 3.0
+  version: 3.0
   item_name: OrcaSecurity
   item_type: Integration
   publish_time: '2022-11-02'
@@ -42,7 +42,7 @@
   removed: false
 - description: Orca Security - Alerts Connector - Added an ability to filter alerts
     by type.
-  integration_version: 4.0
+  version: 4.0
   item_name: Orca Security - Alerts Connector
   item_type: Connector
   publish_time: '2023-03-09'
@@ -53,7 +53,7 @@
   removed: false
 - description: Get Vulnerability Details, Get Compliance Info, Get Asset Details
     - Added Predefined Widgets in preview.
-  integration_version: 5.0
+  version: 5.0
   item_name: Get Vulnerability Details, Get Compliance Info, Get Asset Details
   item_type: Widget
   publish_time: '2023-08-09'
@@ -64,7 +64,7 @@
   removed: false
 - description: Get Asset Details, Get Compliance Info, Get Vulnerability Details
     - Updated Predefined Widgets.
-  integration_version: 6.0
+  version: 6.0
   item_name: Get Asset Details, Get Compliance Info, Get Vulnerability Details
   item_type: Widget
   publish_time: '2024-01-10'
@@ -75,7 +75,7 @@
   removed: false
 - description: Orca Security - Alerts Connector - Improved description for 'Max
     Hours Backwards' parameter.
-  integration_version: 7.0
+  version: 7.0
   item_name: Orca Security - Alerts Connector
   item_type: Connector
   publish_time: '2024-08-08'
@@ -87,7 +87,7 @@
 - description: 'Orca Security integration - Important - Updated the integration
         code to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 8.0
+  version: 8.0
   item_name: OrcaSecurity
   item_type: Integration
   publish_time: '2024-08-21'
@@ -97,7 +97,7 @@
   deprecated: false
   removed: false
 - description: Add Comment To Alert, Update Alert - Added Predefined Widgets.
-  integration_version: 9.0
+  version: 9.0
   item_name: Add Comment To Alert, Update Alert
   item_type: Widget
   publish_time: '2024-11-05'
@@ -107,7 +107,7 @@
   deprecated: false
   removed: false
 - description: Scan Assets - Added Predefined Widget.
-  integration_version: 10.0
+  version: 10.0
   item_name: Scan Assets
   item_type: Widget
   publish_time: '2024-11-27'
@@ -118,7 +118,7 @@
   removed: false
 - description: Get Vulnerability Details, Get Compliance Info, Get Asset Details
     - Updated Predefined Widgets.
-  integration_version: 10.0
+  version: 10.0
   item_name: Get Vulnerability Details, Get Compliance Info, Get Asset Details
   item_type: Widget
   publish_time: '2024-11-27'
@@ -129,7 +129,7 @@
   removed: false
 - description: Orca Security - Alerts Connector - Added ability to work with Orca
     Score
-  integration_version: 11.0
+  version: 11.0
   item_name: Orca Security - Alerts Connector
   item_type: Connector
   publish_time: '2025-01-15'
@@ -141,7 +141,7 @@
 - description: Get Asset Details, Update Alert, Orca Security - Alerts Connector
     - Regressive! Updated the integration to support latest API version. Overwrite
     the ontology mapping to align with the new API Alert structure.
-  integration_version: 12.0
+  version: 12.0
   item_name: Orca Security
   item_type: Integration
   publish_time: '2025-09-25'
@@ -154,7 +154,7 @@
     the ontology mapping to align with the new API Vulnerability structure. Updated severity mappings from
     old format ("compromised", "imminent compromise", "hazardous", "informational")
     to standard format ("critical", "high", "medium", "low", "unknown")
-  integration_version: 13.0
+  version: 13.0
   item_name: Orca Security
   item_type: Integration
   publish_time: '2026-03-03'
@@ -164,7 +164,7 @@
   deprecated: false
   removed: false
 - description: Updated integration metadata.
-  integration_version: 14.0
+  version: 14.0
   item_name: OrcaSecurity
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/recorded_future_intelligence/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/recorded_future_intelligence/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: New integration added - Recorded Future Intelligence.
-  integration_version: 1.0
+  version: 1.0
   item_name: Recorded Future Intelligence
   item_type: Integration
   publish_time: '2024-09-30'
@@ -7,7 +7,7 @@
   new: true
 - description: New actions added - Get Playbook Alert Details, Refresh Playbook Alert,
     Update Playbook Alert.
-  integration_version: 2.0
+  version: 2.0
   item_name: Recorded Future Intelligence
   item_type: Integration
   publish_time: '2024-12-19'
@@ -15,7 +15,7 @@
   new: true
 - description: New connectors added - Playbook Alerts Connector, Playbook Alerts Tracking
     Connector.
-  integration_version: 2.0
+  version: 2.0
   item_name: Recorded Future Intelligence
   item_type: Integration
   publish_time: '2024-12-19'
@@ -24,13 +24,13 @@
 - description: 'Important - Updated the integration code to work with Python version
     3.11. To ensure compatibility and avoid disruptions, follow the upgrade best practices
     described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions'
-  integration_version: 3.0
+  version: 3.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2024-12-26'
   ticket_number: ''
 - description: Integration update
-  integration_version: 4.0
+  version: 4.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2025-03-19'
@@ -39,7 +39,7 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 5.0
+  version: 5.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2025-03-24'
@@ -49,7 +49,7 @@
     with Marketplace requirements. If you've made any custom changes to the official
     integration items, make sure to copy them before upgrading as they will be irreversible
     overwritten otherwise.
-  integration_version: 6.0
+  version: 6.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2025-04-20'
@@ -62,7 +62,7 @@
     Fix Recorded Future API SDK logging issue preventing actions from exiting successfully.
 
     '
-  integration_version: 7.0
+  version: 7.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2025-08-01'
@@ -73,7 +73,7 @@
 
     Update module documentation.
     '
-  integration_version: 8.0
+  version: 8.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2025-10-31'
@@ -82,7 +82,7 @@
 
     Update module documentation.
     '
-  integration_version: 9.0
+  version: 9.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2025-11-06'
@@ -94,13 +94,13 @@
     Fix issue reading update alert action input.
     Fix issue reading playbook alert tracking connector parameter.
     '
-  integration_version: 10.0
+  version: 10.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2026-02-06'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 11.0
+  version: 11.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2026-03-18'
@@ -111,7 +111,7 @@
     Added Malware Report Playbook Alert.
     Fixed issue creating Classic Alerts with no references.
     '
-  integration_version: 12.0
+  version: 12.0
   item_name: RecordedFutureIntelligence
   item_type: Integration
   publish_time: '2026-04-02'

--- a/content/response_integrations/third_party/partner/rubrik_security_cloud/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/rubrik_security_cloud/release_notes.yaml
@@ -1,19 +1,19 @@
 - description: NEW! Rubrik Security Cloud Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Rubrik Security Cloud
   item_type: Integration
   publish_time: '2026-01-29'
   ticket_number: ''
   new: true
 - description: Change display name to `Rubrik Security Cloud`.
-  integration_version: 2.0
+  version: 2.0
   item_name: Rubrik Security Cloud
   item_type: Integration
   publish_time: '2026-02-20'
   ticket_number: ''
   new: false
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: RubrikSecurityCloud
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/silentpush/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/silentpush/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: Initial conversion to new structure.
-  integration_version: 1.0
+  version: 1.0
   item_name: silentpush
   item_type: Integration
   publish_time: '2026-01-27'
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: silentpush
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/silverfort/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/silverfort/release_notes.yaml
@@ -1,7 +1,7 @@
 - description: New Integration Added - Silverfort Identity Security. Provides user
     risk management, service account protection, and authentication policy management
     capabilities.
-  integration_version: 1.0
+  version: 1.0
   item_name: Silverfort
   item_type: Integration
   publish_time: '2026-01-13'
@@ -9,7 +9,7 @@
 
 - description: Added Ping action to test connectivity to Silverfort API with all configured
     API endpoints.
-  integration_version: 1.0
+  version: 1.0
   item_name: Ping
   item_type: Action
   publish_time: '2026-01-13'
@@ -17,7 +17,7 @@
 
 - description: Added Get Entity Risk action to retrieve risk information for users
     and resources.
-  integration_version: 1.0
+  version: 1.0
   item_name: Get Entity Risk
   item_type: Action
   publish_time: '2026-01-13'
@@ -25,7 +25,7 @@
 
 - description: Added Update Entity Risk action to set risk levels for users based
     on external threat intelligence.
-  integration_version: 1.0
+  version: 1.0
   item_name: Update Entity Risk
   item_type: Action
   publish_time: '2026-01-13'
@@ -33,7 +33,7 @@
 
 - description: Added Get Service Account action to retrieve detailed information about
     service accounts.
-  integration_version: 1.0
+  version: 1.0
   item_name: Get Service Account
   item_type: Action
   publish_time: '2026-01-13'
@@ -41,7 +41,7 @@
 
 - description: Added List Service Accounts action to list all service accounts with
     pagination support.
-  integration_version: 1.0
+  version: 1.0
   item_name: List Service Accounts
   item_type: Action
   publish_time: '2026-01-13'
@@ -49,28 +49,28 @@
 
 - description: Added Update SA Policy action to configure protection policies for
     service accounts.
-  integration_version: 1.0
+  version: 1.0
   item_name: Update SA Policy
   item_type: Action
   publish_time: '2026-01-13'
   new: true
 
 - description: Added Get Policy action to retrieve authentication policy configurations.
-  integration_version: 1.0
+  version: 1.0
   item_name: Get Policy
   item_type: Action
   publish_time: '2026-01-13'
   new: true
 
 - description: Added List Policies action to list all authentication policies.
-  integration_version: 1.0
+  version: 1.0
   item_name: List Policies
   item_type: Action
   publish_time: '2026-01-13'
   new: true
 
 - description: Added Update Policy action to modify authentication policy settings.
-  integration_version: 1.0
+  version: 1.0
   item_name: Update Policy
   item_type: Action
   publish_time: '2026-01-13'
@@ -78,14 +78,14 @@
 
 - description: Added Change Policy State action to enable or disable authentication
     policies.
-  integration_version: 1.0
+  version: 1.0
   item_name: Change Policy State
   item_type: Action
   publish_time: '2026-01-13'
   new: true
 
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Silverfort
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/spycloud/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/spycloud/release_notes.yaml
@@ -1,5 +1,5 @@
 - description: Added new integration "SpyCloud"
-  integration_version: 1.0
+  version: 1.0
   item_name: SpyCloud
   item_type: Integration
   publish_time: '2021-07-07'
@@ -9,7 +9,7 @@
   deprecated: false
   removed: false
 - description: Removed unnecessary comments from the integration's code.
-  integration_version: 2.0
+  version: 2.0
   item_name: SpyCloud
   item_type: Integration
   publish_time: '2021-11-10'
@@ -21,7 +21,7 @@
 - description: 'SpyCloud integration - Important - Updated the integration code
         to work with Python version 3.11. To ensure compatibility and avoid disruptions,
         follow the upgrade best practices described in the following document: https://cloud.google.com/chronicle/docs/soar/respond/integrations-setup/upgrade-python-versions.'
-  integration_version: 3.0
+  version: 3.0
   item_name: SpyCloud
   item_type: Integration
   publish_time: '2024-08-29'
@@ -31,7 +31,7 @@
   deprecated: false
   removed: false
 - description: List Entity Breaches - Added Predefined Widget.
-  integration_version: 4.0
+  version: 4.0
   item_name: List Entity Breaches
   item_type: Widget
   publish_time: '2024-11-05'
@@ -41,7 +41,7 @@
   deprecated: false
   removed: false
 - description: List Catalogs - Added Predefined Widget.
-  integration_version: 5.0
+  version: 5.0
   item_name: List Catalogs
   item_type: Widget
   publish_time: '2024-11-27'
@@ -51,7 +51,7 @@
   deprecated: false
   removed: false
 - description: Updated integration metadata.
-  integration_version: 6.0
+  version: 6.0
   item_name: SpyCloud
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/stairwell/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/stairwell/release_notes.yaml
@@ -1,13 +1,13 @@
 - description: NEW! Stairwell integration to power up threat intelligence capabilities
     with file hash, hostname, and IP address enrichment.
-  integration_version: 1.0
+  version: 1.0
   item_name: Stairwell
   item_type: Integration
   publish_time: '2025-07-28'
   ticket_number: xxx
   new: true
 - description: NEW! Ping action for testing connectivity to Stairwell API.
-  integration_version: 1.0
+  version: 1.0
   item_name: Ping
   item_type: Action
   publish_time: '2025-07-28'
@@ -15,7 +15,7 @@
   new: true
 - description: NEW! Enrich Hash action for file hash enrichment with Stairwell threat
     intelligence data.
-  integration_version: 1.0
+  version: 1.0
   item_name: Enrich Hash
   item_type: Action
   publish_time: '2025-07-28'
@@ -23,7 +23,7 @@
   new: true
 - description: NEW! Enrich Hostname action for hostname enrichment with Stairwell
     threat intelligence data.
-  integration_version: 1.0
+  version: 1.0
   item_name: Enrich Hostname
   item_type: Action
   publish_time: '2025-07-28'
@@ -31,20 +31,20 @@
   new: true
 - description: NEW! Enrich IP action for IP address enrichment with Stairwell threat
     intelligence data.
-  integration_version: 1.0
+  version: 1.0
   item_name: Enrich IP
   item_type: Action
   publish_time: '2025-07-28'
   ticket_number: xxx
   new: true
 - description: Updated integration categories to improve marketplace discovery.
-  integration_version: 2.0
+  version: 2.0
   item_name: Stairwell
   item_type: Integration
   publish_time: '2025-09-15'
   ticket_number: xxx
 - description: Updated integration metadata.
-  integration_version: 3.0
+  version: 3.0
   item_name: Stairwell
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/thinkst_canary/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/thinkst_canary/release_notes.yaml
@@ -1,12 +1,12 @@
 - description: NEW! Thinkst Canary integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: THINKST
   item_type: Integration
   publish_time: '2025-11-14'
   ticket_number: xxx
   new: true
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: THINKST
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/torq/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/torq/release_notes.yaml
@@ -1,11 +1,11 @@
 - description: NEW! Torq Response Integration — run Torq workflows and create Torq cases directly from Google SecOps alerts.
-  integration_version: 1.0
+  version: 1.0
   item_name: Torq
   item_type: Integration
   publish_time: '2025-11-17'
   ticket_number: xxx
 - description: Updated integration metadata.
-  integration_version: 2.0
+  version: 2.0
   item_name: Torq
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/wiz/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/wiz/release_notes.yaml
@@ -1,24 +1,24 @@
 - description: New Integration Added - Wiz.
-  integration_version: 1.0
+  version: 1.0
   item_name: Wiz
   item_type: Integration
   publish_time: '2025-08-04'
   ticket_number: '393985746'
   new: true
 - description: Integration - Updated description.
-  integration_version: 2.0
+  version: 2.0
   item_name: Wiz
   item_type: Integration
   publish_time: '2025-08-13'
   ticket_number: '438101649'
 - description: Integration - Integration is now GUS Recommended.
-  integration_version: 3.0
+  version: 3.0
   item_name: Wiz
   item_type: Integration
   publish_time: '2025-11-12'
   ticket_number: '452903277'
 - description: Updated integration metadata.
-  integration_version: 4.0
+  version: 4.0
   item_name: Wiz
   item_type: Integration
   publish_time: '2026-03-18'

--- a/content/response_integrations/third_party/partner/xm_cyber/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/xm_cyber/release_notes.yaml
@@ -1,32 +1,32 @@
 - description: NEW! XMCyber integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: XMCyber
   item_type: Integration
   publish_time: '2025-04-03'
   ticket_number: ''
   new: true
 - description: 'New action added: Calculate Risk Score.'
-  integration_version: 2.0
+  version: 2.0
   item_name: Calculate Risk Score
   item_type: Action
   publish_time: '2025-05-04'
   ticket_number: ''
   new: true
 - description: 'New action added: Enrich Entities.'
-  integration_version: 3.0
+  version: 3.0
   item_name: Enrich Entities
   item_type: Action
   publish_time: '2025-07-21'
   ticket_number: ''
   new: true
 - description: 'Oauth implmentation'
-  integration_version: 4.0
+  version: 4.0
   item_name: XMCyber
   item_type: Integration
   publish_time: '2025-11-18'
   ticket_number: ''
 - description: Updated integration metadata.
-  integration_version: 5.0
+  version: 5.0
   item_name: XMCyber
   item_type: Integration
   publish_time: '2026-03-18'

--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.30.2"
+version = "1.30.3"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/build_project/restructure/integrations/deconstruct.py
+++ b/packages/mp/src/mp/build_project/restructure/integrations/deconstruct.py
@@ -243,7 +243,7 @@ class DeconstructIntegration:
                 content=[
                     NonBuiltReleaseNote(
                         description="",
-                        integration_version=self.integration.metadata.version,
+                        version=self.integration.metadata.version,
                         item_name=self.integration.metadata.identifier,
                         item_type="Integration",
                         publish_time=str(datetime.datetime.now(datetime.UTC).date()),

--- a/packages/mp/src/mp/core/data_models/common/release_notes/metadata.py
+++ b/packages/mp/src/mp/core/data_models/common/release_notes/metadata.py
@@ -82,7 +82,8 @@ class BuiltReleaseNote(TypedDict):
 class NonBuiltReleaseNote(TypedDict):
     description: str
     deprecated: NotRequired[bool]
-    version: float
+    version: NotRequired[float]
+    integration_version: NotRequired[float]
     item_name: str
     item_type: str
     publish_time: NotRequired[str | None]
@@ -166,7 +167,7 @@ class ReleaseNote(SequentialMetadata[BuiltReleaseNote, NonBuiltReleaseNote]):
         return cls(
             description=non_built["description"],
             deprecated=non_built.get("deprecated", False),
-            version=non_built["version"],
+            version=non_built.get("version") or non_built["integration_version"],
             item_name=non_built["item_name"],
             item_type=non_built["item_type"],
             new=non_built.get("new", False),

--- a/packages/mp/src/mp/core/data_models/common/release_notes/metadata.py
+++ b/packages/mp/src/mp/core/data_models/common/release_notes/metadata.py
@@ -82,7 +82,7 @@ class BuiltReleaseNote(TypedDict):
 class NonBuiltReleaseNote(TypedDict):
     description: str
     deprecated: NotRequired[bool]
-    integration_version: float
+    version: float
     item_name: str
     item_type: str
     publish_time: NotRequired[str | None]
@@ -166,7 +166,7 @@ class ReleaseNote(SequentialMetadata[BuiltReleaseNote, NonBuiltReleaseNote]):
         return cls(
             description=non_built["description"],
             deprecated=non_built.get("deprecated", False),
-            version=non_built["integration_version"],
+            version=non_built["version"],
             item_name=non_built["item_name"],
             item_type=non_built["item_type"],
             new=non_built.get("new", False),
@@ -205,7 +205,7 @@ class ReleaseNote(SequentialMetadata[BuiltReleaseNote, NonBuiltReleaseNote]):
         """
         non_built: NonBuiltReleaseNote = NonBuiltReleaseNote(
             description=self.description,
-            integration_version=self.version,
+            version=self.version,
             item_name=self.item_name,
             item_type=self.item_type,
             publish_time=convert_epoch_to_iso(self.publish_time) if self.publish_time is not None else None,

--- a/packages/mp/src/mp/validate/validations/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/validations/integrations/release_notes_date_validation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import os
 import re
@@ -60,12 +61,10 @@ def _versions_on_main(rn_path: Path) -> set[str]:
         when the file does not yet exist on main or cannot be parsed.
 
     """
-    try:
+    with contextlib.suppress(mp.core.unix.NonFatalCommandError):
         base_content = yaml.safe_load(mp.core.unix.get_file_content_from_main_branch(rn_path))
         if isinstance(base_content, list):
-            return {_normalize_version(note.get("version", "")) for note in base_content}
-    except mp.core.unix.NonFatalCommandError:
-        pass  # File doesn't exist on main — new integration, validate all entries
+            return {_normalize_version(note.get("version") or note["integration_version"]) for note in base_content}
     return set()
 
 

--- a/packages/mp/src/mp/validate/validations/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/validations/integrations/release_notes_date_validation.py
@@ -63,7 +63,7 @@ def _versions_on_main(rn_path: Path) -> set[str]:
     try:
         base_content = yaml.safe_load(mp.core.unix.get_file_content_from_main_branch(rn_path))
         if isinstance(base_content, list):
-            return {_normalize_version(note.get("integration_version", "")) for note in base_content}
+            return {_normalize_version(note.get("version", "")) for note in base_content}
     except mp.core.unix.NonFatalCommandError:
         pass  # File doesn't exist on main — new integration, validate all entries
     return set()
@@ -101,7 +101,7 @@ def _perform_validation(content: list[dict], head_sha: str | None, existing_vers
     date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
     invalid: list[str] = []
     for note in content:
-        version = _normalize_version(note.get("integration_version", "?"))
+        version = _normalize_version(note.get("version", "?"))
         if head_sha and version in existing_versions:
             continue  # Pre-existing entry — skip
 

--- a/packages/mp/src/mp/validate/validations/integrations/release_notes_date_validation.py
+++ b/packages/mp/src/mp/validate/validations/integrations/release_notes_date_validation.py
@@ -101,7 +101,7 @@ def _perform_validation(content: list[dict], head_sha: str | None, existing_vers
     date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
     invalid: list[str] = []
     for note in content:
-        version = _normalize_version(note.get("version", "?"))
+        version = _normalize_version(note.get("version") or note.get("integration_version", "?"))
         if head_sha and version in existing_versions:
             continue  # Pre-existing entry — skip
 

--- a/packages/mp/src/mp/validate/validations/integrations/version_consistency_validation.py
+++ b/packages/mp/src/mp/validate/validations/integrations/version_consistency_validation.py
@@ -69,7 +69,7 @@ class VersionConsistencyValidation:
 
         # Get the latest release note version
         latest_rn = rn_content[-1]
-        rn_version = str(latest_rn.get("integration_version", ""))
+        rn_version = str(latest_rn.get("version", ""))
 
         # Normalize versions by stripping trailing ".0" for comparison
         # e.g. "1.0" matches "1", "2.0" matches "2"

--- a/packages/mp/src/mp/validate/validations/integrations/version_consistency_validation.py
+++ b/packages/mp/src/mp/validate/validations/integrations/version_consistency_validation.py
@@ -69,7 +69,7 @@ class VersionConsistencyValidation:
 
         # Get the latest release note version
         latest_rn = rn_content[-1]
-        rn_version = str(latest_rn.get("version", ""))
+        rn_version = str(latest_rn.get("version") or latest_rn.get("integration_version", ""))
 
         # Normalize versions by stripping trailing ".0" for comparison
         # e.g. "1.0" matches "1", "2.0" matches "2"

--- a/packages/mp/tests/test_mp/mock_content_hub/playbooks/third_party/community/mock_non_built_block/release_notes.yaml
+++ b/packages/mp/tests/test_mp/mock_content_hub/playbooks/third_party/community/mock_non_built_block/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Release description
-    integration_version: 1.0
+    version: 1.0
     item_name: Playbook name
     item_type: Playbook
     publish_time: '2025-11-06'

--- a/packages/mp/tests/test_mp/mock_content_hub/playbooks/third_party/community/mock_non_built_playbook/release_notes.yaml
+++ b/packages/mp/tests/test_mp/mock_content_hub/playbooks/third_party/community/mock_non_built_playbook/release_notes.yaml
@@ -1,5 +1,5 @@
 -   description: Release description
-    integration_version: 1.0
+    version: 1.0
     item_name: Playbook name
     item_type: Playbook
     publish_time: '2025-11-06'

--- a/packages/mp/tests/test_mp/mock_content_hub/response_integrations/third_party/mock_integration/release_notes.yaml
+++ b/packages/mp/tests/test_mp/mock_content_hub/response_integrations/third_party/mock_integration/release_notes.yaml
@@ -1,6 +1,6 @@
 - deprecated: true
   description: New Integration Added - Mock Integration.
-  integration_version: 1.0
+  version: 1.0
   item_name: Connector Name
   item_type: Connector
   new: true
@@ -9,7 +9,7 @@
   ticket_number: some ticket
 - deprecated: false
   description: Change Description 1
-  integration_version: 2.0
+  version: 2.0
   item_name: Integration Name
   item_type: Integration
   new: false
@@ -19,7 +19,7 @@
   ticket_number: some ticket
 - deprecated: false
   description: Change Description 2
-  integration_version: 2.0
+  version: 2.0
   item_name: Integration Name
   item_type: Integration
   new: false

--- a/packages/mp/tests/test_mp/test_core/test_data_models/test_release_notes/strategies.py
+++ b/packages/mp/tests/test_mp/test_core/test_data_models/test_release_notes/strategies.py
@@ -49,7 +49,7 @@ ST_VALID_NON_BUILT_RELEASE_NOTE_DICT = st.fixed_dictionaries(
         "Any",
         {
             "description": st_valid_long_description,
-            "integration_version": st_valid_version,
+            "version": st_valid_version,
             "item_name": st.text(),
             "item_type": st.text(),
         },

--- a/packages/mp/tests/test_mp/test_core/test_data_models/test_release_notes/test_metadata.py
+++ b/packages/mp/tests/test_mp/test_core/test_data_models/test_release_notes/test_metadata.py
@@ -42,3 +42,17 @@ class TestValidations:
     @given(valid_built=ST_VALID_BUILT_RELEASE_NOTE_DICT)
     def test_valid_built(self, valid_built: BuiltReleaseNote) -> None:
         ReleaseNote.from_built(valid_built)
+
+    def test_backward_compatibility_integration_version(self) -> None:
+        """
+        Verify that we can still load release notes that use 'integration_version' instead of 'version'.
+        """
+        legacy_data: NonBuiltReleaseNote = {
+            "description": "Legacy entry",
+            "integration_version": 1.0,
+            "item_name": "Test Integration",
+            "item_type": "Integration",
+        }
+        # This should not raise KeyError
+        rn = ReleaseNote.from_non_built(legacy_data)
+        assert rn.version == 1.0

--- a/packages/mp/tests/test_mp/test_validate/test_validations/test_integrations/test_release_notes_date_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_validations/test_integrations/test_release_notes_date_validation.py
@@ -31,41 +31,41 @@ if TYPE_CHECKING:
 VALIDATOR = ReleaseNotesDateValidation()
 
 VALID_RN = """\
-- integration_version: '1.0'
+- version: '1.0'
   publish_time: '2024-01-01'
   description: Initial release
 """
 
 INVALID_RN = """\
-- integration_version: '1.0'
+- version: '1.0'
   publish_time: ''
   description: Initial release
 """
 
 MISSING_PUBLISH_TIME_RN = """\
-- integration_version: '1.0'
+- version: '1.0'
   description: Initial release
 """
 
 TWO_ENTRY_RN_VALID = """\
-- integration_version: '2.0'
+- version: '2.0'
   publish_time: '2026-04-28'
   description: New feature
-- integration_version: '1.0'
+- version: '1.0'
   publish_time: '2024-01-01'
   description: Initial release
 """
 
 TWO_ENTRY_RN_OLD_MISSING = """\
-- integration_version: '2.0'
+- version: '2.0'
   publish_time: '2026-04-28'
   description: New feature
-- integration_version: '1.0'
+- version: '1.0'
   description: Initial release
 """
 
 OLD_MAIN_RN = """\
-- integration_version: '1.0'
+- version: '1.0'
   description: Initial release
 """
 
@@ -128,10 +128,10 @@ class TestReleaseNotesDateValidationCI:
     def test_new_invalid_entry_fails(self, temp_integration: Path) -> None:
         rn = temp_integration / "release_notes.yaml"
         new_rn = """\
-- integration_version: '2.0'
+- version: '2.0'
   publish_time: ''
   description: New feature
-- integration_version: '1.0'
+- version: '1.0'
   publish_time: '2024-01-01'
   description: Initial release
 """
@@ -208,14 +208,10 @@ class TestReleaseNotesDateValidationCI:
         so a pre-existing entry with version 1.0 (float) is skipped when comparing to a
         new entry at version 2.0, and the old float-versioned entry isn't re-validated."""
         # Main branch has unquoted 1.0 → parsed as float by yaml.safe_load
-        old_main_rn_unquoted = "- integration_version: 1.0\n  description: Initial\n"
+        old_main_rn_unquoted = "- version: 1.0\n  description: Initial\n"
         # Current file has new entry (2.0) plus pre-existing (1.0, no publish_time)
         current_rn = (
-            "- integration_version: 2.0\n"
-            "  publish_time: '2026-04-28'\n"
-            "  description: New\n"
-            "- integration_version: 1.0\n"
-            "  description: Initial\n"
+            "- version: 2.0\n  publish_time: '2026-04-28'\n  description: New\n- version: 1.0\n  description: Initial\n"
         )
         rn = temp_integration / "release_notes.yaml"
         rn.write_text(current_rn, encoding="utf-8")

--- a/packages/mp/tests/test_mp/test_validate/test_validations/test_integrations/test_version_bump_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_validations/test_integrations/test_version_bump_validation.py
@@ -41,7 +41,7 @@ dependencies = [
 OLD_RN_CONTENT = """
 -   deprecated: true
     description: New Integration Added - Mock Integration.
-    integration_version: 1.0
+    version: 1.0
     item_name: Connector Name
     item_type: Connector
     new: true
@@ -52,7 +52,7 @@ OLD_RN_CONTENT = """
 RN_ENTRY_TEMPLATE = """
 -   deprecated: true
     description: New Integration Added - Mock Integration.
-    integration_version: {version}
+    version: {version}
     item_name: Connector Name
     item_type: Connector
     new: true
@@ -75,7 +75,7 @@ def _setup_test_files(
 
 
 class TestVersionBumpValidationFlow:
-    def test_valid_existing_integration_version_bump_success(self, temp_integration: Path) -> None:
+    def test_valid_existing_version_bump_success(self, temp_integration: Path) -> None:
         old_toml_content = PYPROJECT_TOML_TEMPLATE.format(version="1.0")
         new_toml_content = PYPROJECT_TOML_TEMPLATE.format(version="2.0")
         new_rn_entry = RN_ENTRY_TEMPLATE.format(version="2.0")
@@ -97,7 +97,7 @@ class TestVersionBumpValidationFlow:
 
             _version_bump_validation_run_checks(existing_files, new_files)
 
-    def test_invalid_existing_integration_version_bump_fail(self, temp_integration: Path) -> None:
+    def test_invalid_existing_version_bump_fail(self, temp_integration: Path) -> None:
         old_toml_content = PYPROJECT_TOML_TEMPLATE.format(version="1.0")
         new_toml_content = PYPROJECT_TOML_TEMPLATE.format(version="3.0")
         new_rn_entry = RN_ENTRY_TEMPLATE.format(version="3.0")
@@ -116,7 +116,7 @@ class TestVersionBumpValidationFlow:
             with pytest.raises(NonFatalValidationError, match=r"must be incremented by exactly 1\.0"):
                 _version_bump_validation_run_checks(existing_files, new_files)
 
-    def test_invalid_existing_integration_version_bump_float_fail(
+    def test_invalid_existing_version_bump_float_fail(
         self,
         temp_integration: Path,
     ) -> None:

--- a/packages/mp/tests/test_mp/test_validate/test_validations/test_integrations/test_version_consistency_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_validations/test_integrations/test_version_consistency_validation.py
@@ -47,7 +47,7 @@ def _write_release_notes(integration_path: Path, versions: list[str]) -> None:
     """Write a release_notes.yaml with entries for the given versions."""
     entries = [
         {
-            "integration_version": v,
+            "version": v,
             "description": f"Release {v}",
             "publish_time": "2024-01-01",
             "item_name": "Integration Name",

--- a/packages/mp/tests/test_mp/test_validate/test_validations/test_playbooks/test_version_bump_validation.py
+++ b/packages/mp/tests/test_mp/test_validate/test_validations/test_playbooks/test_version_bump_validation.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 OLD_RN_CONTENT = """
 -   deprecated: true
     description: New Playbook Added - Mock Playbook.
-    integration_version: 1.0
+    version: 1.0
     item_name: Playbook Name
     item_type: Playbook
     new: true
@@ -45,7 +45,7 @@ OLD_RN_CONTENT = """
 RN_ENTRY_TEMPLATE = """
 -   deprecated: true
     description: New Playbook Added - Mock Playbook.
-    integration_version: {version}
+    version: {version}
     item_name: Playbook Name
     item_type: Playbook
     new: true

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.30.2"
+version = "1.30.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
- Update core data models and CLI logic in 'mp' package to use 'version' instead of 'integration_version' for release notes.
- Perform a global migration of all 'release_notes.yaml' files in the content directories
- Update tests and mock data to reflect the change.
