### PR TITLE
FIX(workflow): refactor change detection to handle large scale PRs

### DIFF
--- a/.github/workflows/google_code_check.yml
+++ b/.github/workflows/google_code_check.yml
@@ -36,7 +36,6 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          list-files: csv
           # language=yaml
           filters: |
             mp:
@@ -55,7 +54,8 @@ jobs:
           FILTER_MP: ${{ steps.filter.outputs.mp }}
           FILTER_PACKAGES: ${{ steps.filter.outputs.integration_packages }}
           FILTER_GOOGLE: ${{ steps.filter.outputs.response_integrations_google }}
-          FILTER_GOOGLE_FILES: ${{ steps.filter.outputs.response_integrations_google_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         # language=bash
         run: |
           # If shared packages or mp changed, test everything
@@ -68,12 +68,21 @@ jobs:
 
           echo "test_all=false" >> $GITHUB_OUTPUT
 
+          # Get changed files directly from git to avoid environment variable limits
+          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]] || [[ -z "$BASE_SHA" ]]; then
+            # New branch or push without base, compare against parent
+            git diff --name-only --diff-filter=d HEAD~1 HEAD > changed_files.txt
+          else
+            # Use three-dot diff for PRs to get changes relative to the merge base
+            # For pushes, it works as a standard two-dot diff if the range is valid
+            git diff --name-only --diff-filter=d "$BASE_SHA...$HEAD_SHA" > changed_files.txt || \
+            git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" > changed_files.txt
+          fi
+
           INTEGRATIONS=""
           # Extract unique integration names from changed file paths (Google)
           if [[ "$FILTER_GOOGLE" == "true" ]]; then
