### PR TITLE
FIX: make package version resolution more robust

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.30.6"
+version = "1.30.7"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/build_project/restructure/integrations/deconstruct_dependencies.py
+++ b/packages/mp/src/mp/build_project/restructure/integrations/deconstruct_dependencies.py
@@ -260,8 +260,10 @@ def _find_package_file(package_dir: Path, wheel_name_prefix: str) -> Path:
 
     """
     for extension in PACAKGE_SUFFIXES:
-        for file in package_dir.glob(f"{wheel_name_prefix}{extension}"):
-            return file
+        ext_suffix = extension.lstrip("*")
+        for file in package_dir.glob(f"{wheel_name_prefix}*{ext_suffix}"):
+            if file.name.startswith(f"{wheel_name_prefix}-") or file.name == f"{wheel_name_prefix}{ext_suffix}":
+                return file
 
     msg: str = f"No wheel or source distribution found in {package_dir}"
     raise FileNotFoundError(msg)

--- a/packages/mp/src/mp/build_project/restructure/integrations/deconstruct_dependencies.py
+++ b/packages/mp/src/mp/build_project/restructure/integrations/deconstruct_dependencies.py
@@ -261,8 +261,10 @@ def _find_package_file(package_dir: Path, wheel_name_prefix: str) -> Path:
     """
     for extension in PACAKGE_SUFFIXES:
         ext_suffix = extension.lstrip("*")
+        wheel_prefix_with_dash = f"{wheel_name_prefix}-"
+        exact_match_name = f"{wheel_name_prefix}{ext_suffix}"
         for file in package_dir.glob(f"{wheel_name_prefix}*{ext_suffix}"):
-            if file.name.startswith(f"{wheel_name_prefix}-") or file.name == f"{wheel_name_prefix}{ext_suffix}":
+            if file.name.startswith(wheel_prefix_with_dash) or file.name == exact_match_name:
                 return file
 
     msg: str = f"No wheel or source distribution found in {package_dir}"

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.30.6"
+version = "1.30.7"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
force the mp version resolution for packages to find a full match (e.g when searching for version 1.0.11 dont take 1.0.11.1)