### PR TITLE
FIX: Add missing EnvironmentCommon dependency to 5 Google integrations

### DIFF
--- a/content/response_integrations/google/fire_eye_ex/pyproject.toml
+++ b/content/response_integrations/google/fire_eye_ex/pyproject.toml
@@ -14,10 +14,11 @@
 
 [project]
 name = "FireEyeEX"
-version = "14.0"
+version = "15.0"
 description = "FireEye Email Security detects and blocks every kind of unwanted email, especially targeted advanced attacks. Time and again, this solution has proven itself capable of detecting corporate email threats in traffic accepted as safe by other products"
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "environmentcommon",
     "arrow==1.3.0",
     "defusedxml==0.7.1",
     "requests==2.32.4",
@@ -41,3 +42,6 @@ path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.12-py2.py3-none-any.wh
 
 [tool.uv.sources.soar-sdk]
 git = "https://github.com/chronicle/soar-sdk.git"
+
+[tool.uv.sources.environmentcommon]
+path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.1-py2.py3-none-any.whl"

--- a/content/response_integrations/google/fire_eye_ex/release_notes.yaml
+++ b/content/response_integrations/google/fire_eye_ex/release_notes.yaml
@@ -167,3 +167,13 @@
   deprecated: false
   removed: false
   ticket_number: '495762513'
+
+- description: 'Dependencies update'
+  version: 15.0
+  item_name: FireEyeEX
+  item_type: Integration
+  publish_time: '2026-05-13'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/google/fire_eye_ex/uv.lock
+++ b/content/response_integrations/google/fire_eye_ex/uv.lock
@@ -152,12 +152,21 @@ wheels = [
 ]
 
 [[package]]
