### PR TITLE
Fix: log successful SSH connections at info level

### DIFF
--- a/content/response_integrations/power_ups/git_sync/core/GitManager.py
+++ b/content/response_integrations/power_ups/git_sync/core/GitManager.py
@@ -631,18 +631,18 @@ class SiemplifyParamikoSSHVendor:
 
     def run_command(
         self,
-        host,
-        command,
-        username=None,
-        port=None,
-        password=None,
-        key_filename=None,
-        protocol_version=None,
-        **kwargs,
-    ):
+        host: str,
+        command: str,
+        username: str | None = None,
+        port: int | None = None,
+        password: Any = None,
+        key_filename: str | None = None,
+        protocol_version: int | None = None,
+        **kwargs: Any,
+    ) -> _ParamikoWrapper:
         client = paramiko.SSHClient()
 
-        connection_kwargs = {"hostname": host}
+        connection_kwargs: dict[str, Any] = {"hostname": host}
         connection_kwargs.update(self.kwargs)
         if username:
             connection_kwargs["username"] = username

--- a/content/response_integrations/power_ups/git_sync/core/GitManager.py
+++ b/content/response_integrations/power_ups/git_sync/core/GitManager.py
@@ -672,7 +672,7 @@ class SiemplifyParamikoSSHVendor:
         if protocol_version is None or protocol_version == 2:
             channel.set_environment_variable(name="GIT_PROTOCOL", value="version=2")
 
-        self.siemplify_logger.error(f"Successfully connected to {host}")
+        self.siemplify_logger.info(f"Successfully connected to {host}")
 
         channel.exec_command(command)
 

--- a/content/response_integrations/power_ups/git_sync/tests/test_git_manager.py
+++ b/content/response_integrations/power_ups/git_sync/tests/test_git_manager.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch, sentinel
+
+from ..core import GitManager
+
+
+def test_run_command_logs_successful_connection_at_info_level() -> None:
+    """Successful SSH connections should emit an info log, not an error log."""
+    logger = Mock()
+    client = Mock()
+    channel = Mock()
+    transport = Mock()
+    transport.open_session.return_value = channel
+    client.get_transport.return_value = transport
+
+    vendor = GitManager.SiemplifyParamikoSSHVendor(
+        siemplify_logger=logger,
+        git_server_fingerprint="SHA256:test-fingerprint",
+    )
+
+    with (
+        patch.object(GitManager.paramiko, "SSHClient", return_value=client),
+        patch.object(GitManager, "_ParamikoWrapper", return_value=sentinel.wrapper),
+    ):
+        result = vendor.run_command(
+            host="example.com",
+            command="git-upload-pack '/repo.git'",
+            protocol_version=2,
+        )
+
+    assert result is sentinel.wrapper
+    client.connect.assert_called_once_with(hostname="example.com")
+    channel.set_environment_variable.assert_called_once_with(
+        name="GIT_PROTOCOL",
+        value="version=2",
+    )
+    channel.exec_command.assert_called_once_with("git-upload-pack '/repo.git'")
+    logger.info.assert_any_call("Successfully connected to example.com")
+    logger.error.assert_not_called()


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

This fixes an incorrect error-level log on the successful SSH connection path in `GitManager`.

A successful SSH connection currently logs `Successfully connected to {host}` with `error` severity, which makes normal connections appear as failures in health monitoring and log-based alerting.

**How does this PR solve the problem?**

It changes that success log in `SiemplifyParamikoSSHVendor.run_command` from `error` to `info`.

**Any other relevant information (e.g. design choices, tradeoffs, known issues)?**

This is a logging-only change. It does not change SSH connection behavior or error handling.