### PR TITLE
Abnormal Security: fix Get Activity Status tenant param

### DIFF
--- a/content/response_integrations/third_party/partner/abnormal_security/actions/GetActivityStatus.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/actions/GetActivityStatus.py
@@ -55,12 +55,13 @@ def main() -> None:
         is_mandatory=True,
         print_value=True,
     )
+    # Tenant scope is resolved from the API key; this field is optional and unused.
     tenant_ids_raw = siemplify.extract_action_param(
         param_name="Tenant IDs",
-        is_mandatory=True,
+        is_mandatory=False,
         print_value=True,
     )
-    tenant_ids = [t.strip() for t in tenant_ids_raw.split(",") if t.strip()]
+    tenant_ids = [t.strip() for t in tenant_ids_raw.split(",") if t.strip()] if tenant_ids_raw else None
 
     result_value = False
     status = EXECUTION_STATE_FAILED

--- a/content/response_integrations/third_party/partner/abnormal_security/actions/GetActivityStatus.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/actions/GetActivityStatus.yaml
@@ -12,8 +12,9 @@ parameters:
 -   name: Tenant IDs
     default_value: ''
     type: string
-    description: Comma-separated list of tenant IDs to query for remediation status.
-    is_mandatory: true
+    description: Optional. Tenant scope is resolved from the API key, so this field
+        is not required and is ignored by the status endpoint.
+    is_mandatory: false
 dynamic_results_metadata:
 -   result_example_path: resources/GetActivityStatus_JsonResult_example.json
     result_name: JsonResult

--- a/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
@@ -320,6 +320,9 @@ class AbnormalManager:
         The status endpoint scopes to the tenants authorized by the API key (resolved
         server-side from the bearer token) and rejects a tenant query param, so
         ``tenant_ids`` is accepted for signature compatibility but not sent.
+
+        Raises:
+            AbnormalValidationError: If activity_log_id is not provided.
         """
         if not activity_log_id:
             raise AbnormalValidationError(ERROR_MSG_MISSING_ACTIVITY_ID)
@@ -541,8 +544,9 @@ class AbnormalManager:
         params: dict[str, Any] = {"pageSize": page_size, "pageNumber": page_number}
         if tenant_ids:
             # The /v1/search/activities view reads request.GET.getlist("tenant_ids")
-            # (snake_case), so send that key — not camelCase.
-            params["tenant_ids"] = ",".join(tenant_ids)
+            # (snake_case). Pass a list so requests emits repeated query params
+            # (?tenant_ids=a&tenant_ids=b) rather than one comma-joined value.
+            params["tenant_ids"] = tenant_ids
         return self._make_request("GET", ACTIVITIES_LIST_ENDPOINT, params=params)
 
     # ── Inquiry ───────────────────────────────────────────────────────────────

--- a/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
@@ -32,7 +32,6 @@ from .constants import (
     ERROR_MSG_MISSING_ACTIVITY_ID,
     ERROR_MSG_MISSING_CASE_ID,
     ERROR_MSG_MISSING_INQUIRY_REPORTER,
-    ERROR_MSG_MISSING_TENANT_IDS,
     ERROR_MSG_MISSING_THREAT_ID,
     ERROR_MSG_NO_MESSAGES,
     ERROR_MSG_RATE_LIMIT,
@@ -314,17 +313,19 @@ class AbnormalManager:
     def get_activity_status(
         self,
         activity_log_id: str,
-        tenant_ids: list[str],
+        tenant_ids: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Get status of a remediation activity. GET /v1/search/activities/{id}/status"""
+        """Get status of a remediation activity. GET /v1/search/activities/{id}/status
+
+        The status endpoint scopes to the tenants authorized by the API key (resolved
+        server-side from the bearer token) and rejects a tenant query param, so
+        ``tenant_ids`` is accepted for signature compatibility but not sent.
+        """
         if not activity_log_id:
             raise AbnormalValidationError(ERROR_MSG_MISSING_ACTIVITY_ID)
