### PR TITLE
Search Environment Custom Lists - Updated string search to be case-insensitive

### DIFF
--- a/content/response_integrations/power_ups/lists/actions/SearchEnvironmentCustomLists.py
+++ b/content/response_integrations/power_ups/lists/actions/SearchEnvironmentCustomLists.py
@@ -70,7 +70,7 @@ def main():
             if relevant_records:
                 if string:
                     for record in relevant_records:
-                        if string in record["entityIdentifier"]:
+                        if string.lower() in record["entityIdentifier"].lower():
                             match_records.append(record)
                 else:
                     match_records = relevant_records

--- a/content/response_integrations/power_ups/lists/actions/SearchEnvironmentCustomLists.py
+++ b/content/response_integrations/power_ups/lists/actions/SearchEnvironmentCustomLists.py
@@ -69,8 +69,9 @@ def main():
             match_records = []
             if relevant_records:
                 if string:
+                    string_lower = string.lower()
                     for record in relevant_records:
-                        if string.lower() in record["entityIdentifier"].lower():
+                        if string_lower in record["entityIdentifier"].lower():
                             match_records.append(record)
                 else:
                     match_records = relevant_records

--- a/content/response_integrations/power_ups/lists/pyproject.toml
+++ b/content/response_integrations/power_ups/lists/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Lists"
-version = "15.0"
+version = "16.0"
 description = "A set of tools to facilitate managing custom lists within Google SecOps."
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/power_ups/lists/release_notes.yaml
+++ b/content/response_integrations/power_ups/lists/release_notes.yaml
@@ -106,3 +106,9 @@
   item_type: Integration
   publish_time: '2026-05-20'
   ticket_number: '513210842'
+- description: Search Environment Custom Lists - Updated string search to be case-insensitive.
+  integration_version: 16.0
+  item_name: Search Environment Custom Lists
+  item_type: Action
+  publish_time: '2026-05-26'
+  ticket_number: '492433581'

--- a/content/response_integrations/power_ups/lists/release_notes.yaml
+++ b/content/response_integrations/power_ups/lists/release_notes.yaml
@@ -110,5 +110,5 @@
   integration_version: 16.0
   item_name: Search Environment Custom Lists
   item_type: Action
-  publish_time: '2026-05-26'
+  publish_time: '2026-05-27'
   ticket_number: '492433581'

--- a/content/response_integrations/power_ups/lists/uv.lock
+++ b/content/response_integrations/power_ups/lists/uv.lock
@@ -416,7 +416,7 @@ requires-dist = [
 
 [[package]]
 name = "lists"
-version = "15.0"
+version = "16.0"
 source = { virtual = "." }
 dependencies = [
     { name = "environmentcommon" },


### PR DESCRIPTION
## Title

[Buganizer ID: [492433581](https://b.corp.google.com/issues/492433581)] Fix: Make string search case-insensitive in Search Environment Custom Lists

---

## Description

**What problem does this PR solve?**
Fixes an issue where string searching within custom list records in the `Search Environment Custom Lists` action was case-sensitive. Users had to match the exact case of `entityIdentifier` to find records.

**How does this PR solve the problem?**
Modified the search condition in [SearchEnvironmentCustomLists.py](file:///usr/local/google/home/ryermilov/repos/content-hub/content/response_integrations/power_ups/lists/actions/SearchEnvironmentCustomLists.py#L73) to perform case-insensitive comparison using `.lower()`.

**Any other relevant information (e.g., design choices, tradeoffs, known issues):**
None. This is a straightforward, backward-compatible fix.

---

## Checklist:

Please ensure you have completed the following items before submitting your PR.
This helps us review your contribution faster and more efficiently.

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.

---
