### PR TITLE
Abnormal Security: send Soar-Integration-Origin header

### DIFF
--- a/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/core/AbnormalManager.py
@@ -39,6 +39,7 @@ from .constants import (
     ERROR_MSG_TIMEOUT,
     HEADER_AUTHORIZATION,
     HEADER_CONTENT_TYPE,
+    HEADER_SOAR_INTEGRATION_ORIGIN,
     HEADER_USER_AGENT,
     INQUIRY_ENDPOINT,
     MAX_RETRIES,
@@ -46,6 +47,7 @@ from .constants import (
     MESSAGES_SEARCH_ENDPOINT,
     RETRY_BACKOFF_FACTOR,
     RETRY_STATUS_CODES,
+    SOAR_INTEGRATION_ORIGIN,
     THREAT_ATTACHMENTS_ENDPOINT,
     THREAT_BY_ID_ENDPOINT,
     THREAT_LINKS_ENDPOINT,
@@ -189,6 +191,7 @@ class AbnormalManager:
             HEADER_AUTHORIZATION: f"Bearer {self.api_key}",
             HEADER_CONTENT_TYPE: CONTENT_TYPE_JSON,
             HEADER_USER_AGENT: USER_AGENT,
+            HEADER_SOAR_INTEGRATION_ORIGIN: SOAR_INTEGRATION_ORIGIN,
         })
         session.verify = self.verify_ssl
         return session

--- a/content/response_integrations/third_party/partner/abnormal_security/core/constants.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/core/constants.py
@@ -69,6 +69,11 @@ TERMINAL_STATUSES = {"success", "partial_success", "error"}
 HEADER_AUTHORIZATION = "Authorization"
 HEADER_CONTENT_TYPE = "Content-Type"
 HEADER_USER_AGENT = "User-Agent"
+# Identifies SOAR-originated API calls to the Abnormal Security backend. The
+# Abnormal SOAR API reads this header to apply the Google SecOps egress subnet
+# allowlist and origin metrics; without it requests default to "Rest API".
+HEADER_SOAR_INTEGRATION_ORIGIN = "Soar-Integration-Origin"
+SOAR_INTEGRATION_ORIGIN = "Google SecOps"
 CONTENT_TYPE_JSON = "application/json"
 
 # Connector

--- a/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
+++ b/content/response_integrations/third_party/partner/abnormal_security/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AbnormalSecurity"
-version = "3.0"
+version = "4.0"
 description = "Abnormal Security uses AI to protect organizations from email attacks. This integration enables automated ingestion of threats and cases as SOAR alerts, plus search and remediation of malicious email messages through the Abnormal Security API. For support, contact: support@abnormalsecurity.com"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/abnormal_security/release_notes.yaml
@@ -40,3 +40,16 @@
   regressive: false
   deprecated: false
   removed: false
+- description: 'Send the Soar-Integration-Origin: Google SecOps header on all API
+        requests so the Abnormal Security backend identifies SOAR-originated traffic
+        and applies the Google SecOps egress subnet allowlist (requests previously
+        defaulted to the generic Rest API origin).'
+  integration_version: 4.0
+  item_name: AbnormalSecurity
+  item_type: Integration
+  publish_time: '2026-06-17'
+  ticket_number: ''
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/third_party/partner/abnormal_security/tests/test_defaults/test_session_headers.py
+++ b/content/response_integrations/third_party/partner/abnormal_security/tests/test_defaults/test_session_headers.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from ...core.AbnormalManager import AbnormalManager
+from ...core.constants import (
+    HEADER_SOAR_INTEGRATION_ORIGIN,
+    SOAR_INTEGRATION_ORIGIN,
+    USER_AGENT,
+)
+
+
+class TestSessionHeaders:
+    def _manager(self) -> AbnormalManager:
+        return AbnormalManager(api_url="https://api.abnormalplatform.com", api_key="test-key")
+
+    def test_soar_integration_origin_header_is_set(self) -> None:
+        # The Abnormal SOAR API reads Soar-Integration-Origin to identify the
+        # calling platform and apply the Google SecOps egress subnet allowlist.
+        headers = self._manager().session.headers
+        assert headers[HEADER_SOAR_INTEGRATION_ORIGIN] == SOAR_INTEGRATION_ORIGIN
+        assert SOAR_INTEGRATION_ORIGIN == "Google SecOps"
+
+    def test_auth_and_user_agent_headers_are_set(self) -> None:
+        headers = self._manager().session.headers
+        assert headers["Authorization"] == "Bearer test-key"
+        assert headers["User-Agent"] == USER_AGENT

--- a/content/response_integrations/third_party/partner/abnormal_security/uv.lock
+++ b/content/response_integrations/third_party/partner/abnormal_security/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.11.*"
 
 [[package]]
 name = "abnormalsecurity"
-version = "3.0"
+version = "4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
API requests from the Google SecOps SOAR integration to the Abnormal Security backend did not send the `Soar-Integration-Origin` header, so they defaulted to the generic `Rest API` origin. The Abnormal SOAR API uses this header to identify the calling platform, apply the Google SecOps egress subnet allowlist, and label origin metrics.

**How does this PR solve the problem?**
- Send `Soar-Integration-Origin: Google SecOps` on every API request via the shared `requests` session in `AbnormalManager`.
- Added `HEADER_SOAR_INTEGRATION_ORIGIN` / `SOAR_INTEGRATION_ORIGIN` constants.
- Bumped `3.0 → 4.0` with a release note (marketplace version-bump rule requires +1.0).

## Checklist:

### General Checks:

- [x] I have read and followed the project's contributing.md guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary. (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems.

## Test Plan

```bash
$ mp validate integration abnormal_security
Integration: abnormal_security | Passed: 22 | Executed: 22 / 22 validations

$ ruff check content/response_integrations/third_party/partner/abnormal_security
All checks passed!
```

- [x] Verified the header is set on the session and sent on every request (Authorization, Content-Type, User-Agent, Soar-Integration-Origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
