### PR TITLE
  [MP] Capture and log tool output as debug in mp.core.unix

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.29.4"
+version = "1.29.5"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/core/unix.py
+++ b/packages/mp/src/mp/core/unix.py
@@ -46,6 +46,18 @@ class NonFatalCommandError(NonFatalValidationError):
     """Non-fatal error that happens during shell commands."""
 
 
+def _log_subprocess_result(result: sp.CompletedProcess[str] | sp.CalledProcessError) -> None:
+    """Log the output of a subprocess command.
+
+    Args:
+        result: The result of the subprocess command.
+    """
+    for line in (result.stdout or "").splitlines():
+        logger.debug(line)
+    for line in (result.stderr or "").splitlines():
+        logger.debug(line)
+
+
 def compile_core_integration_dependencies(project_path: Path, requirements_path: Path) -> None:
     """Compile/Export all project dependencies into a requirements' file.
 
@@ -82,11 +94,9 @@ def compile_core_integration_dependencies(project_path: Path, requirements_path:
 
     try:
         result = sp.run(command, cwd=project_path, check=True, text=True, capture_output=True)  # noqa: S603
-        if result.stdout:
-            logger.debug(result.stdout)
-        if result.stderr:
-            logger.debug(result.stderr)
+        _log_subprocess_result(result)
     except sp.CalledProcessError as e:
+        _log_subprocess_result(e)
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
 
@@ -109,11 +119,9 @@ def run_pip_command(command: list[str], cwd: Path) -> None:
     logger.debug("Running pip command: %s in %s", command, cwd)
     try:
         result = sp.run(command, cwd=cwd, capture_output=True, text=True, check=True)  # noqa: S603
-        if result.stdout:
-            logger.debug(result.stdout)
-        if result.stderr:
-            logger.debug(result.stderr)
+        _log_subprocess_result(result)
     except sp.CalledProcessError as e:
+        _log_subprocess_result(e)
         # Check if this is a safe-to-ignore error / marker issue
         if ignored_packages := _get_safe_to_ignore_packages(e):
             message = (
@@ -253,12 +261,9 @@ def _add_regular_dependencies_to_toml(deps_to_add: list[str], base_command: list
     deps_command.extend(deps_to_add)
     try:
         result = sp.run(deps_command, cwd=project_path, check=True, text=True, capture_output=True)  # noqa: S603
-        if result.stdout:
-            logger.debug(result.stdout)
-        if result.stderr:
-            logger.debug(result.stderr)
-
+        _log_subprocess_result(result)
     except sp.CalledProcessError as e:
+        _log_subprocess_result(e)
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
 
@@ -278,11 +283,9 @@ def _add_dev_dependencies_to_toml(dev_deps_to_add: list[str], base_command: list
         result = sp.run(  # noqa: S603
             dev_base_command, cwd=project_path, check=True, text=True, capture_output=True
         )
-        if result.stdout:
-            logger.debug(result.stdout)
-        if result.stderr:
-            logger.debug(result.stderr)
+        _log_subprocess_result(result)
     except sp.CalledProcessError as e:
+        _log_subprocess_result(e)
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
 
@@ -349,11 +352,9 @@ def init_python_project(project_path: Path) -> None:
 
     try:
         result = sp.run(command, cwd=project_path, check=True, text=True, capture_output=True)  # noqa: S603
-        if result.stdout:
-            logger.debug(result.stdout)
-        if result.stderr:
-            logger.debug(result.stderr)
+        _log_subprocess_result(result)
     except sp.CalledProcessError as e:
+        _log_subprocess_result(e)
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
 
@@ -579,12 +580,10 @@ def check_lock_file(project_path: Path) -> None:
         result = sp.run(  # noqa: S603
             command, cwd=project_path, check=True, text=True, capture_output=True
         )
-        if result.stdout:
-            logger.debug(result.stdout)
-        if result.stderr:
-            logger.debug(result.stderr)
+        _log_subprocess_result(result)
 
     except sp.CalledProcessError as e:
+        _log_subprocess_result(e)
         error_output = e.stderr.strip()
         error_output = f"{COMMAND_ERR_MSG.format('uv lock --check')}: {error_output}"
         raise NonFatalCommandError(error_output) from e

--- a/packages/mp/src/mp/core/unix.py
+++ b/packages/mp/src/mp/core/unix.py
@@ -46,18 +46,6 @@ class NonFatalCommandError(NonFatalValidationError):
     """Non-fatal error that happens during shell commands."""
 
 
-def _log_subprocess_result(result: sp.CompletedProcess[str] | sp.CalledProcessError) -> None:
-    """Log the output of a subprocess command.
-
-    Args:
-        result: The result of the subprocess command.
-    """
-    for line in (result.stdout or "").splitlines():
-        logger.debug(line)
-    for line in (result.stderr or "").splitlines():
-        logger.debug(line)
-
-
 def compile_core_integration_dependencies(project_path: Path, requirements_path: Path) -> None:
     """Compile/Export all project dependencies into a requirements' file.
 
@@ -671,3 +659,16 @@ def get_file_content_from_main_branch(file_path: Path) -> str:
 
 def _get_python_version() -> str:
     return f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
