### PR TITLE
FIX: prioritize DefaultValue over empty Value string in ActionParameter

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.30.7"
+version = "1.30.8"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/core/data_models/integrations/action/parameter.py
+++ b/packages/mp/src/mp/core/data_models/integrations/action/parameter.py
@@ -108,7 +108,7 @@ class ActionParameter(
             name=built["Name"],
             optional_values=built.get("OptionalValues"),
             type_=ActionParamType(int(built["Type"])),
-            default_value=built.get("Value", built.get("DefaultValue")),
+            default_value=v if (v := built.get("Value")) not in {"", None} else built.get("DefaultValue"),
         )
 
     @classmethod

--- a/packages/mp/tests/test_mp/test_core/test_data_models/test_action/test_action_parameter.py
+++ b/packages/mp/tests/test_mp/test_core/test_data_models/test_action/test_action_parameter.py
@@ -42,3 +42,79 @@ class TestValidations:
     @given(valid_built=ST_VALID_BUILT_PARAM_DICT)
     def test_valid_built(self, valid_built: BuiltActionParameter) -> None:
         ActionParameter.from_built(valid_built)
+
+
+class TestActionParameterValues:
+    """
+    Tests for ActionParameter value selection logic (Value vs DefaultValue).
+    """
+
+    def test_from_built_empty_value_picks_default(self) -> None:
+        """Test that an empty string in 'Value' falls back to 'DefaultValue'."""
+        built: BuiltActionParameter = {
+            "Name": "test_param",
+            "Description": "test desc",
+            "IsMandatory": True,
+            "Type": 0,  # STRING
+            "Value": "",
+            "DefaultValue": "functional_default",
+            "OptionalValues": None,
+        }
+        param = ActionParameter.from_built(built)
+        assert param.default_value == "functional_default"
+
+    def test_from_built_none_value_picks_default(self) -> None:
+        """Test that None in 'Value' falls back to 'DefaultValue'."""
+        built: BuiltActionParameter = {
+            "Name": "test_param",
+            "Description": "test desc",
+            "IsMandatory": True,
+            "Type": 0,
+            "Value": None,
+            "DefaultValue": "functional_default",
+            "OptionalValues": None,
+        }
+        param = ActionParameter.from_built(built)
+        assert param.default_value == "functional_default"
+
+    def test_from_built_present_value_overrides_default(self) -> None:
+        """Test that a non-empty 'Value' is prioritized over 'DefaultValue'."""
+        built: BuiltActionParameter = {
+            "Name": "test_param",
+            "Description": "test desc",
+            "IsMandatory": True,
+            "Type": 0,
+            "Value": "user_value",
+            "DefaultValue": "default_value",
+            "OptionalValues": None,
+        }
+        param = ActionParameter.from_built(built)
+        assert param.default_value == "user_value"
+
+    def test_from_built_falsy_but_not_empty_value_preserved(self) -> None:
+        """Test that numeric 0 or False in 'Value' is NOT treated as 'empty'."""
+        # Test with 0
+        built_zero: BuiltActionParameter = {
+            "Name": "test_int",
+            "Description": "test desc",
+            "IsMandatory": True,
+            "Type": 0,
+            "Value": 0,
+            "DefaultValue": 100,
+            "OptionalValues": None,
+        }
+        param_zero = ActionParameter.from_built(built_zero)
+        assert param_zero.default_value == 0
+
+        # Test with False
+        built_false: BuiltActionParameter = {
+            "Name": "test_bool",
+            "Description": "test desc",
+            "IsMandatory": True,
+            "Type": 1,  # BOOLEAN
+            "Value": False,
+            "DefaultValue": True,
+            "OptionalValues": None,
+        }
+        param_false = ActionParameter.from_built(built_false)
+        assert param_false.default_value is False

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.30.7"
+version = "1.30.8"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
fix the logic for integrations with an empty strigng in their value key, and the real value in the DefaultValue key