-            GOOGLE_INTS=$(echo "$FILTER_GOOGLE_FILES" | tr ',' '\n' | \
-              sed 's/"//g' | \
-              grep "^content/response_integrations/google/" | \
+            GOOGLE_INTS=$(grep "^content/response_integrations/google/" changed_files.txt | \
               sed 's|content/response_integrations/google/||' | \
               cut -d'/' -f1 | \
               sort -u | \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
         id: filter
         with:
           base: ${{ github.event.pull_request.base.sha }}
-          list-files: csv
           # language=yaml
           filters: |
             mp:
@@ -55,9 +54,9 @@ jobs:
           FILTER_MP: ${{ steps.filter.outputs.mp }}
           FILTER_PACKAGES: ${{ steps.filter.outputs.integration_packages }}
           FILTER_THIRD_PARTY: ${{ steps.filter.outputs.response_integrations_third_party }}
-          FILTER_THIRD_PARTY_FILES: ${{ steps.filter.outputs.response_integrations_third_party_files }}
           FILTER_GOOGLE: ${{ steps.filter.outputs.response_integrations_google }}
-          FILTER_GOOGLE_FILES: ${{ steps.filter.outputs.response_integrations_google_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         # language=bash
         run: |
           # If shared packages or mp changed, test everything
@@ -70,12 +69,15 @@ jobs:
 
           echo "test_all=false" >> $GITHUB_OUTPUT
 
+          # Get changed files directly from git to avoid environment variable limits
+          # Use three-dot diff to get changes in the PR branch relative to the base branch
+          # Use --diff-filter=d to exclude deleted files (we can't test what's not there)
+          git diff --name-only --diff-filter=d "$BASE_SHA...$HEAD_SHA" > changed_files.txt
+
           INTEGRATIONS=""
           # Extract unique integration names from changed file paths (Third-Party/Power-Ups)
           if [[ "$FILTER_THIRD_PARTY" == "true" ]]; then
-            THIRD_PARTY_INTS=$(echo "$FILTER_THIRD_PARTY_FILES" | tr ',' '\n' | \
-              sed 's/"//g' | \
-              grep "^content/response_integrations/" | \
+            THIRD_PARTY_INTS=$(grep "^content/response_integrations/third_party/\|^content/response_integrations/power_up[s]*/" changed_files.txt | \
               sed 's|content/response_integrations/third_party/[^/]*/||' | \
               sed 's|content/response_integrations/power_up[s]*/||' | \
               cut -d'/' -f1 | \
@@ -86,9 +88,7 @@ jobs:
 
           # Extract unique integration names from changed file paths (Google)
           if [[ "$FILTER_GOOGLE" == "true" ]]; then
-            GOOGLE_INTS=$(echo "$FILTER_GOOGLE_FILES" | tr ',' '\n' | \
-              sed 's/"//g' | \
-              grep "^content/response_integrations/google/" | \
+            GOOGLE_INTS=$(grep "^content/response_integrations/google/" changed_files.txt | \
               sed 's|content/response_integrations/google/||' | \
               cut -d'/' -f1 | \
               sort -u | \

--- a/.github/workflows/third_party_code_check.yml
+++ b/.github/workflows/third_party_code_check.yml
@@ -38,7 +38,6 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
-          list-files: csv
           # language=yaml
           filters: |
             mp:
@@ -58,7 +57,8 @@ jobs:
           FILTER_MP: ${{ steps.filter.outputs.mp }}
           FILTER_PACKAGES: ${{ steps.filter.outputs.integration_packages }}
           FILTER_THIRD_PARTY: ${{ steps.filter.outputs.response_integrations_third_party }}
-          FILTER_THIRD_PARTY_FILES: ${{ steps.filter.outputs.response_integrations_third_party_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         # language=bash
         run: |
           # If shared packages or mp changed, test everything
@@ -71,12 +71,21 @@ jobs:
 
           echo "test_all=false" >> $GITHUB_OUTPUT
 
+          # Get changed files directly from git to avoid environment variable limits
+          if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]] || [[ -z "$BASE_SHA" ]]; then
+            # New branch or push without base, compare against parent
+            git diff --name-only --diff-filter=d HEAD~1 HEAD > changed_files.txt
+          else
+            # Use three-dot diff for PRs to get changes relative to the merge base
+            # For pushes, it works as a standard two-dot diff if the range is valid
+            git diff --name-only --diff-filter=d "$BASE_SHA...$HEAD_SHA" > changed_files.txt || \
+            git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" > changed_files.txt
+          fi
+
           INTEGRATIONS=""
           # Extract unique integration names from changed file paths (Third-Party/Power-Ups)
           if [[ "$FILTER_THIRD_PARTY" == "true" ]]; then
-            THIRD_PARTY_INTS=$(echo "$FILTER_THIRD_PARTY_FILES" | tr ',' '\n' | \
-              sed 's/"//g' | \
-              grep "^content/response_integrations/" | \
+            THIRD_PARTY_INTS=$(grep "^content/response_integrations/third_party/\|^content/response_integrations/power_up[s]*/" changed_files.txt | \
               sed 's|content/response_integrations/third_party/[^/]*/||' | \
               sed 's|content/response_integrations/power_up[s]*/||' | \
               cut -d'/' -f1 | \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,6 @@ jobs:
       uses: dorny/paths-filter@v3
       id: filter
       with:
-        list-files: csv
         # language=yaml
         filters: |
           mp:
@@ -64,13 +63,11 @@ jobs:
         FILTER_MP: ${{ steps.filter.outputs.mp }}
         FILTER_PACKAGES: ${{ steps.filter.outputs.integration_packages }}
         FILTER_THIRD_PARTY: ${{ steps.filter.outputs.response_integrations_third_party }}
-        FILTER_THIRD_PARTY_FILES: ${{ steps.filter.outputs.response_integrations_third_party_files }}
         FILTER_GOOGLE: ${{ steps.filter.outputs.response_integrations_google }}
-        FILTER_GOOGLE_FILES: ${{ steps.filter.outputs.response_integrations_google_files }}
         FILTER_PLAYBOOKS_THIRD_PARTY: ${{ steps.filter.outputs.playbooks_third_party }}
-        FILTER_PLAYBOOKS_THIRD_PARTY_FILES: ${{ steps.filter.outputs.playbooks_third_party_files }}
         FILTER_PLAYBOOKS_COMMERCIAL: ${{ steps.filter.outputs.playbooks_commercial }}
-        FILTER_PLAYBOOKS_COMMERCIAL_FILES: ${{ steps.filter.outputs.playbooks_commercial_files }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       # language=bash
       run: |
         # If shared packages or mp changed, validate everything
@@ -84,12 +81,20 @@ jobs:
         
         echo "test_all=false" >> $GITHUB_OUTPUT
         
+        # Get changed files directly from git to avoid environment variable limits
+        if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]] || [[ -z "$BASE_SHA" ]]; then
+          # New branch or push without base, compare against parent
+          git diff --name-only --diff-filter=d HEAD~1 HEAD > changed_files.txt
+        else
+          # Use three-dot diff for PRs to get changes relative to the merge base
+          git diff --name-only --diff-filter=d "$BASE_SHA...$HEAD_SHA" > changed_files.txt || \
+          git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" > changed_files.txt
+        fi
+
         INTEGRATIONS=""
         # Extract unique integration names from changed file paths (Third-Party/Power-Ups)
         if [[ "$FILTER_THIRD_PARTY" == "true" ]]; then
-          THIRD_PARTY_INTS=$(echo "$FILTER_THIRD_PARTY_FILES" | tr ',' '\n' | \
-            sed 's/"//g' | \
-            grep "^content/response_integrations/" | \
+          THIRD_PARTY_INTS=$(grep "^content/response_integrations/third_party/\|^content/response_integrations/power_up[s]*/" changed_files.txt | \
             sed 's|content/response_integrations/third_party/[^/]*/||' | \
             sed 's|content/response_integrations/power_up[s]*/||' | \
             cut -d'/' -f1 | \
@@ -100,9 +105,7 @@ jobs:
         
         # Extract unique integration names from changed file paths (Google)
         if [[ "$FILTER_GOOGLE" == "true" ]]; then
-          GOOGLE_INTS=$(echo "$FILTER_GOOGLE_FILES" | tr ',' '\n' | \
-            sed 's/"//g' | \
-            grep "^content/response_integrations/google/" | \
+          GOOGLE_INTS=$(grep "^content/response_integrations/google/" changed_files.txt | \
             sed 's|content/response_integrations/google/||' | \
             cut -d'/' -f1 | \
             sort -u | \
@@ -115,9 +118,7 @@ jobs:
         PLAYBOOKS=""
         # Extract unique playbook names from changed file paths (Third-Party)
         if [[ "$FILTER_PLAYBOOKS_THIRD_PARTY" == "true" ]]; then
-          THIRD_PARTY_PBS=$(echo "$FILTER_PLAYBOOKS_THIRD_PARTY_FILES" | tr ',' '\n' | \
-            sed 's/"//g' | \
-            grep "^content/playbooks/third_party/" | \
+          THIRD_PARTY_PBS=$(grep "^content/playbooks/third_party/" changed_files.txt | \
             sed 's|content/playbooks/third_party/[^/]*/||' | \
             cut -d'/' -f1 | \
             sort -u | \
@@ -127,9 +128,7 @@ jobs:
         
         # Extract unique playbook names from changed file paths (Commercial)
         if [[ "$FILTER_PLAYBOOKS_COMMERCIAL" == "true" ]]; then
-          COMMERCIAL_PBS=$(echo "$FILTER_PLAYBOOKS_COMMERCIAL_FILES" | tr ',' '\n' | \
-            sed 's/"//g' | \
-            grep "^content/playbooks/commercial/" | \
+          COMMERCIAL_PBS=$(grep "^content/playbooks/commercial/" changed_files.txt | \
             sed 's|content/playbooks/commercial/||' | \
             cut -d'/' -f1 | \
             sed 's/\.json$//' | \


### PR DESCRIPTION
refactor change detection to use git diff and avoid Argument list too long error

This change replaces the path-filter list-files (CSV) output with direct git diff commands, piping to temporary files to bypass environment variable limits. It also implements three-dot diffs for accurate PR change detection and --diff-filter=d to exclude deleted files.
