### PR TITLE
[b/512746920]Enforce Mandatory Nested JSON Structure for Parser Test Logs

### DIFF
--- a/docs/content_deep_dive/parsers/parser_structure.md
+++ b/docs/content_deep_dive/parsers/parser_structure.md
@@ -72,7 +72,23 @@ Each subdirectory under folder `cbn/` will contain the following files:
 * **references**: A public documentation link regarding the log source.
 
 **`testdata/` (Directory)**: This subdirectory houses files for testing the parser's correctness:
-* **`*_log.json` or `*.txt` files**: Sample raw log files (e.g., `sample_input_log.json`). These files contain representative log entries that the parser is expected to process. Naming of the file is flexible in the beginning but has to end with _log.json. 
+* **`*_log.json` or `*.txt` files**: Sample raw log files (e.g., `sample_input_log.json`). Naming of the file is flexible in the beginning but has to end with _log.json. 
+All the log files must follow the nested JSON format described below.
+
+```json
+{
+  "create_time": "YYYY-MM-DDTHH:MM:SS.ssssssZ", // The timestamp indicating when the log batch was generated. 
+  "raw_logs": { //
+    "start_time": "YYYY-MM-DDTHH:MM:SS.ssssssZ", // (Optional) The start timestamp for the collection window of these logs.
+    "entries": [ // A list of objects containing the log data.
+      {
+        "data": "The actual raw log string", // (Mandatory) The raw string of the log message to be parsed.
+        "collection_time": "YYYY-MM-DDTHH:MM:SS.ssssssZ" (optional) // The specific timestamp when this individual log entry was collected.
+      }
+    ]
+  }
+}
+```
 * **`*_events.json` files**: JSON files representing the expected UDM output for each corresponding input log file (e.g., `sample_input_events.json`). The JSON structure must conform to the publicly documented Google Security Operations UDM schema. This allows for validation without exposing internal proto definitions. Naming of the file is flexible but has to end with _events.json.
 
 **`Naming Convention for Logs and Events Files`**: For any log - event pair their prefixes are mandatariliy be same (e.g. `sample_input_log.json` and `sample_input_events.json`). There can be multiple such pairs of logs and events.

--- a/docs/content_deep_dive/parsers/parser_structure.md
+++ b/docs/content_deep_dive/parsers/parser_structure.md
@@ -83,7 +83,7 @@ All the log files must follow the nested JSON format described below.
     "entries": [ // A list of objects containing the log data.
       {
         "data": "The actual raw log string", // (Mandatory) The raw string of the log message to be parsed.
-        "collection_time": "YYYY-MM-DDTHH:MM:SS.ssssssZ" (optional) // The specific timestamp when this individual log entry was collected.
+        "collection_time": "YYYY-MM-DDTHH:MM:SS.ssssssZ" // (optional) The specific timestamp when this individual log entry was collected.
       }
     ]
   }

