### PR TITLE
FIX: relax mp requires-python to allow Python 3.12-3.14

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Hagit Eliahu", email = "haggit@google.com" },
     { name = "Eran Chriqui", email = "eranc@google.com" },
 ]
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.11,<3.15"
 keywords = [
     "mp",
     "google",


### PR DESCRIPTION
## Summary

Relax `requires-python` in `packages/mp/pyproject.toml` from `>=3.11,<3.12` to `>=3.11,<3.15`, allowing `mp` to be installed and used on Python 3.12, 3.13 and 3.14.

## Motivation

The current constraint locks `mp` to Python 3.11.x only. This contradicts:

- The classifiers in the same `pyproject.toml`, which already declare support for Python 3.12 and 3.13:
"Programming Language :: Python :: 3.12",
"Programming Language :: Python :: 3.13",


- The installation guide at `packages/mp/docs/installation.md`, which states "Python 3.11 or later (Python 3.11.0+ is officially supported)".

## Validation

Tested locally on Windows 11:

- `uv sync --python 3.14` resolves all dependencies cleanly, no conflicts.
- `mp --version` and `mp --help` work as expected.
- `mp validate playbook <name>` runs end-to-end and reports `All Validations Passed`.

Python versions covered by the new constraint: 3.11, 3.12, 3.13, 3.14 (matches the upper-bound style used by many libraries — leaves 3.15 to be re-tested when released).

## Notes

- No code changes, only the version constraint.
- On Windows, `PYTHONUTF8=1` is needed for emoji output in the console, but this is unrelated to `mp` and applies to any Python 3.x app printing Unicode on `cp1252` consoles.