+def _log_subprocess_result(result: sp.CompletedProcess[str] | sp.CalledProcessError) -> None:
+    """Log the output of a subprocess command.
+
+    Args:
+        result: The result of the subprocess command.
+
+    """
+    for line in (result.stdout or "").splitlines():
+        logger.debug(line)
+    for line in (result.stderr or "").splitlines():
+        logger.debug(line)

--- a/packages/mp/src/mp/core/unix.py
+++ b/packages/mp/src/mp/core/unix.py
@@ -81,7 +81,11 @@ def compile_core_integration_dependencies(project_path: Path, requirements_path:
     logger.debug("Running command: %s", command)
 
     try:
-        sp.run(command, cwd=project_path, check=True, text=True)  # noqa: S603
+        result = sp.run(command, cwd=project_path, check=True, text=True, capture_output=True)  # noqa: S603
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
     except sp.CalledProcessError as e:
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
@@ -104,7 +108,11 @@ def run_pip_command(command: list[str], cwd: Path) -> None:
     """
     logger.debug("Running pip command: %s in %s", command, cwd)
     try:
-        sp.run(command, cwd=cwd, capture_output=True, text=True, check=True)  # noqa: S603
+        result = sp.run(command, cwd=cwd, capture_output=True, text=True, check=True)  # noqa: S603
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
     except sp.CalledProcessError as e:
         # Check if this is a safe-to-ignore error / marker issue
         if ignored_packages := _get_safe_to_ignore_packages(e):
@@ -244,7 +252,11 @@ def _add_regular_dependencies_to_toml(deps_to_add: list[str], base_command: list
     deps_command: list[str] = base_command.copy()
     deps_command.extend(deps_to_add)
     try:
-        sp.run(deps_command, cwd=project_path, check=True, text=True)  # noqa: S603
+        result = sp.run(deps_command, cwd=project_path, check=True, text=True, capture_output=True)  # noqa: S603
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
 
     except sp.CalledProcessError as e:
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
@@ -263,9 +275,13 @@ def _add_dev_dependencies_to_toml(dev_deps_to_add: list[str], base_command: list
     dev_base_command.extend(_get_base_dev_dependencies())
     dev_base_command.extend(dev_deps_to_add)
     try:
-        sp.run(  # noqa: S603
-            dev_base_command, cwd=project_path, check=True, text=True
+        result = sp.run(  # noqa: S603
+            dev_base_command, cwd=project_path, check=True, text=True, capture_output=True
         )
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
     except sp.CalledProcessError as e:
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
@@ -332,7 +348,11 @@ def init_python_project(project_path: Path) -> None:
     logger.debug("Running command: %s", command)
 
     try:
-        sp.run(command, cwd=project_path, check=True, text=True)  # noqa: S603
+        result = sp.run(command, cwd=project_path, check=True, text=True, capture_output=True)  # noqa: S603
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
     except sp.CalledProcessError as e:
         raise FatalCommandError(COMMAND_ERR_MSG.format(e)) from e
 
@@ -421,9 +441,9 @@ def execute_command_and_get_output(command: list[str], paths: Iterable[Path], **
     logger.debug("Executing command and capturing output: %s", command)
 
     try:
-        process: sp.Popen[bytes] = sp.Popen(command)  # noqa: S603
+        process: sp.Popen[bytes] = sp.Popen(command, stdout=sp.PIPE, stderr=sp.STDOUT)  # noqa: S603
         for line in _stream_process_output(process):
-            logger.info("%s", line.decode(errors="replace").rstrip())
+            logger.debug("%s", line.decode(errors="replace").rstrip())
 
         return process.wait()
 
@@ -556,9 +576,13 @@ def check_lock_file(project_path: Path) -> None:
     logger.debug("Checking lock file consistency: %s", command)
 
     try:
-        sp.run(  # noqa: S603
+        result = sp.run(  # noqa: S603
             command, cwd=project_path, check=True, text=True, capture_output=True
         )
+        if result.stdout:
+            logger.debug(result.stdout)
+        if result.stderr:
+            logger.debug(result.stderr)
 
     except sp.CalledProcessError as e:
         error_output = e.stderr.strip()

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.29.4"
+version = "1.29.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
  Description
  This PR refactors the command execution logic within src/mp/core/unix.py to capture and redirect the output of underlying tools (primarily uv and pip) to the
  application's debug logger.

  Previously, these tools would print progress and status messages (e.g., "Resolved 59 packages...") directly to the terminal. This cluttered the CLI output during
  standard operations like building or deconstructing integrations. By capturing this output and logging it as DEBUG, we ensure a cleaner "quiet-by-default" experience
  while preserving the ability to see full tool details when running with --verbose.

  Key Changes
   * Capture Subprocess Output: Updated sp.run calls in functions like compile_core_integration_dependencies, run_pip_command, and init_python_project to use
     capture_output=True.
   * Redirect to Debug Logger: Logged captured stdout and stderr using logger.debug on successful command completion.
   * Refactored Streaming Output: Updated execute_command_and_get_output to capture and stream subprocess output (e.g., from ruff or ty) directly to the debug logger
     instead of the info logger.
   * Maintained Error Visibility: Ensured that sp.CalledProcessError still handles failure output correctly for fatal error reporting.

  Testing
   * Manual Verification: Confirmed that uv and pip progress messages are hidden during standard builds but visible when using the -v flag.
   * Unit Tests: Executed pytest tests/test_mp/test_core/test_unix.py to verify that all command execution flows and error handling logic remains intact.