--- a/tools/parsers/validations/run_parser_validations.py
+++ b/tools/parsers/validations/run_parser_validations.py
@@ -151,14 +151,14 @@ def get_pretty_relpath(path: Path) -> str:
 
 def validate_log_structure(data: Any, file_name: str) -> bool:
     """Validates that the log file follows the required nested structure.
-    
+
     Expected Structure:
     {
       "create_time": "...",
       "raw_logs": {
         "start_time": "...",
         "entries": [
-          { "data": "...", "collection_time": "..." (optional) }
+          { "data": "...", "collection_time": "..." }
         ]
       }
     }
@@ -167,35 +167,23 @@ def validate_log_structure(data: Any, file_name: str) -> bool:
         logging.error(f"  Error: {file_name} structure is incorrect. It must be a JSON object.")
         return False
 
-    if "create_time" not in data:
-        logging.error(f"  Error: {file_name} structure is incorrect. Missing 'create_time' at the root.")
+    if not isinstance(data.get("create_time"), str):
+        logging.error(f"  Error: {file_name} structure is incorrect. Missing or invalid 'create_time' at the root (must be a string).")
         return False
 
-    if "raw_logs" not in data:
-        logging.error(f"  Error: {file_name} structure is incorrect. Missing 'raw_logs' at the root.")
-        return False
-
-    raw_logs = data["raw_logs"]
+    raw_logs = data.get("raw_logs")
     if not isinstance(raw_logs, dict):
-        logging.error(f"  Error: {file_name} structure is incorrect. 'raw_logs' must be an object.")
+        logging.error(f"  Error: {file_name} structure is incorrect. Missing or invalid 'raw_logs' object.")
         return False
 
-    if "entries" not in raw_logs:
-        logging.error(f"  Error: {file_name} structure is incorrect. 'raw_logs' is missing 'entries'.")
-        return False
-
-    entries = raw_logs["entries"]
-    if not isinstance(entries, list):
-        logging.error(f"  Error: {file_name} structure is incorrect. 'entries' must be a list.")
-        return False
-
-    if not entries:
-        logging.error(f"  Error: {file_name} structure is incorrect. 'entries' list is empty.")
+    entries = raw_logs.get("entries")
+    if not isinstance(entries, list) or not entries:
+        logging.error(f"  Error: {file_name} structure is incorrect. 'entries' must be a non-empty list.")
         return False
 
     for i, entry in enumerate(entries):
-        if not isinstance(entry, dict) or "data" not in entry:
-            logging.error(f"  Error: {file_name} structure is incorrect. Entry at index {i} is missing 'data' field.")
+        if not isinstance(entry, dict) or not isinstance(entry.get("data"), str):
+            logging.error(f"  Error: {file_name} structure is incorrect. Entry at index {i} must be an object with a 'data' string.")
             return False
 
     return True
@@ -287,8 +275,8 @@ def main(argv: list[str]) -> None:
             try:
                 metadata_data = json.loads(metadata_file.read_text())
                 actual_log_type = metadata_data.get("log_type", _DEFAULT_LOG_TYPE)
-            except json.JSONDecodeError:
-                logging.warning(f"  Warning: Could not parse {metadata_file}.")
+            except json.JSONDecodeError as e:
+                logging.warning(f"  Warning: Could not parse {metadata_file}: {e}. Using default log type '{_DEFAULT_LOG_TYPE}'.")
 
         raw_logs_path = cbn_path / "testdata" / "raw_logs"
         expected_events_path = cbn_path / "testdata" / "expected_events"
@@ -315,8 +303,8 @@ def main(argv: list[str]) -> None:
 
             try:
                 logs_data = json.loads(log_file.read_text())
-            except json.JSONDecodeError:
-                logging.error(f"  Error: Failed to parse JSON from {log_file.name}")
+            except json.JSONDecodeError as e:
+                logging.error(f"  Error: Failed to parse JSON from {log_file.name}: {e}")
                 continue
 
             if not validate_log_structure(logs_data, log_file.name):

--- a/tools/parsers/validations/run_parser_validations.py
+++ b/tools/parsers/validations/run_parser_validations.py
@@ -149,6 +149,58 @@ def get_pretty_relpath(path: Path) -> str:
     return os.path.relpath(path)
 
 
+def validate_log_structure(data: Any, file_name: str) -> bool:
+    """Validates that the log file follows the required nested structure.
+    
+    Expected Structure:
+    {
+      "create_time": "...",
+      "raw_logs": {
+        "start_time": "...",
+        "entries": [
+          { "data": "...", "collection_time": "..." (optional) }
+        ]
+      }
+    }
+    """
+    if not isinstance(data, dict):
+        logging.error(f"  Error: {file_name} structure is incorrect. It must be a JSON object.")
+        return False
+
+    if "create_time" not in data:
+        logging.error(f"  Error: {file_name} structure is incorrect. Missing 'create_time' at the root.")
+        return False
+
+    if "raw_logs" not in data:
+        logging.error(f"  Error: {file_name} structure is incorrect. Missing 'raw_logs' at the root.")
+        return False
+
+    raw_logs = data["raw_logs"]
+    if not isinstance(raw_logs, dict):
+        logging.error(f"  Error: {file_name} structure is incorrect. 'raw_logs' must be an object.")
+        return False
+
+    if "entries" not in raw_logs:
+        logging.error(f"  Error: {file_name} structure is incorrect. 'raw_logs' is missing 'entries'.")
+        return False
+
+    entries = raw_logs["entries"]
+    if not isinstance(entries, list):
+        logging.error(f"  Error: {file_name} structure is incorrect. 'entries' must be a list.")
+        return False
+
+    if not entries:
+        logging.error(f"  Error: {file_name} structure is incorrect. 'entries' list is empty.")
+        return False
+
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict) or "data" not in entry:
+            logging.error(f"  Error: {file_name} structure is incorrect. Entry at index {i} is missing 'data' field.")
+            return False
+
+    return True
+
+
 def main(argv: list[str]) -> None:
     """Runs parser validations on log types.
 
