### PR TITLE
[Buganizer ID: 514347461] Fix: Add "IPs/Ranges" parameter to mp exclusions and bump version

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.30.13"
+version = "1.30.14"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/core/data/exclusions.yaml
+++ b/packages/mp/src/mp/core/data/exclusions.yaml
@@ -152,6 +152,7 @@ excluded_param_display_names_for_regex:
   - "Track\\ New\\ Events\\ Threshold\\ \\(hours\\)"
   - "Token\\ Timeout\\ \\(in\\ Seconds\\)"
   - "Script\\ Timeout\\ \\(Seconds\\)"
+  - "IPs/Ranges"
 
 excluded_script_identifier_names_for_regex:
   - "Bitdefender GravityZone"

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.30.13"
+version = "1.30.14"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The `mp check` and `mp validate` validations fail on response integrations when a parameter name contains special characters such as a forward slash (`/`) (specifically `"IPs/Ranges"` used in the `qualys_vm` integration). Modifying the parameter name in the integration itself is not possible due to backward-compatibility requirements (avoiding customer regressions).

**How does this PR solve the problem?**
- Added `"IPs/Ranges"` to the `excluded_param_display_names_for_regex` list inside the `mp` CLI exclusions configuration (`packages/mp/src/mp/core/data/exclusions.yaml`). This allows the specific parameter display name to bypass strict character set validations.
- Bumped the `mp` CLI package version to `1.30.14` in `pyproject.toml` and synchronized the workspace dependencies using `uv version --bump patch` (updating `uv.lock`).

**Any other relevant information (e.g., design choices, tradeoffs, known issues):**
None. This is a non-breaking configuration addition that unblocks integration validation pipelines using the standard `mp` tool.

---

## Checklist:

### General Checks:
- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:
- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:
- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 514347461" or "Related Buganizer: go/buganizer/514347461").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.

---

## Further Comments / Questions

None.