+name = "environmentcommon"
+version = "1.0.1"
+source = { path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.1-py2.py3-none-any.whl" }
+wheels = [
+    { filename = "environmentcommon-1.0.1-py2.py3-none-any.whl", hash = "sha256:a3652bd23029ca01c7acd8e424bfc69f1525d6a9da81c165cb35ac8d107e091e" },
+]
+
+[[package]]
 name = "fireeyeex"
-version = "14.0"
+version = "15.0"
 source = { virtual = "." }
 dependencies = [
     { name = "arrow" },
     { name = "defusedxml" },
+    { name = "environmentcommon" },
     { name = "requests" },
     { name = "tipcommon" },
 ]
@@ -173,6 +182,7 @@ dev = [
 requires-dist = [
     { name = "arrow", specifier = "==1.3.0" },
     { name = "defusedxml", specifier = "==0.7.1" },
+    { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.1-py2.py3-none-any.whl" },
     { name = "requests", specifier = "==2.32.4" },
     { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.12-py2.py3-none-any.whl" },
 ]

--- a/content/response_integrations/google/illusive_networks/pyproject.toml
+++ b/content/response_integrations/google/illusive_networks/pyproject.toml
@@ -14,10 +14,11 @@
 
 [project]
 name = "IllusiveNetworks"
-version = "8.0"
+version = "9.0"
 description = "Shrink your organization’s attack surface. Find and eliminate the vulnerable credentials and connections that attackers use to escalate privileges and move laterally. Agentless, undetectable deception technology that creates a hostile environment for attackers, stopping lateral movement and access to your critical assets. Get actionable, real-time or on-demand forensic attack insight to accelerate blocking and remediation."
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "environmentcommon",
     "requests==2.32.4",
     "tipcommon",
 ]
@@ -39,3 +40,6 @@ path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.10-py3-none-any.whl"
 
 [tool.uv.sources.soar-sdk]
 git = "https://github.com/chronicle/soar-sdk.git"
+
+[tool.uv.sources.environmentcommon]
+path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl"

--- a/content/response_integrations/google/illusive_networks/release_notes.yaml
+++ b/content/response_integrations/google/illusive_networks/release_notes.yaml
@@ -107,3 +107,13 @@
   deprecated: false
   removed: false
   ticket_number: '495762513'
+
+- description: 'Dependencies update'
+  version: 9.0
+  item_name: IllusiveNetworks
+  item_type: Integration
+  publish_time: '2026-05-13'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/google/illusive_networks/uv.lock
+++ b/content/response_integrations/google/illusive_networks/uv.lock
@@ -143,6 +143,14 @@ wheels = [
 ]
 
 [[package]]
+name = "environmentcommon"
+version = "1.0.0"
+source = { path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl" }
+wheels = [
+    { filename = "environmentcommon-1.0.0-py3-none-any.whl", hash = "sha256:d0e9ebf77f4c1f0b444415270ea728f633fbd8cbfee23a5bb9c5e36161d14c16" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -166,9 +174,10 @@ wheels = [
 
 [[package]]
 name = "illusivenetworks"
-version = "8.0"
+version = "9.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "environmentcommon" },
     { name = "requests" },
     { name = "tipcommon" },
 ]
@@ -182,6 +191,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl" },
     { name = "requests", specifier = "==2.32.4" },
     { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.10-py3-none-any.whl" },
 ]

--- a/content/response_integrations/google/observe_it/pyproject.toml
+++ b/content/response_integrations/google/observe_it/pyproject.toml
@@ -14,10 +14,11 @@
 
 [project]
 name = "ObserveIT"
-version = "6.0"
+version = "7.0"
 description = "The ObserveIT platform correlates activity and data movement, empowering security teams to identify user risk, detect to insider-led data breaches, and accelerate security incident response.  Leveraging a powerful contextual intelligence engine and a library of over 400 threat templates drawn from customers and leading cybersecurity frameworks, ObserveIT delivers rapid time to value and proven capability to streamline insider threat programs."
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "environmentcommon",
     "requests==2.32.4",
     "tipcommon",
 ]
@@ -39,3 +40,6 @@ path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.11-py2.py3-none-any.wh
 
 [tool.uv.sources.soar-sdk]
 git = "https://github.com/chronicle/soar-sdk.git"
+
+[tool.uv.sources.environmentcommon]
+path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.2-py2.py3-none-any.whl"

--- a/content/response_integrations/google/observe_it/release_notes.yaml
+++ b/content/response_integrations/google/observe_it/release_notes.yaml
@@ -78,3 +78,13 @@
   deprecated: false
   removed: false
   ticket_number: '495762513'
+
+- description: 'Dependencies update'
+  version: 7.0
+  item_name: ObserveIT
+  item_type: Integration
+  publish_time: '2026-05-13'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/google/observe_it/uv.lock
+++ b/content/response_integrations/google/observe_it/uv.lock
@@ -143,6 +143,14 @@ wheels = [
 ]
 
 [[package]]
+name = "environmentcommon"
+version = "1.0.2"
+source = { path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.2-py2.py3-none-any.whl" }
+wheels = [
+    { filename = "environmentcommon-1.0.2-py2.py3-none-any.whl", hash = "sha256:a31d611ddf539fb081cfe9423a8d506d198fb5aefdb225c5534904ef9d80aaaa" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -175,9 +183,10 @@ wheels = [
 
 [[package]]
 name = "observeit"
-version = "6.0"
+version = "7.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "environmentcommon" },
     { name = "requests" },
     { name = "tipcommon" },
 ]
@@ -191,6 +200,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.2-py2.py3-none-any.whl" },
     { name = "requests", specifier = "==2.32.4" },
     { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.11-py2.py3-none-any.whl" },
 ]

--- a/content/response_integrations/google/outpost24/pyproject.toml
+++ b/content/response_integrations/google/outpost24/pyproject.toml
@@ -14,10 +14,11 @@
 
 [project]
 name = "Outpost24"
-version = "9.0"
+version = "10.0"
 description = "Outpost24 is a leading cyber assessment product focused on enabling its customers to achieve maximum value from their evolving technology investments. By leveraging their full stack security insights to reduce the attack surface for any architecture, Outpost24 customers continuously improve their security posture with the least effort."
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "environmentcommon",
     "requests==2.32.4",
     "tipcommon",
 ]
@@ -39,3 +40,6 @@ path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.10-py3-none-any.whl"
 
 [tool.uv.sources.soar-sdk]
 git = "https://github.com/chronicle/soar-sdk.git"
+
+[tool.uv.sources.environmentcommon]
+path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl"

--- a/content/response_integrations/google/outpost24/release_notes.yaml
+++ b/content/response_integrations/google/outpost24/release_notes.yaml
@@ -107,3 +107,13 @@
   deprecated: false
   removed: false
   ticket_number: '495762513'
+
+- description: 'Dependencies update'
+  version: 10.0
+  item_name: Outpost24
+  item_type: Integration
+  publish_time: '2026-05-13'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/google/outpost24/uv.lock
+++ b/content/response_integrations/google/outpost24/uv.lock
@@ -143,6 +143,14 @@ wheels = [
 ]
 
 [[package]]
+name = "environmentcommon"
+version = "1.0.0"
+source = { path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl" }
+wheels = [
+    { filename = "environmentcommon-1.0.0-py3-none-any.whl", hash = "sha256:d0e9ebf77f4c1f0b444415270ea728f633fbd8cbfee23a5bb9c5e36161d14c16" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -175,9 +183,10 @@ wheels = [
 
 [[package]]
 name = "outpost24"
-version = "9.0"
+version = "10.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "environmentcommon" },
     { name = "requests" },
     { name = "tipcommon" },
 ]
@@ -191,6 +200,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl" },
     { name = "requests", specifier = "==2.32.4" },
     { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.10-py3-none-any.whl" },
 ]

--- a/content/response_integrations/google/site24x7/pyproject.toml
+++ b/content/response_integrations/google/site24x7/pyproject.toml
@@ -14,10 +14,11 @@
 
 [project]
 name = "Site24x7"
-version = "7.0"
+version = "8.0"
 description = "Site24x7 offers unified cloud monitoring for DevOps and IT operations within small to large organizations. The solution monitors the experience of real users accessing websites and applications from desktop and mobile devices. In-depth monitoring capabilities enable DevOps teams to monitor and troubleshoot applications, servers and network infrastructure, including private and public clouds. End-user experience monitoring is done from more than 100 locations across the world and various wireless carriers."
 requires-python = ">=3.11,<3.12"
 dependencies = [
+    "environmentcommon",
     "python-dateutil>=2.9.0.post0",
     "requests==2.32.4",
     "tipcommon",
@@ -40,3 +41,6 @@ path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.10-py3-none-any.whl"
 
 [tool.uv.sources.soar-sdk]
 git = "https://github.com/chronicle/soar-sdk.git"
+
+[tool.uv.sources.environmentcommon]
+path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl"

--- a/content/response_integrations/google/site24x7/release_notes.yaml
+++ b/content/response_integrations/google/site24x7/release_notes.yaml
@@ -87,3 +87,13 @@
   deprecated: false
   removed: false
   ticket_number: '495762513'
+
+- description: 'Dependencies update'
+  version: 8.0
+  item_name: Site24x7
+  item_type: Integration
+  publish_time: '2026-05-13'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/google/site24x7/uv.lock
+++ b/content/response_integrations/google/site24x7/uv.lock
@@ -143,6 +143,14 @@ wheels = [
 ]
 
 [[package]]
+name = "environmentcommon"
+version = "1.0.0"
+source = { path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl" }
+wheels = [
+    { filename = "environmentcommon-1.0.0-py3-none-any.whl", hash = "sha256:d0e9ebf77f4c1f0b444415270ea728f633fbd8cbfee23a5bb9c5e36161d14c16" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -334,9 +342,10 @@ wheels = [
 
 [[package]]
 name = "site24x7"
-version = "7.0"
+version = "8.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "environmentcommon" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "tipcommon" },
@@ -351,6 +360,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.0-py3-none-any.whl" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "requests", specifier = "==2.32.4" },
     { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-1.0.10-py3-none-any.whl" },


### PR DESCRIPTION
This update resolves the import test missing 'EnvironmentCommon' for FireEyeEX, IllusiveNetworks, ObserveIT, Outpost24, and Site24x7. Each integration has been updated with the specific version of EnvironmentCommon found in its source dependencies, bumped in version, and had its release notes updated.