### PR TITLE
Fix SOCRadar connector context property and documentation link

### DIFF
--- a/content/response_integrations/third_party/partner/socradar_xti/connectors/SOCRadarAlarmsConnector.py
+++ b/content/response_integrations/third_party/partner/socradar_xti/connectors/SOCRadarAlarmsConnector.py
@@ -471,7 +471,8 @@ def main(is_test_run: bool = False) -> None:
         siemplify.LOGGER.info(f"Fetched {len(alarms)} alarms (total: {total})")
 
         # Deduplication — skip already-ingested alarm IDs
-        existing_ids = siemplify.get_connector_context_property("processed_ids") or ""
+        connector_id = siemplify.context.connector_info.identifier
+        existing_ids = siemplify.get_connector_context_property(connector_id, "processed_ids") or ""
         processed_set = {x for x in existing_ids.split(",") if x} if existing_ids else set()
 
         last_processed_ts = last_run
@@ -505,7 +506,7 @@ def main(is_test_run: bool = False) -> None:
         for alert in alerts:
             processed_set.add(alert.display_id)
         trimmed = sorted(processed_set, key=lambda x: int(x) if x.isdigit() else 0)[-1000:]
-        siemplify.set_connector_context_property("processed_ids", ",".join(trimmed))
+        siemplify.set_connector_context_property(connector_id, "processed_ids", ",".join(trimmed))
 
         if not is_test_run:
             # Save the newest processed alarm's timestamp (not "now") so we

--- a/content/response_integrations/third_party/partner/socradar_xti/connectors/SOCRadarAlarmsConnector.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/connectors/SOCRadarAlarmsConnector.yaml
@@ -125,7 +125,7 @@ description: >
   Severity mapped to risk-score bands (CRITICAL=90, HIGH=70, MEDIUM=50, LOW=30, INFO=10).
   Supports filtering by severity, status, main type, sub type, tags, and assignees.
 integration: SOCRadar
-documentation_link: https://socradar.io/docs
+documentation_link: https://help.socradar.io
 rules: []
 is_connector_rules_supported: false
 creator: SOCRadar

--- a/content/response_integrations/third_party/partner/socradar_xti/definition.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/definition.yaml
@@ -33,7 +33,7 @@ parameters:
   description: Separate API key for SOCRadar Rapid Reputation (add-on). Provides quick reputation lookups for IPs, domains, URLs, and hashes. Leave empty to skip.
   is_mandatory: false
   integration_identifier: SOCRadar
-documentation_link: https://socradar.io/docs
+documentation_link: https://help.socradar.io
 categories:
 - Threat Intelligence
 - Incident Management

--- a/content/response_integrations/third_party/partner/socradar_xti/pyproject.toml
+++ b/content/response_integrations/third_party/partner/socradar_xti/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SOCRadar"
-version = "1.1"
+version = "2.0"
 description = "Bidirectional integration between SOCRadar Extended Threat Intelligence (XTI) and Google SecOps SOAR. Ingests SOCRadar alarms as cases, provides IOC enrichment, threat feed collection, rapid reputation lookups, and full alarm lifecycle management. Support: integration@socradar.io"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/socradar_xti/pyproject.toml
+++ b/content/response_integrations/third_party/partner/socradar_xti/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SOCRadar"
-version = "1.0"
+version = "1.1"
 description = "Bidirectional integration between SOCRadar Extended Threat Intelligence (XTI) and Google SecOps SOAR. Ingests SOCRadar alarms as cases, provides IOC enrichment, threat feed collection, rapid reputation lookups, and full alarm lifecycle management. Support: integration@socradar.io"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
@@ -1,4 +1,14 @@
 - description: >
+    Fixed connector context property calls (get/set_connector_context_property)
+    that were missing the required identifier argument, causing TypeError at runtime.
+    Updated documentation link to https://help.socradar.io.
+  version: 1.1
+  item_name: SOCRadar
+  item_type: Integration
+  publish_time: '2026-06-16'
+  ticket_number: ''
+  new: false
+- description: >
     New integration added - SOCRadar XTI.
     Features: Alarm ingestion connector, 15 actions (Ping, GetAlarmDetails,
     AddComment, AddTag, RemoveTag, ChangeAlarmStatus, ChangeSeverity,

--- a/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
@@ -1,14 +1,4 @@
 - description: >
-    Fixed connector context property calls (get/set_connector_context_property)
-    that were missing the required identifier argument, causing TypeError at runtime.
-    Updated documentation link to https://help.socradar.io.
-  version: 2.0
-  item_name: SOCRadar
-  item_type: Integration
-  publish_time: '2026-06-16'
-  ticket_number: ''
-  new: false
-- description: >
     New integration added - SOCRadar XTI.
     Features: Alarm ingestion connector, 15 actions (Ping, GetAlarmDetails,
     AddComment, AddTag, RemoveTag, ChangeAlarmStatus, ChangeSeverity,
@@ -22,3 +12,13 @@
   publish_time: '2026-05-26'
   ticket_number: ''
   new: true
+- description: >
+    Fixed connector context property calls (get/set_connector_context_property)
+    that were missing the required identifier argument, causing TypeError at runtime.
+    Updated documentation link to https://help.socradar.io.
+  version: 2.0
+  item_name: SOCRadar
+  item_type: Integration
+  publish_time: '2026-06-16'
+  ticket_number: ''
+  new: false

--- a/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
@@ -2,7 +2,7 @@
     Fixed connector context property calls (get/set_connector_context_property)
     that were missing the required identifier argument, causing TypeError at runtime.
     Updated documentation link to https://help.socradar.io.
-  version: 1.1
+  version: 2.0
   item_name: SOCRadar
   item_type: Integration
   publish_time: '2026-06-16'

--- a/content/response_integrations/third_party/partner/socradar_xti/uv.lock
+++ b/content/response_integrations/third_party/partner/socradar_xti/uv.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "socradar"
-version = "1.0"
+version = "2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary
- **Bug fix:** `get_connector_context_property()` and `set_connector_context_property()` require `(identifier, property_key)` but were called with only `property_key`, causing `TypeError: missing 1 required positional argument: 'property_key'` at runtime. Added `connector_id = siemplify.context.connector_info.identifier` as the first argument.
- **Documentation link fix:** Updated `documentation_link` from `https://socradar.io/docs` (invalid) to `https://help.socradar.io` in `definition.yaml` and `SOCRadarAlarmsConnector.yaml`.

## Test plan
- [x] Deployed fixed connector to Google SecOps SOAR tenant
- [x] Ran connector test — returned `{"IsSuccess": true}`
- [x] Verified alarms are ingested as cases successfully
- [x] Verified `https://help.socradar.io` resolves correctly