### PR TITLE
Fix Abnormal Security Post Threat/Case Action endpoints (HTTP 405)

### DIFF
--- a/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
@@ -13,7 +13,6 @@ from urllib3.util.retry import Retry
 
 from .constants import (
     ACTIVITY_STATUS_ENDPOINT,
-    CASE_ACTION_ENDPOINT,
     CASE_BY_ID_ENDPOINT,
     CASES_ENDPOINT,
     CONTENT_TYPE_JSON,
@@ -42,7 +41,6 @@ from .constants import (
     MESSAGES_SEARCH_ENDPOINT,
     RETRY_BACKOFF_FACTOR,
     RETRY_STATUS_CODES,
-    THREAT_ACTION_ENDPOINT,
     THREAT_BY_ID_ENDPOINT,
     THREATS_ENDPOINT,
     USER_AGENT,
@@ -281,15 +279,20 @@ class AbnormalManager:
         action: str,
         message_ids: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Take action on a threat. POST /v1/threats/{id}/actions/{action_id}"""
+        """Take action on a threat. POST /v1/threats/{id} with {"action": ...} in body.
+
+        The /v1/threats/{id}/actions/{action_id} endpoint is GET-only — it returns
+        status for an already-submitted action. To submit a new action, POST to the
+        threat resource itself with the action verb in the body.
+        """
         if not threat_id:
             raise AbnormalValidationError(ERROR_MSG_MISSING_THREAT_ID)
         if action not in VALID_THREAT_ACTIONS:
             raise AbnormalValidationError(
                 f"{ERROR_MSG_INVALID_THREAT_ACTION} Valid: {', '.join(VALID_THREAT_ACTIONS)}"
             )
-        endpoint = THREAT_ACTION_ENDPOINT.format(threat_id=threat_id, action_id=action)
-        body: dict[str, Any] = {}
+        endpoint = THREAT_BY_ID_ENDPOINT.format(threat_id=threat_id)
+        body: dict[str, Any] = {"action": action}
         if message_ids:
             body["message_ids"] = message_ids
         return self._make_request("POST", endpoint, json_data=body)
@@ -316,12 +319,17 @@ class AbnormalManager:
         return self._make_request("GET", endpoint)
 
     def post_case_action(self, case_id: str, action: str) -> dict[str, Any]:
-        """Take action on a case. POST /v1/cases/{id}/actions/{action_id}"""
+        """Take action on a case. POST /v1/cases/{id} with {"action": ...} in body.
+
+        Same pattern as post_threat_action — /v1/cases/{id}/actions/{action_id} is
+        GET-only for status; submitting a new action goes to the case resource.
+        """
         if not case_id:
             raise AbnormalValidationError(ERROR_MSG_MISSING_CASE_ID)
         if action not in VALID_CASE_ACTIONS:
             raise AbnormalValidationError(
                 f"{ERROR_MSG_INVALID_CASE_ACTION} Valid: {', '.join(VALID_CASE_ACTIONS)}"
             )
-        endpoint = CASE_ACTION_ENDPOINT.format(case_id=case_id, action_id=action)
-        return self._make_request("POST", endpoint, json_data={})
+        endpoint = CASE_BY_ID_ENDPOINT.format(case_id=case_id)
+        body: dict[str, Any] = {"action": action}
+        return self._make_request("POST", endpoint, json_data=body)

--- a/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
@@ -279,11 +279,32 @@ class AbnormalManager:
         action: str,
         message_ids: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Take action on a threat. POST /v1/threats/{id} with {"action": ...} in body.
+        """Take action on a threat.
 
-        The /v1/threats/{id}/actions/{action_id} endpoint is GET-only — it returns
-        status for an already-submitted action. To submit a new action, POST to the
-        threat resource itself with the action verb in the body.
+        Submits a new action by POSTing to /v1/threats/{id} with the action
+        verb in the body. The /v1/threats/{id}/actions/{action_id} endpoint
+        is GET-only — it returns status for an already-submitted action, not
+        a submission endpoint.
+
+        Args:
+            threat_id: UUID of the threat to take action on.
+            action: Action verb to perform. Must be one of VALID_THREAT_ACTIONS
+                (currently "remediate" or "unremediate").
+            message_ids: Optional list of message IDs to scope the action to.
+                If omitted, the action applies to all messages in the threat.
+
+        Returns:
+            Decoded JSON response body from the Abnormal Security API,
+            including the submitted action_id and status fields.
+
+        Raises:
+            AbnormalValidationError: If threat_id is empty or action is not
+                in VALID_THREAT_ACTIONS.
+            AbnormalAuthenticationError: If the API rejects the credentials.
+            AbnormalRateLimitError: If the API returns HTTP 429.
+            AbnormalConnectionError: On network failures or timeouts.
+            AbnormalAPIManagerError: On other non-2xx responses or invalid
+                response bodies.
         """
         if not threat_id:
             raise AbnormalValidationError(ERROR_MSG_MISSING_THREAT_ID)
@@ -319,10 +340,31 @@ class AbnormalManager:
         return self._make_request("GET", endpoint)
 
     def post_case_action(self, case_id: str, action: str) -> dict[str, Any]:
-        """Take action on a case. POST /v1/cases/{id} with {"action": ...} in body.
+        """Take action on a case.
 
-        Same pattern as post_threat_action — /v1/cases/{id}/actions/{action_id} is
-        GET-only for status; submitting a new action goes to the case resource.
+        Submits a new action by POSTing to /v1/cases/{id} with the action
+        verb in the body. The /v1/cases/{id}/actions/{action_id} endpoint
+        is GET-only — it returns status for an already-submitted action, not
+        a submission endpoint.
+
+        Args:
+            case_id: ID of the case to take action on.
+            action: Action verb to perform. Must be one of VALID_CASE_ACTIONS
+                (action_required, acknowledge_resolved, acknowledge_in_progress,
+                acknowledge_not_an_attack).
+
+        Returns:
+            Decoded JSON response body from the Abnormal Security API,
+            including the submitted action_id and status fields.
+
+        Raises:
+            AbnormalValidationError: If case_id is empty or action is not
+                in VALID_CASE_ACTIONS.
+            AbnormalAuthenticationError: If the API rejects the credentials.
+            AbnormalRateLimitError: If the API returns HTTP 429.
+            AbnormalConnectionError: On network failures or timeouts.
+            AbnormalAPIManagerError: On other non-2xx responses or invalid
+                response bodies.
         """
         if not case_id:
             raise AbnormalValidationError(ERROR_MSG_MISSING_CASE_ID)

--- a/content/response_integrations/third_party/partner/abnormal_security/tests/core/session.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/tests/core/session.py
@@ -38,7 +38,7 @@ class AbnormalSession(MockSession[MockRequest, MockResponse, Abnormal]):
         except Exception as e:
             return MockResponse(content=str(e), status_code=500)
 
-    @router.post(r"/v1/threats/[^/]+/actions/[^/]+/?$")
+    @router.post(r"/v1/threats/[^/]+/?$")
     def post_threat_action(self, request: MockRequest) -> MockResponse:
         try:
             return MockResponse(content=self._product.post_threat_action())
@@ -59,7 +59,7 @@ class AbnormalSession(MockSession[MockRequest, MockResponse, Abnormal]):
         except Exception as e:
             return MockResponse(content=str(e), status_code=500)
 
-    @router.post(r"/v1/cases/[^/]+/actions/[^/]+/?$")
+    @router.post(r"/v1/cases/[^/]+/?$")
     def post_case_action(self, request: MockRequest) -> MockResponse:
         try:
             return MockResponse(content=self._product.post_case_action())


### PR DESCRIPTION
## Description

Follow-up fix for the recently merged Abnormal Security integration (#682).

The **Post Threat Action** and **Post Case Action** actions returned HTTP 405 when invoked:

\`\`\`
HTTP 405: {"detail": "Endpoint not found: POST abnormal.apps.soar_threats.views.threats.threat_action_id_endpoint"}
\`\`\`

## Root Cause

The integration was POSTing to \`/v1/threats/{id}/actions/{action_id}\` and \`/v1/cases/{id}/actions/{action_id}\`, but those URLs are **GET-only** — they return status for an already-submitted action.

To submit a new action, the Abnormal Security API expects:

- \`POST /v1/threats/{id}\` with body \`{"action": "remediate"}\`
- \`POST /v1/cases/{id}\` with body \`{"action": "acknowledge_resolved"}\`

The Django view at \`threat_by_id_endpoint\` is decorated \`@api_view(["GET", "POST"])\` where the POST branch dispatches to \`post_threat_action\`. Same for \`case_id_endpoint\`.

## Changes

- \`core/AbnormalManager.py\`:
  - \`post_threat_action()\` — POST to \`THREAT_BY_ID_ENDPOINT\` with action in body
  - \`post_case_action()\` — POST to \`CASE_BY_ID_ENDPOINT\` with action in body
  - Removed unused imports (\`THREAT_ACTION_ENDPOINT\`, \`CASE_ACTION_ENDPOINT\`)
- \`tests/core/session.py\` — updated MockSession route regexes to match new URL pattern

The \`THREAT_ACTION_ENDPOINT\` and \`CASE_ACTION_ENDPOINT\` constants remain in \`constants.py\` because they're still valid for a future \"Get Action Status\" action (GET on those URLs).

## Test Plan

\`\`\`
$ mp check content/response_integrations/third_party/partner/abnormal_security/
All checks passed!

$ mp validate -i AbnormalSecurity
All Validations Passed

$ mp test --integration abnormal_security
Integration: abnormal_security | Passed: 7 | Executed: 7 / 7 collected
All Tests Passed
\`\`\`

End-to-end verified manually against a real Abnormal tenant — Post Threat Action now returns 200 with an action submission ID instead of 405.

## Checklist

- [x] Followed [contributing.md](https://github.com/chronicle/content-hub/blob/main/docs/contributing.md)
- [x] Self-reviewed code
- [x] \`mp check\`, \`mp validate\`, \`mp test\` all pass locally
- [x] No PII or sensitive data
- [x] Public-safe content