-        if not tenant_ids:
-            raise AbnormalValidationError(ERROR_MSG_MISSING_TENANT_IDS)
 
         endpoint = ACTIVITY_STATUS_ENDPOINT.format(activity_log_id=activity_log_id)
-        params = {"tenant_ids": ",".join(tenant_ids)}
-        return self._make_request("GET", endpoint, params=params)
+        return self._make_request("GET", endpoint)
 
     # ── Threats ───────────────────────────────────────────────────────────────
 
@@ -539,7 +540,9 @@ class AbnormalManager:
         """
         params: dict[str, Any] = {"pageSize": page_size, "pageNumber": page_number}
         if tenant_ids:
-            params["tenantIds"] = ",".join(tenant_ids)
+            # The /v1/search/activities view reads request.GET.getlist("tenant_ids")
+            # (snake_case), so send that key — not camelCase.
+            params["tenant_ids"] = ",".join(tenant_ids)
         return self._make_request("GET", ACTIVITIES_LIST_ENDPOINT, params=params)
 
     # ── Inquiry ───────────────────────────────────────────────────────────────

--- a/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
+++ b/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AbnormalSecurity"
-version = "2.0"
+version = "3.0"
 description = "Abnormal Security uses AI to protect organizations from email attacks. This integration enables automated ingestion of threats and cases as SOAR alerts, plus search and remediation of malicious email messages through the Abnormal Security API. For support, contact: support@abnormalsecurity.com"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
+++ b/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AbnormalSecurity"
-version = "2.1"
+version = "3.0"
 description = "Abnormal Security uses AI to protect organizations from email attacks. This integration enables automated ingestion of threats and cases as SOAR alerts, plus search and remediation of malicious email messages through the Abnormal Security API. For support, contact: support@abnormalsecurity.com"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
+++ b/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AbnormalSecurity"
-version = "2.0"
+version = "2.1"
 description = "Abnormal Security uses AI to protect organizations from email attacks. This integration enables automated ingestion of threats and cases as SOAR alerts, plus search and remediation of malicious email messages through the Abnormal Security API. For support, contact: support@abnormalsecurity.com"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
+++ b/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AbnormalSecurity"
-version = "3.0"
+version = "2.0"
 description = "Abnormal Security uses AI to protect organizations from email attacks. This integration enables automated ingestion of threats and cases as SOAR alerts, plus search and remediation of malicious email messages through the Abnormal Security API. For support, contact: support@abnormalsecurity.com"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -27,16 +27,3 @@
   regressive: false
   deprecated: false
   removed: false
-- description: 'Fixed Get Activity Status: the status endpoint resolves tenant scope
-        from the API key and rejects a tenant query parameter, so the Tenant IDs field
-        is now optional and no longer sent. List Activities passes tenant_ids as
-        repeated query parameters in the casing the API expects.'
-  integration_version: 3.0
-  item_name: AbnormalSecurity
-  item_type: Integration
-  publish_time: '2026-06-09'
-  ticket_number: ''
-  new: false
-  regressive: false
-  deprecated: false
-  removed: false

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -31,7 +31,7 @@
         from the API key and rejects a tenant query parameter, so the Tenant IDs field
         is now optional and no longer sent. List Activities passes tenant_ids as
         repeated query parameters in the casing the API expects.'
-  integration_version: 2.1
+  integration_version: 3.0
   item_name: AbnormalSecurity
   item_type: Integration
   publish_time: '2026-06-10'

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -27,3 +27,16 @@
   regressive: false
   deprecated: false
   removed: false
+- description: 'Fixed Get Activity Status: the status endpoint resolves tenant scope
+        from the API key and rejects a tenant query parameter, so the Tenant IDs field
+        is now optional and no longer sent. List Activities passes tenant_ids as
+        repeated query parameters in the casing the API expects.'
+  integration_version: 3.0
+  item_name: AbnormalSecurity
+  item_type: Integration
+  publish_time: '2026-06-09'
+  ticket_number: ''
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -27,3 +27,16 @@
   regressive: false
   deprecated: false
   removed: false
+- description: 'Fixed Get Activity Status: the status endpoint resolves tenant scope
+        from the API key and rejects a tenant query parameter, so the Tenant IDs field
+        is now optional and no longer sent. List Activities sends tenant_ids in the
+        casing the API expects.'
+  integration_version: 3.0
+  item_name: AbnormalSecurity
+  item_type: Integration
+  publish_time: '2026-06-09'
+  ticket_number: ''
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -27,16 +27,3 @@
   regressive: false
   deprecated: false
   removed: false
-- description: 'Fixed Get Activity Status: the status endpoint resolves tenant scope
-        from the API key and rejects a tenant query parameter, so the Tenant IDs field
-        is now optional and no longer sent. List Activities sends tenant_ids in the
-        casing the API expects.'
-  integration_version: 3.0
-  item_name: AbnormalSecurity
-  item_type: Integration
-  publish_time: '2026-06-09'
-  ticket_number: ''
-  new: false
-  regressive: false
-  deprecated: false
-  removed: false

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -27,3 +27,16 @@
   regressive: false
   deprecated: false
   removed: false
+- description: 'Fixed Get Activity Status: the status endpoint resolves tenant scope
+        from the API key and rejects a tenant query parameter, so the Tenant IDs field
+        is now optional and no longer sent. List Activities passes tenant_ids as
+        repeated query parameters in the casing the API expects.'
+  integration_version: 2.1
+  item_name: AbnormalSecurity
+  item_type: Integration
+  publish_time: '2026-06-10'
+  ticket_number: ''
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/third_party/partner/abnormal_security/uv.lock
+++ b/content/response_integrations/third_party/partner/abnormal_security/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.11.*"
 
 [[package]]
 name = "abnormalsecurity"
-version = "2.0"
+version = "2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },

--- a/content/response_integrations/third_party/partner/abnormal_security/uv.lock
+++ b/content/response_integrations/third_party/partner/abnormal_security/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.11.*"
 
 [[package]]
 name = "abnormalsecurity"
-version = "2.1"
+version = "3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },

--- a/content/response_integrations/third_party/partner/abnormal_security/uv.lock
+++ b/content/response_integrations/third_party/partner/abnormal_security/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.11.*"
 
 [[package]]
 name = "abnormalsecurity"
-version = "2.0"
+version = "3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },

--- a/content/response_integrations/third_party/partner/abnormal_security/uv.lock
+++ b/content/response_integrations/third_party/partner/abnormal_security/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.11.*"
 
 [[package]]
 name = "abnormalsecurity"
-version = "3.0"
+version = "2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Description

Follow-up to #866 (merged). Fixes the **Get Activity Status** action, which returned `HTTP 400: Unsupported param key(s): tenant_ids` against a live SecOps SOAR tenant.

**What problem does this PR solve?**
`Get Activity Status` failed with `HTTP 400: Unsupported param key(s): tenant_ids`. The `/v1/search/activities/{id}/status` endpoint resolves tenant scope from the API key (bearer token) and the param-validation middleware rejects a tenant query param.

**How does this PR solve the problem?**
- `get_activity_status` no longer sends any tenant query param; the `Tenant IDs` field is now optional and ignored. Added a `Raises:` section to the docstring.
- `list_activities` passes `tenant_ids` as a list so `requests` emits repeated query params (`?tenant_ids=a&tenant_ids=b`), matching the view's `request.GET.getlist("tenant_ids")` (snake_case).
- Version bump `2.0 → 3.0` with a release note (marketplace version-bump validation).

**Other relevant information:**
Gemini review comments addressed: docstring `Raises` section, and list-vs-comma-joined tenant param serialization.

---

## Checklist:

### General Checks:

- [x] I have read and followed the project's contributing.md guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary. (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems.

---

## Test Plan

```bash
$ mp validate integration abnormal_security
Integration: abnormal_security | Passed: 22 | Executed: 22 / 22 validations

$ ruff check content/response_integrations/third_party/partner/abnormal_security
All checks passed!
```

- [x] Get Activity Status with only an Activity Log ID (Tenant IDs blank) — no longer rejected with `Unsupported param key(s): tenant_ids`.
- (reviewer) Confirm List Activities tenant filtering returns the expected scoped results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