@@ -261,8 +313,19 @@ def main(argv: list[str]) -> None:
                 )
                 continue
 
-            logs_data = json.loads(log_file.read_text())
-            logs = logs_data.get("raw_logs", [])
+            try:
+                logs_data = json.loads(log_file.read_text())
+            except json.JSONDecodeError:
+                logging.error(f"  Error: Failed to parse JSON from {log_file.name}")
+                continue
+
+            if not validate_log_structure(logs_data, log_file.name):
+                logging.error(f"  Please fix the structure of {log_file.name} to match the expected nested format.")
+                # Use os._exit(1) to bypass absl exception handling and stop immediately.
+                os._exit(1)
+
+            # Extract raw logs from the validated structure
+            logs = [entry.get("data", "") for entry in logs_data["raw_logs"]["entries"]]
 
             logging.info(f"    Raw logs file: {get_pretty_relpath(log_file)}")
 


### PR DESCRIPTION
## Description

This PR introduces a standardized nested JSON structure for all parser test data files (`*_log.json`) and updates the validation script to enforce this format. This change ensures consistency across test datasets and provides a more robust validation process by including necessary metadata fields.

## Key Changes

### 1. Mandatory Log Structure
Updated `docs/content_deep_dive/parsers/parser_structure.md` to define the required nested JSON format for `*_log.json` files. The new structure includes:
- `create_time`: (Mandatory) Timestamp for the log batch.
- `raw_logs.start_time`: (Optional) Collection window start time.
- `raw_logs.entries`: (Mandatory) A list of log objects.
- `raw_logs.entries[].data`: (Mandatory) The actual raw log string.
- `raw_logs.entries[].collection_time`: (Optional) Individual collection timestamp.

### 2. Structural Validation Logic
Added a `validate_log_structure` helper function to `run_parser_validations.py`. This function performs deep checks on the presence and types of all required fields before any parsing logic is executed.

### 3. Fail-Fast Policy
Modified the validation script to implement an immediate "fail-fast" termination. If a log file does not conform to the new structure, the script logs a detailed error identifying the missing field and terminates the entire process using `os._exit(1)`. This prevents misleading success summaries or partial validation runs.

### 4. Updated Data Extraction
Refactored the core validation loop to correctly extract raw log strings from the new nested `raw_logs.entries[].data` path.

## Verification Results

- **Compliant Files**: Verified that files following the new nested structure are correctly parsed and validated.
- **Non-Compliant Files**: Verified that the script correctly identifies structural deficiencies (e.g., missing `create_time` or `data` fields) and terminates immediately with exit code `1`.

---


## Checklist:

Please ensure you have completed the following items before submitting your PR.
This helps us review your contribution faster and more efficiently.

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.

---

## Screenshots (If Applicable)

If your changes involve UI or visual elements, please include screenshots or GIFs here.
Ensure any sensitive data is redacted or generalized.

---

## Further Comments / Questions

Any additional comments, questions, or areas where you'd like specific feedback.
