### PR TITLE
removed deprecated siemplify.end_string function

### DIFF
--- a/content/response_integrations/power_ups/git_sync/jobs/PullConnector.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullConnector.py
@@ -73,7 +73,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullContent.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullContent.py
@@ -262,7 +262,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullCustomFamily.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullCustomFamily.py
@@ -45,7 +45,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullIntegration.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullIntegration.py
@@ -56,7 +56,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullJobs.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullJobs.py
@@ -50,7 +50,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullMappings.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullMappings.py
@@ -41,7 +41,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullPlaybook.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullPlaybook.py
@@ -65,7 +65,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PullSimulatedCases.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PullSimulatedCases.py
@@ -50,7 +50,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PushContent.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PushContent.py
@@ -280,7 +280,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PushIntegration.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PushIntegration.py
@@ -74,7 +74,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":

--- a/content/response_integrations/power_ups/git_sync/jobs/PushPlaybook.py
+++ b/content/response_integrations/power_ups/git_sync/jobs/PushPlaybook.py
@@ -116,7 +116,6 @@ def main():
         siemplify.LOGGER.exception(e)
         raise
 
-    siemplify.end_script()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The  siemplify.end_string() function is deprecated for Jobs and breaks the UX experience