### PR TITLE
[Buganizer ID: 508550184] Feature: Implement Custom Fields and Alert Grouping Rules pull/push sync

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.32.0"
+version = "1.32.1"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/build_project/restructure/views/build.py
+++ b/packages/mp/src/mp/build_project/restructure/views/build.py
@@ -64,10 +64,18 @@ class ViewBuilder:
 
         """
         widgets_folder_path: Path = self.view_path / mp.core.constants.WIDGETS_DIR
+        used_html_filenames: set[str] = set()
         for i, w in enumerate(overview.widgets or []):
             if w.type is WidgetType.HTML:
                 sanitized_title = sanitize_widget_filename(w.title or "")
-                filename = sanitized_title or f"widget_{w.identifier or i}"
+                base_filename = sanitized_title or f"widget_{w.identifier or i}"
+                filename = base_filename
+                counter = 1
+                while filename.lower() in used_html_filenames:
+                    filename = f"{base_filename}_{counter}"
+                    counter += 1
+                used_html_filenames.add(filename.lower())
+
                 html_file_path = widgets_folder_path / f"{filename}.html"
                 if html_file_path.exists():
                     html_content = html_file_path.read_text(encoding="utf-8")

--- a/packages/mp/src/mp/build_project/restructure/views/deconstruct.py
+++ b/packages/mp/src/mp/build_project/restructure/views/deconstruct.py
@@ -73,9 +73,17 @@ class ViewDeconstructor:
 
         non_built_widgets: list[NonBuiltPlaybookWidgetMetadata] = [w.to_non_built() for w in self.overview.widgets]
 
+        used_filenames: set[str] = set()
         for i, w in enumerate(non_built_widgets):
             sanitized_title = sanitize_widget_filename(w.get("title") or "")
-            filename = sanitized_title or f"widget_{w.get('identifier') or i}"
+            base_filename = sanitized_title or f"widget_{w.get('identifier') or i}"
+            filename = base_filename
+            counter = 1
+            while filename.lower() in used_filenames:
+                filename = f"{base_filename}_{counter}"
+                counter += 1
+            used_filenames.add(filename.lower())
+
             widget_path: Path = widgets_path / f"{filename}{mp.core.constants.YAML_SUFFIX}"
             try:
                 mp.core.file_utils.save_yaml(w, widget_path)
@@ -89,10 +97,18 @@ class ViewDeconstructor:
                 )
                 raise
 
+        used_html_filenames: set[str] = set()
         for i, w in enumerate(self.overview.widgets):
             if w.type is WidgetType.HTML:
                 sanitized_title = sanitize_widget_filename(w.title or "")
-                filename = sanitized_title or f"widget_{w.identifier or i}"
+                base_filename = sanitized_title or f"widget_{w.identifier or i}"
+                filename = base_filename
+                counter = 1
+                while filename.lower() in used_html_filenames:
+                    filename = f"{base_filename}_{counter}"
+                    counter += 1
+                used_html_filenames.add(filename.lower())
+
                 widget_filename = f"{filename}.{mp.core.constants.HTML_SUFFIX}"
                 widget_path: Path = widgets_path / widget_filename
                 html_content: str = ""

--- a/packages/mp/src/mp/core/data_models/common/overview/metadata.py
+++ b/packages/mp/src/mp/core/data_models/common/overview/metadata.py
@@ -186,9 +186,7 @@ class Overview(SequentialMetadata[BuiltOverview, NonBuiltOverview]):
                     widget.widget_size = WidgetSize.from_string(w_d["size"])
                 widgets.append(widget)
             elif title:
-                err_msg = f"Widget '{title}' declared in widgets_details but not found in widgets directory."
-                logger.error(err_msg)
-                raise ValueError(err_msg)
+                logger.warning(f"Widget '{title}' declared in widgets_details but not found in widgets directory.")
 
         ov: Self = cls._from_non_built(non_built_view)
         ov.widgets = widgets

--- a/packages/mp/src/mp/core/data_models/common/overview/metadata.py
+++ b/packages/mp/src/mp/core/data_models/common/overview/metadata.py
@@ -40,6 +40,9 @@ class OverviewType(RepresentableEnum):
     SYSTEM_ALERT = 2
     SYSTEM_CASE = 3
     ALERT_TYPE = 4
+    SYSTEM_DEFAULT_CASE = 5
+    SYSTEM_DEFAULT_ALERT = 6
+    SYSTEM_DETECTION = 7
 
 
 class OverviewWidgetDetails(TypedDict):
@@ -168,8 +171,11 @@ class Overview(SequentialMetadata[BuiltOverview, NonBuiltOverview]):
 
         # Load all widgets from widgets/ directory
         all_widget: list[PlaybookWidgetMetadata] = PlaybookWidgetMetadata.from_non_built_path(path)
+        all_widget.sort(key=lambda w: w.order)
 
         widget_details: list[OverviewWidgetDetails] = non_built_view.get("widgets_details") or []
+        widget_details.sort(key=lambda wd: wd.get("order") or 0)
+        
         widget_by_title: dict[str, list[PlaybookWidgetMetadata]] = {}
         for w in all_widget:
             if w.title:
@@ -206,10 +212,13 @@ class Overview(SequentialMetadata[BuiltOverview, NonBuiltOverview]):
             alert_rule_type=built["OverviewTemplate"]["AlertRuleType"],
             roles=built["OverviewTemplate"]["Roles"],
             role_names=built.get("Roles", []),
-            widgets=[
-                PlaybookWidgetMetadata.from_built("", built_widget)
-                for built_widget in built["OverviewTemplate"]["Widgets"]
-            ],
+            widgets=sorted(
+                [
+                    PlaybookWidgetMetadata.from_built("", built_widget)
+                    for built_widget in built["OverviewTemplate"]["Widgets"]
+                ],
+                key=lambda w: w.order,
+            ),
         )
 
     @classmethod
@@ -269,7 +278,7 @@ class Overview(SequentialMetadata[BuiltOverview, NonBuiltOverview]):
                     size=w.widget_size.to_string(),
                     order=w.order,
                 )
-                for w in self.widgets
+                for w in sorted(self.widgets, key=lambda w: w.order)
             ],
         )
         return non_built

--- a/packages/mp/src/mp/core/data_models/common/overview/metadata.py
+++ b/packages/mp/src/mp/core/data_models/common/overview/metadata.py
@@ -186,7 +186,9 @@ class Overview(SequentialMetadata[BuiltOverview, NonBuiltOverview]):
                     widget.widget_size = WidgetSize.from_string(w_d["size"])
                 widgets.append(widget)
             elif title:
-                logger.warning(f"Widget '{title}' declared in widgets_details but not found in widgets directory.")
+                err_msg = f"Widget '{title}' declared in widgets_details but not found in widgets directory."
+                logger.error(err_msg)
+                raise ValueError(err_msg)
 
         ov: Self = cls._from_non_built(non_built_view)
         ov.widgets = widgets

--- a/packages/mp/src/mp/core/file_utils/__init__.py
+++ b/packages/mp/src/mp/core/file_utils/__init__.py
@@ -14,6 +14,9 @@
 
 from __future__ import annotations
 
+from .alert_grouping_rules import (
+    create_or_get_alert_grouping_rules_root_dir,
+)
 from .common import (
     VALID_REPEATED_FILES,
     create_dir_if_not_exists,
@@ -30,6 +33,9 @@ from .common import (
     remove_rglobs_if_exists,
     save_yaml,
     validate_safe_path,
+)
+from .custom_fields import (
+    create_or_get_custom_fields_root_dir,
 )
 from .integrations import (
     IntegrationParityValidator,
@@ -86,7 +92,9 @@ __all__: list[str] = [
     "base64_to_png_file",
     "create_dir_if_not_exists",
     "create_dirs_if_not_exists",
+    "create_or_get_alert_grouping_rules_root_dir",
     "create_or_get_content_dir",
+    "create_or_get_custom_fields_root_dir",
     "create_or_get_download_dir",
     "create_or_get_integrations_dir",
     "create_or_get_integrations_path",

--- a/packages/mp/src/mp/core/file_utils/alert_grouping_rules/__init__.py
+++ b/packages/mp/src/mp/core/file_utils/alert_grouping_rules/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .file_utils import create_or_get_alert_grouping_rules_root_dir
+
+__all__: list[str] = [
+    "create_or_get_alert_grouping_rules_root_dir",
+]

--- a/packages/mp/src/mp/core/file_utils/alert_grouping_rules/__init__.py
+++ b/packages/mp/src/mp/core/file_utils/alert_grouping_rules/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from .file_utils import create_or_get_alert_grouping_rules_root_dir
 
 __all__: list[str] = [

--- a/packages/mp/src/mp/core/file_utils/alert_grouping_rules/file_utils.py
+++ b/packages/mp/src/mp/core/file_utils/alert_grouping_rules/file_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import typing
+
+if typing.TYPE_CHECKING:
+    from pathlib import Path
+
+from mp.core.file_utils.common import create_or_get_content_dir
+
+logger = logging.getLogger(__name__)
+
+
+def create_or_get_alert_grouping_rules_root_dir() -> Path:
+    """Create or get the alert grouping rules root directory.
+
+    Returns:
+        The alert grouping rules root directory Path.
+
+    """
+    content_dir = create_or_get_content_dir()
+    alert_grouping_rules_dir = content_dir / "alert_grouping_rules"
+    alert_grouping_rules_dir.mkdir(parents=True, exist_ok=True)
+    return alert_grouping_rules_dir

--- a/packages/mp/src/mp/core/file_utils/custom_fields/__init__.py
+++ b/packages/mp/src/mp/core/file_utils/custom_fields/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .file_utils import create_or_get_custom_fields_root_dir
+
+__all__: list[str] = [
+    "create_or_get_custom_fields_root_dir",
+]

--- a/packages/mp/src/mp/core/file_utils/custom_fields/__init__.py
+++ b/packages/mp/src/mp/core/file_utils/custom_fields/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from .file_utils import create_or_get_custom_fields_root_dir
 
 __all__: list[str] = [

--- a/packages/mp/src/mp/core/file_utils/custom_fields/file_utils.py
+++ b/packages/mp/src/mp/core/file_utils/custom_fields/file_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import typing
+
+if typing.TYPE_CHECKING:
+    from pathlib import Path
+
+from mp.core.file_utils.common import create_or_get_content_dir
+
+logger = logging.getLogger(__name__)
+
+
+def create_or_get_custom_fields_root_dir() -> Path:
+    """Create or get the custom fields root directory.
+
+    Returns:
+        The custom fields root directory Path.
+
+    """
+    content_dir = create_or_get_content_dir()
+    custom_fields_dir = content_dir / "custom_fields"
+    custom_fields_dir.mkdir(parents=True, exist_ok=True)
+    return custom_fields_dir

--- a/packages/mp/src/mp/dev_env/__init__.py
+++ b/packages/mp/src/mp/dev_env/__init__.py
@@ -14,6 +14,10 @@
 
 from __future__ import annotations
 
+from .sub_commands.alert_grouping_rule.pull import pull_alert_grouping_rule
+from .sub_commands.alert_grouping_rule.push import push_alert_grouping_rule
+from .sub_commands.custom_field.pull import pull_custom_field
+from .sub_commands.custom_field.push import push_custom_field
 from .sub_commands.integration.pull import pull_integration
 from .sub_commands.integration.push import push_integration
 from .sub_commands.login import login
@@ -24,9 +28,13 @@ from .sub_commands.view.push import push_view
 
 __all__: list[str] = [
     "login",
+    "pull_alert_grouping_rule",
+    "pull_custom_field",
     "pull_integration",
     "pull_playbook",
     "pull_view",
+    "push_alert_grouping_rule",
+    "push_custom_field",
     "push_integration",
     "push_playbook",
     "push_view",

--- a/packages/mp/src/mp/dev_env/api.py
+++ b/packages/mp/src/mp/dev_env/api.py
@@ -268,3 +268,104 @@ class BackendAPI:
         resp = self.session.post(url, json=view_data)
         resp.raise_for_status()
         return resp.json()
+
+    def list_custom_fields(self) -> list[dict[str, Any]]:
+        """List all custom fields from the SOAR platform.
+
+        Returns:
+            list[dict[str, Any]]: The list of custom fields.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/customFields"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        return resp.json().get("items", [])
+
+    def download_custom_field(self, field_id: int) -> dict[str, Any]:
+        """Download a custom field by ID from the SOAR platform.
+
+        Args:
+            field_id: The ID of the custom field.
+
+        Returns:
+            dict: The custom field details.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/customFields/{field_id}"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+    def create_custom_field(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new custom field on the SOAR platform.
+
+        Args:
+            data: The custom field data.
+
+        Returns:
+            dict: The created custom field details.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/customFields"
+        resp = self.session.post(url, json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_custom_field(self, field_id: int, data: dict[str, Any]) -> dict[str, Any]:
+        """Update an existing custom field on the SOAR platform.
+
+        Args:
+            field_id: The ID of the custom field.
+            data: The custom field data.
+
+        Returns:
+            dict: The updated custom field details.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/customFields/{field_id}"
+        resp = self.session.patch(url, json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_alert_grouping_rules(self) -> list[dict[str, Any]]:
+        """List all alert grouping rules from the SOAR platform.
+
+        Returns:
+            list[dict[str, Any]]: The list of alert grouping rules.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        return resp.json().get("items", [])
+
+    def create_alert_grouping_rule(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new alert grouping rule on the SOAR platform.
+
+        Args:
+            data: The alert grouping rule data.
+
+        Returns:
+            dict: The created alert grouping rule details.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules"
+        resp = self.session.post(url, json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_alert_grouping_rule(self, rule_id: int, data: dict[str, Any]) -> dict[str, Any]:
+        """Update an existing alert grouping rule on the SOAR platform.
+
+        Args:
+            rule_id: The ID of the alert grouping rule.
+            data: The alert grouping rule data.
+
+        Returns:
+            dict: The updated alert grouping rule details.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules/{rule_id}"
+        resp = self.session.put(url, json=data)
+        resp.raise_for_status()
+        return resp.json()

--- a/packages/mp/src/mp/dev_env/api.py
+++ b/packages/mp/src/mp/dev_env/api.py
@@ -378,6 +378,6 @@ class BackendAPI:
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules/{rule_id}"
-        resp = self.session.put(url, json=data)
+        resp = self.session.patch(url, json=data)
         resp.raise_for_status()
         return resp.json()

--- a/packages/mp/src/mp/dev_env/api.py
+++ b/packages/mp/src/mp/dev_env/api.py
@@ -288,7 +288,7 @@ class BackendAPI:
             field_id: The ID of the custom field.
 
         Returns:
-            dict: The custom field details.
+            The custom field details.
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/customFields/{field_id}"
@@ -303,7 +303,7 @@ class BackendAPI:
             data: The custom field data.
 
         Returns:
-            dict: The created custom field details.
+            The created custom field details.
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/customFields"
@@ -319,7 +319,7 @@ class BackendAPI:
             data: The custom field data.
 
         Returns:
-            dict: The updated custom field details.
+            The updated custom field details.
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/customFields/{field_id}"
@@ -331,7 +331,7 @@ class BackendAPI:
         """List all alert grouping rules from the SOAR platform.
 
         Returns:
-            list[dict[str, Any]]: The list of alert grouping rules.
+            The list of alert grouping rules.
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules"
@@ -346,7 +346,7 @@ class BackendAPI:
             data: The alert grouping rule data.
 
         Returns:
-            dict: The created alert grouping rule details.
+            The created alert grouping rule details.
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules"
@@ -362,7 +362,7 @@ class BackendAPI:
             data: The alert grouping rule data.
 
         Returns:
-            dict: The updated alert grouping rule details.
+            The updated alert grouping rule details.
 
         """
         url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules/{rule_id}"

--- a/packages/mp/src/mp/dev_env/api.py
+++ b/packages/mp/src/mp/dev_env/api.py
@@ -178,6 +178,43 @@ class BackendAPI:
         resp.raise_for_status()
         return resp
 
+    def list_installed_integrations(self) -> list[dict[str, Any]]:
+        """List all installed integrations on the SOAR platform.
+
+        Returns:
+            The list of installed integrations.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/integrations"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        if resp.status_code == 204:
+            return []
+        data = resp.json()
+        if isinstance(data, dict):
+            return data.get("items", [])
+        return data if isinstance(data, list) else []
+
+    def list_integration_instances(self, integration_id: str = "$all") -> list[dict[str, Any]]:
+        """List integration instances for a given integration identifier or all integrations.
+
+        Args:
+            integration_id: The integration identifier, defaults to '$all'.
+
+        Returns:
+            The list of integration instances.
+
+        """
+        url: str = f"{self.api_root}/api/1p/external/v1/integrations/{integration_id}/integrationInstances"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        if resp.status_code == 204:
+            return []
+        data = resp.json()
+        if isinstance(data, dict):
+            return data.get("items", [])
+        return data if isinstance(data, list) else []
+
     def upload_playbook(self, zip_path: Path) -> dict[str, Any]:
         """Upload a zipped playbook package to the backend.
 

--- a/packages/mp/src/mp/dev_env/api.py
+++ b/packages/mp/src/mp/dev_env/api.py
@@ -266,6 +266,8 @@ class BackendAPI:
         """
         url: str = f"{self.api_root}/api/external/v1/case-overview/SaveOverviewTemplate"
         resp = self.session.post(url, json=view_data)
+        if not resp.ok:
+            logger.error(f"SaveOverviewTemplate failed with status {resp.status_code}. Response: {resp.text}")
         resp.raise_for_status()
         return resp.json()
 
@@ -278,8 +280,16 @@ class BackendAPI:
         """
         url: str = f"{self.api_root}/api/1p/external/v1/customFields"
         resp = self.session.get(url)
+        if not resp.ok:
+            logger.error(f"list_custom_fields failed: {resp.status_code} - {resp.text}")
         resp.raise_for_status()
-        return resp.json().get("items", [])
+        if resp.status_code == 204:
+            return []
+        try:
+            return resp.json().get("items", [])
+        except Exception:
+            logger.error(f"JSON Decode Error in list_custom_fields. Response text: {resp.text}")
+            raise
 
     def download_custom_field(self, field_id: int) -> dict[str, Any]:
         """Download a custom field by ID from the SOAR platform.
@@ -337,6 +347,8 @@ class BackendAPI:
         url: str = f"{self.api_root}/api/1p/external/v1/system/settings/alert-grouping-rules"
         resp = self.session.get(url)
         resp.raise_for_status()
+        if resp.status_code == 204:
+            return []
         return resp.json().get("items", [])
 
     def create_alert_grouping_rule(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/__init__.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/__init__.py
@@ -1,1 +1,3 @@
 # Copyright 2026 Google LLC
+
+from __future__ import annotations

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/__init__.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2026 Google LLC

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path  # noqa: TC003
+from typing import Annotated
+
+import typer
+
+import mp.core.file_utils
+from mp.dev_env.sub_commands.pull import pull_app
+from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.telemetry import track_command
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@pull_app.command(name="alert-grouping-rule")
+@track_command
+def pull_alert_grouping_rule(
+    rule_name_or_id: Annotated[
+        str | None, typer.Argument(help="The alert grouping rule name or identifier to pull.")
+    ] = None,
+    dst: Annotated[
+        Path | None,
+        typer.Option(
+            "--custom",
+            help="Destination file. Defaults to 'content/alert_grouping_rules/<name>.yaml'.",
+        ),
+    ] = None,
+    *,
+    pull_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Pull all alert grouping rules from the environment.",
+        ),
+    ] = False,
+    list_only: Annotated[
+        bool,
+        typer.Option(
+            "--list",
+            help="List all alert grouping rules available in the environment without pulling.",
+        ),
+    ] = False,
+) -> None:
+    """Pull alert grouping rules from the SOAR environment.
+
+    Raises:
+        typer.Exit: If the pull fails or invalid arguments are provided.
+
+    """
+    if rule_name_or_id is None and not pull_all and not list_only:
+        logger.error("You must specify either a rule name/identifier, or use the --all or --list flags.")
+        raise typer.Exit(1)
+
+    config = load_dev_env_config()
+    backend_api = get_backend_api(config)
+
+    logger.info("Fetching installed alert grouping rules...")
+    try:
+        installed_rules = backend_api.list_alert_grouping_rules()
+    except Exception as e:
+        logger.exception("Failed to fetch installed alert grouping rules")
+        raise typer.Exit(1) from e
+
+    if list_only:
+        _list_alert_grouping_rules(installed_rules)
+        return
+
+    if pull_all:
+        _pull_all_alert_grouping_rules(installed_rules, dst)
+        return
+
+    # Standard single pull
+    if rule_name_or_id is None:
+        logger.error("rule_name_or_id is required if not pulling or listing all")
+        raise typer.Exit(1)
+    rule_id = find_entity_identifier(rule_name_or_id, installed_rules, "Alert Grouping Rule")
+
+    # In the Alert Grouping Rule API, list usually returns all fields, but we will use the matched dict directly,
+    # or download it if there was a separate download method. We don't have download_alert_grouping_rule,
+    # so we'll just extract it from installed_rules.
+    rule_data = next((r for r in installed_rules if r.get("id") == rule_id or r.get("Id") == rule_id), None)
+
+    if not rule_data:
+        logger.error("Could not find rule data for ID %s", rule_id)
+        raise typer.Exit(1)
+
+    _save_alert_grouping_rule(rule_data, dst)
+
+
+def _list_alert_grouping_rules(installed_rules: list[dict]) -> None:
+    logger.info("Available Alert Grouping Rules:")
+    for rule in installed_rules:
+        logger.info("  - Name: '%s' (ID: %s)", rule.get("name", "Unknown"), rule.get("id", "Unknown"))
+
+
+def _pull_all_alert_grouping_rules(installed_rules: list[dict], dst: Path | None) -> None:
+    logger.info("Pulling all %d alert grouping rules...", len(installed_rules))
+    for rule in installed_rules:
+        rule_id = rule.get("id")
+        rule_name = rule.get("name") or rule_id
+        if not rule_id:
+            continue
+
+        try:
+            _save_alert_grouping_rule(rule, dst)
+        except Exception:
+            logger.exception("Skipping alert grouping rule '%s' due to an error.", rule_name)
+
+    logger.info("Successfully finished pulling all alert grouping rules.")
+
+
+def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
+    # Determine destination path
+    actual_dst = dst
+    rule_id = rule_data.get("id", "Unknown")
+    if actual_dst is None:
+        rules_root = mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir()
+        raw_name = str(rule_data.get("displayName") or rule_data.get("name") or rule_id)
+        safe_name = raw_name.replace("/", "_").replace(" ", "_")
+        file_name = f"{safe_name}.yaml"
+        actual_dst = rules_root / file_name
+
+    logger.info("Saving alert grouping rule to %s...", actual_dst)
+    try:
+        mp.core.file_utils.write_yaml_to_file(rule_data, actual_dst)
+    except Exception as e:
+        logger.exception("Failed to save alert grouping rule to '%s'", actual_dst)
+        raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -67,6 +67,10 @@ def pull_alert_grouping_rule(
         logger.error("You must specify either a rule name/identifier, or use the --all or --list flags.")
         raise typer.Exit(1)
 
+    if pull_all and dst is not None:
+        logger.error("The --custom option cannot be used when pulling all alert grouping rules.")
+        raise typer.Exit(1)
+
     config = load_dev_env_config()
     backend_api = get_backend_api(config)
 
@@ -94,7 +98,14 @@ def pull_alert_grouping_rule(
     # In the Alert Grouping Rule API, list usually returns all fields, but we will use the matched dict directly,
     # or download it if there was a separate download method. We don't have download_alert_grouping_rule,
     # so we'll just extract it from installed_rules.
-    rule_data = next((r for r in installed_rules if r.get("id") == rule_id or r.get("Id") == rule_id), None)
+    rule_data = next(
+        (
+            r
+            for r in installed_rules
+            if any(r.get(k) == rule_id for k in ("Identifier", "identifier", "Id", "id"))
+        ),
+        None,
+    )
 
     if not rule_data:
         logger.error("Could not find rule data for ID %s", rule_id)

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -150,6 +150,7 @@ def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
 
     logger.info("Saving alert grouping rule to %s...", actual_dst)
     try:
+        actual_dst.parent.mkdir(parents=True, exist_ok=True)
         mp.core.file_utils.save_yaml(rule_data, actual_dst)
     except Exception as e:
         logger.exception("Failed to save alert grouping rule to '%s'", actual_dst)

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -138,7 +138,7 @@ def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
 
     logger.info("Saving alert grouping rule to %s...", actual_dst)
     try:
-        mp.core.file_utils.write_yaml_to_file(rule_data, actual_dst)
+        mp.core.file_utils.save_yaml(rule_data, actual_dst)
     except Exception as e:
         logger.exception("Failed to save alert grouping rule to '%s'", actual_dst)
         raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -67,10 +67,6 @@ def pull_alert_grouping_rule(
         logger.error("You must specify either a rule name/identifier, or use the --all or --list flags.")
         raise typer.Exit(1)
 
-    if pull_all and dst is not None:
-        logger.error("The --custom option cannot be used when pulling all alert grouping rules.")
-        raise typer.Exit(1)
-
     config = load_dev_env_config()
     backend_api = get_backend_api(config)
 
@@ -138,14 +134,19 @@ def _pull_all_alert_grouping_rules(installed_rules: list[dict], dst: Path | None
 
 def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
     # Determine destination path
-    actual_dst = dst
     rule_id = rule_data.get("id", "Unknown")
-    if actual_dst is None:
+    raw_name = str(rule_data.get("displayName") or rule_data.get("name") or rule_id)
+    safe_name = raw_name.replace("/", "_").replace(" ", "_")
+    file_name = f"{safe_name}.yaml"
+
+    if dst is None:
         rules_root = mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir()
-        raw_name = str(rule_data.get("displayName") or rule_data.get("name") or rule_id)
-        safe_name = raw_name.replace("/", "_").replace(" ", "_")
-        file_name = f"{safe_name}.yaml"
         actual_dst = rules_root / file_name
+    elif dst.is_dir() or dst.suffix not in {".yaml", ".yml"}:
+        dst.mkdir(parents=True, exist_ok=True)
+        actual_dst = dst / file_name
+    else:
+        actual_dst = dst
 
     logger.info("Saving alert grouping rule to %s...", actual_dst)
     try:

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -22,7 +22,8 @@ import typer
 
 import mp.core.file_utils
 from mp.dev_env.sub_commands.pull import pull_app
-from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.dev_env.sub_commands.utils import get_backend_api_clean as get_backend_api
+from mp.dev_env.utils import find_entity_identifier, load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -74,8 +75,8 @@ def pull_alert_grouping_rule(
     try:
         installed_rules = backend_api.list_alert_grouping_rules()
     except Exception as e:
-        logger.exception("Failed to fetch installed alert grouping rules")
-        raise typer.Exit(1) from e
+        logger.error("Failed to fetch installed alert grouping rules: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     if list_only:
         _list_alert_grouping_rules(installed_rules)
@@ -154,8 +155,8 @@ def _pull_all_alert_grouping_rules(installed_rules: list[dict], dst: Path | None
 
         try:
             _save_alert_grouping_rule(rule, dst)
-        except Exception:
-            logger.exception("Skipping alert grouping rule '%s' due to an error.", rule_name)
+        except Exception as e:
+            logger.error("Skipping alert grouping rule '%s' due to an error: %s", rule_name, e)  # noqa: TRY400
 
     logger.info("Successfully finished pulling all alert grouping rules.")
 
@@ -188,5 +189,5 @@ def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
         actual_dst.parent.mkdir(parents=True, exist_ok=True)
         mp.core.file_utils.save_yaml(rule_data, actual_dst)
     except Exception as e:
-        logger.exception("Failed to save alert grouping rule to '%s'", actual_dst)
-        raise typer.Exit(1) from e
+        logger.error("Failed to save alert grouping rule to '%s': %s", actual_dst, e)  # noqa: TRY400
+        raise typer.Exit(1) from None

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/pull.py
@@ -89,25 +89,53 @@ def pull_alert_grouping_rule(
     if rule_name_or_id is None:
         logger.error("rule_name_or_id is required if not pulling or listing all")
         raise typer.Exit(1)
-    rule_id = find_entity_identifier(rule_name_or_id, installed_rules, "Alert Grouping Rule")
+    matched_rules = []
+    
+    # First, try to match by ID if it's numeric
+    try:
+        numeric_id = int(rule_name_or_id)
+        rule_data = next((r for r in installed_rules if r.get("id") == numeric_id), None)
+        if rule_data:
+            matched_rules.append(rule_data)
+    except (ValueError, TypeError):
+        pass
+        
+    # If not matched by ID, match by Category name (friendly display name or code)
+    if not matched_rules:
+        def match_category(user_input: str, rule: dict) -> bool:
+            category = str(rule.get("category", "")).lower()
+            category_mappings = {
+                "all": "all",
+                "alert type": "alerttype",
+                "alert_type": "alerttype",
+                "alerttype": "alerttype",
+                "data source": "datasource",
+                "data_source": "datasource",
+                "datasource": "datasource",
+                "product": "productname",
+                "product name": "productname",
+                "product_name": "productname",
+                "productname": "productname"
+            }
+            normalized_input = category_mappings.get(user_input.lower(), user_input.lower())
+            return normalized_input == category
 
-    # In the Alert Grouping Rule API, list usually returns all fields, but we will use the matched dict directly,
-    # or download it if there was a separate download method. We don't have download_alert_grouping_rule,
-    # so we'll just extract it from installed_rules.
-    rule_data = next(
-        (
-            r
-            for r in installed_rules
-            if any(r.get(k) == rule_id for k in ("Identifier", "identifier", "Id", "id"))
-        ),
-        None,
-    )
+        matched_rules = [r for r in installed_rules if match_category(rule_name_or_id, r)]
 
-    if not rule_data:
-        logger.error("Could not find rule data for ID %s", rule_id)
+    if not matched_rules:
+        logger.error("Could not find rule data matching '%s'", rule_name_or_id)
         raise typer.Exit(1)
 
-    _save_alert_grouping_rule(rule_data, dst)
+    if len(matched_rules) > 1 and dst is not None and dst.suffix in {".yaml", ".yml"}:
+        logger.error(
+            "Multiple alert grouping rules found matching '%s', but target destination '%s' is a single file path.",
+            rule_name_or_id,
+            dst,
+        )
+        raise typer.Exit(1)
+
+    for rule in matched_rules:
+        _save_alert_grouping_rule(rule, dst)
 
 
 def _list_alert_grouping_rules(installed_rules: list[dict]) -> None:
@@ -133,11 +161,15 @@ def _pull_all_alert_grouping_rules(installed_rules: list[dict], dst: Path | None
 
 
 def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
-    # Determine destination path
-    rule_id = rule_data.get("id", "Unknown")
-    raw_name = str(rule_data.get("displayName") or rule_data.get("name") or rule_id)
-    safe_name = raw_name.replace("/", "_").replace(" ", "_")
-    file_name = f"{safe_name}.yaml"
+    # Determine destination path using category and subcategories to keep it clean and prevent collisions
+    category_name = rule_data.get("category") or "Unknown"
+    subs = [x.get("identifier") for x in rule_data.get("categoryDetails", []) if x.get("identifier")]
+    if subs:
+        # Join sorted subcategories to create a clean suffix
+        safe_subs = [str(s).replace(" ", "_").replace("/", "_").lower() for s in sorted(subs)]
+        file_name = f"{category_name}_{'_'.join(safe_subs)}.yaml"
+    else:
+        file_name = f"{category_name}.yaml"
 
     if dst is None:
         rules_root = mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir()
@@ -149,6 +181,9 @@ def _save_alert_grouping_rule(rule_data: dict, dst: Path | None) -> None:
         actual_dst = dst
 
     logger.info("Saving alert grouping rule to %s...", actual_dst)
+    # Clean up environment-specific fields to keep the files environment-agnostic
+    rule_data.pop("id", None)
+    rule_data.pop("name", None)
     try:
         actual_dst.parent.mkdir(parents=True, exist_ok=True)
         mp.core.file_utils.save_yaml(rule_data, actual_dst)

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
@@ -85,7 +85,7 @@ def push_alert_grouping_rule(
     if existing_id is not None:
         logger.info("Updating existing alert grouping rule (ID: %s)...", existing_id)
         try:
-            backend_api.update_alert_grouping_rule(existing_id, rule_data)
+            backend_api.update_alert_grouping_rule(int(existing_id), rule_data)
         except Exception as e:
             logger.exception("Failed to update alert grouping rule '%s'", rule_name)
             raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
@@ -23,7 +23,8 @@ import typer
 
 import mp.core.file_utils
 from mp.dev_env.sub_commands.push import push_app
-from mp.dev_env.utils import get_backend_api, load_dev_env_config
+from mp.dev_env.sub_commands.utils import get_backend_api_clean as get_backend_api
+from mp.dev_env.utils import load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -102,8 +103,8 @@ def _push_single_alert_grouping_rule(rule_file: Path, force: bool) -> None:
     try:
         rule_data = mp.core.file_utils.load_yaml_file(rule_file)
     except Exception as e:
-        logger.exception("Failed to parse alert grouping rule YAML")
-        raise typer.Exit(1) from e
+        logger.error("Failed to parse alert grouping rule YAML: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     if not isinstance(rule_data, dict):
         logger.error("Alert grouping rule data must be a dictionary.")
@@ -116,8 +117,8 @@ def _push_single_alert_grouping_rule(rule_file: Path, force: bool) -> None:
     try:
         installed_rules = backend_api.list_alert_grouping_rules()
     except Exception as e:
-        logger.exception("Failed to fetch installed alert grouping rules")
-        raise typer.Exit(1) from e
+        logger.error("Failed to fetch installed alert grouping rules: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     rule_category = rule_data.get("category")
     if not rule_category:
@@ -147,18 +148,22 @@ def _push_single_alert_grouping_rule(rule_file: Path, force: bool) -> None:
             logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
             raise typer.Exit(1) from e
         except Exception as e:
-            logger.exception("Failed to update alert grouping rule for category '%s'", rule_category)
-            raise typer.Exit(1) from e
+            logger.error("Failed to update alert grouping rule for category '%s': %s", rule_category, e)  # noqa: TRY400
+            raise typer.Exit(1) from None
     else:
         if not force:
-            logger.error("Alert grouping rule for category '%s' not found on the platform. Skipping because --force was not specified.", rule_category)
+            logger.error("=" * 80)
+            logger.error("[VALIDATION ERROR] Alert Grouping Rule Not Installed")
+            logger.error("Alert grouping rule for category '%s' not found on the platform.", rule_category)
+            logger.error("Creation of new alert grouping rules is blocked by default. Use the --force flag to force creation.")
+            logger.error("=" * 80)
             raise typer.Exit(1)
             
         logger.info("Creating new alert grouping rule...")
         try:
             backend_api.create_alert_grouping_rule(rule_data)
         except Exception as e:
-            logger.exception("Failed to create alert grouping rule for category '%s'", rule_category)
-            raise typer.Exit(1) from e
+            logger.error("Failed to create alert grouping rule for category '%s': %s", rule_category, e)  # noqa: TRY400
+            raise typer.Exit(1) from None
 
     logger.info("Alert grouping rule for category '%s' pushed successfully.", rule_category)

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
@@ -31,7 +31,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @push_app.command(name="alert-grouping-rule")
 @track_command
-def push_alert_grouping_rule(
+def push_alert_grouping_rule(  # noqa: C901, PLR0915
     rule_file_or_name: Annotated[str, typer.Argument(help="The alert grouping rule YAML file path or name to push.")],
 ) -> None:
     """Push an alert grouping rule to the SOAR environment.
@@ -85,7 +85,11 @@ def push_alert_grouping_rule(
     if existing_id is not None:
         logger.info("Updating existing alert grouping rule (ID: %s)...", existing_id)
         try:
-            backend_api.update_alert_grouping_rule(int(existing_id), rule_data)
+            numeric_id = int(existing_id)
+            backend_api.update_alert_grouping_rule(numeric_id, rule_data)
+        except (ValueError, TypeError) as e:
+            logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
+            raise typer.Exit(1) from e
         except Exception as e:
             logger.exception("Failed to update alert grouping rule '%s'", rule_name)
             raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
@@ -43,11 +43,11 @@ def push_alert_grouping_rule(  # noqa: C901, PLR0915
             help="Push all alert grouping rules from the local directory to the environment.",
         ),
     ] = False,
-    allow_create: Annotated[
+    force: Annotated[
         bool,
         typer.Option(
-            "--allow-create",
-            help="Allow creating new alert grouping rules if they do not exist on the platform.",
+            "--force",
+            help="Force creating new alert grouping rules if they do not exist on the platform.",
         ),
     ] = False,
 ) -> None:
@@ -75,27 +75,29 @@ def push_alert_grouping_rule(  # noqa: C901, PLR0915
             return
 
         for f in yaml_files:
-            _push_single_alert_grouping_rule(f, allow_create)
+            _push_single_alert_grouping_rule(f, force)
         
         logger.info("Successfully finished pushing all alert grouping rules.")
         return
 
     # Standard single push
     rule_file = Path(rule_file_or_name)
-    if not rule_file.is_file():
-        # Try resolving by name in the default alert grouping rules directory
+    if rule_file.is_file():
+        _push_single_alert_grouping_rule(rule_file, force)
+    else:
+        # Resolve by name/prefix lookup
+        # E.g. rule_file_or_name = "AlertType" -> matches AlertType.yaml, AlertType_malware.yaml, etc.
         safe_name = rule_file_or_name.replace("/", "_").replace(" ", "_")
-        candidate_file = rules_root / f"{safe_name}.yaml"
-        if candidate_file.is_file():
-            rule_file = candidate_file
-        else:
-            logger.error("Alert grouping rule file not found at '%s' or '%s'", rule_file_or_name, candidate_file)
+        matched_files = list(rules_root.glob(f"{safe_name}*.yaml")) + list(rules_root.glob(f"{safe_name}*.yml"))
+        if not matched_files:
+            logger.error("No alert grouping rule files matching '%s' found in '%s'", rule_file_or_name, rules_root)
             raise typer.Exit(1)
-            
-    _push_single_alert_grouping_rule(rule_file, allow_create)
+        
+        for f in matched_files:
+            _push_single_alert_grouping_rule(f, force)
 
 
-def _push_single_alert_grouping_rule(rule_file: Path, allow_create: bool) -> None:
+def _push_single_alert_grouping_rule(rule_file: Path, force: bool) -> None:
     logger.info("Loading alert grouping rule YAML from '%s'...", rule_file)
     try:
         rule_data = mp.core.file_utils.load_yaml_file(rule_file)
@@ -117,16 +119,20 @@ def _push_single_alert_grouping_rule(rule_file: Path, allow_create: bool) -> Non
         logger.exception("Failed to fetch installed alert grouping rules")
         raise typer.Exit(1) from e
 
-    rule_name = rule_data.get("displayName")
-    if not rule_name:
-        logger.error("Alert grouping rule data is missing a 'displayName' field.")
+    rule_category = rule_data.get("category")
+    if not rule_category:
+        logger.error("Alert grouping rule data is missing a 'category' field.")
         raise typer.Exit(1)
+
+    local_subs = {x.get("identifier") for x in rule_data.get("categoryDetails", []) if x.get("identifier")}
 
     existing_id = None
     for rule in installed_rules:
-        if str(rule.get("displayName")).lower() == rule_name.lower():
-            existing_id = rule.get("id")
-            break
+        if str(rule.get("category")).lower() == str(rule_category).lower():
+            server_subs = {x.get("identifier") for x in rule.get("categoryDetails", []) if x.get("identifier")}
+            if server_subs == local_subs:
+                existing_id = rule.get("id")
+                break
 
     if existing_id is not None:
         logger.info("Updating existing alert grouping rule (ID: %s)...", existing_id)
@@ -141,18 +147,18 @@ def _push_single_alert_grouping_rule(rule_file: Path, allow_create: bool) -> Non
             logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
             raise typer.Exit(1) from e
         except Exception as e:
-            logger.exception("Failed to update alert grouping rule '%s'", rule_name)
+            logger.exception("Failed to update alert grouping rule for category '%s'", rule_category)
             raise typer.Exit(1) from e
     else:
-        if not allow_create:
-            logger.error("Alert grouping rule '%s' not found on the platform. Skipping because --allow-create was not specified.", rule_name)
+        if not force:
+            logger.error("Alert grouping rule for category '%s' not found on the platform. Skipping because --force was not specified.", rule_category)
             raise typer.Exit(1)
             
         logger.info("Creating new alert grouping rule...")
         try:
             backend_api.create_alert_grouping_rule(rule_data)
         except Exception as e:
-            logger.exception("Failed to create alert grouping rule '%s'", rule_name)
+            logger.exception("Failed to create alert grouping rule for category '%s'", rule_category)
             raise typer.Exit(1) from e
 
-    logger.info("Alert grouping rule '%s' pushed successfully.", rule_name)
+    logger.info("Alert grouping rule for category '%s' pushed successfully.", rule_category)

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
@@ -23,7 +23,7 @@ import typer
 
 import mp.core.file_utils
 from mp.dev_env.sub_commands.push import push_app
-from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.dev_env.utils import get_backend_api, load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -32,18 +32,58 @@ logger: logging.Logger = logging.getLogger(__name__)
 @push_app.command(name="alert-grouping-rule")
 @track_command
 def push_alert_grouping_rule(  # noqa: C901, PLR0915
-    rule_file_or_name: Annotated[str, typer.Argument(help="The alert grouping rule YAML file path or name to push.")],
+    rule_file_or_name: Annotated[
+        str | None, typer.Argument(help="The alert grouping rule YAML file path or name to push.")
+    ] = None,
+    *,
+    push_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Push all alert grouping rules from the local directory to the environment.",
+        ),
+    ] = False,
+    allow_create: Annotated[
+        bool,
+        typer.Option(
+            "--allow-create",
+            help="Allow creating new alert grouping rules if they do not exist on the platform.",
+        ),
+    ] = False,
 ) -> None:
-    """Push an alert grouping rule to the SOAR environment.
+    """Push alert grouping rule(s) to the SOAR environment.
 
     Raises:
         typer.Exit: If the push fails.
 
     """
+    if rule_file_or_name is None and not push_all:
+        logger.error("You must specify either an alert grouping rule name/file, or use the --all flag.")
+        raise typer.Exit(1)
+
+    rules_root = mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir()
+
+    if push_all:
+        logger.info("Pushing all alert grouping rules from '%s'...", rules_root)
+        if not rules_root.exists() or not rules_root.is_dir():
+            logger.error("Alert grouping rules directory not found.")
+            raise typer.Exit(1)
+        
+        yaml_files = list(rules_root.glob("*.yaml")) + list(rules_root.glob("*.yml"))
+        if not yaml_files:
+            logger.info("No alert grouping rule files found to push.")
+            return
+
+        for f in yaml_files:
+            _push_single_alert_grouping_rule(f, allow_create)
+        
+        logger.info("Successfully finished pushing all alert grouping rules.")
+        return
+
+    # Standard single push
     rule_file = Path(rule_file_or_name)
     if not rule_file.is_file():
         # Try resolving by name in the default alert grouping rules directory
-        rules_root = mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir()
         safe_name = rule_file_or_name.replace("/", "_").replace(" ", "_")
         candidate_file = rules_root / f"{safe_name}.yaml"
         if candidate_file.is_file():
@@ -51,8 +91,12 @@ def push_alert_grouping_rule(  # noqa: C901, PLR0915
         else:
             logger.error("Alert grouping rule file not found at '%s' or '%s'", rule_file_or_name, candidate_file)
             raise typer.Exit(1)
+            
+    _push_single_alert_grouping_rule(rule_file, allow_create)
 
-    logger.info("Loading alert grouping rule YAML...")
+
+def _push_single_alert_grouping_rule(rule_file: Path, allow_create: bool) -> None:
+    logger.info("Loading alert grouping rule YAML from '%s'...", rule_file)
     try:
         rule_data = mp.core.file_utils.load_yaml_file(rule_file)
     except Exception as e:
@@ -73,19 +117,25 @@ def push_alert_grouping_rule(  # noqa: C901, PLR0915
         logger.exception("Failed to fetch installed alert grouping rules")
         raise typer.Exit(1) from e
 
-    rule_name = rule_data.get("name")
+    rule_name = rule_data.get("displayName")
     if not rule_name:
-        logger.error("Alert grouping rule data is missing a 'name' field.")
+        logger.error("Alert grouping rule data is missing a 'displayName' field.")
         raise typer.Exit(1)
 
     existing_id = None
-    with contextlib.suppress(typer.Exit):
-        existing_id = find_entity_identifier(rule_name, installed_rules, "Alert Grouping Rule")
+    for rule in installed_rules:
+        if str(rule.get("displayName")).lower() == rule_name.lower():
+            existing_id = rule.get("id")
+            break
 
     if existing_id is not None:
         logger.info("Updating existing alert grouping rule (ID: %s)...", existing_id)
         try:
             numeric_id = int(existing_id)
+            # Update the payload with the target environment's ID and name
+            rule_data["id"] = numeric_id
+            rule_data["name"] = f"projects//locations//instances//alertGroupingRules/{numeric_id}"
+            
             backend_api.update_alert_grouping_rule(numeric_id, rule_data)
         except (ValueError, TypeError) as e:
             logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
@@ -94,6 +144,10 @@ def push_alert_grouping_rule(  # noqa: C901, PLR0915
             logger.exception("Failed to update alert grouping rule '%s'", rule_name)
             raise typer.Exit(1) from e
     else:
+        if not allow_create:
+            logger.error("Alert grouping rule '%s' not found on the platform. Skipping because --allow-create was not specified.", rule_name)
+            raise typer.Exit(1)
+            
         logger.info("Creating new alert grouping rule...")
         try:
             backend_api.create_alert_grouping_rule(rule_data)

--- a/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/alert_grouping_rule/push.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+import mp.core.file_utils
+from mp.dev_env.sub_commands.push import push_app
+from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.telemetry import track_command
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@push_app.command(name="alert-grouping-rule")
+@track_command
+def push_alert_grouping_rule(
+    rule_file_or_name: Annotated[str, typer.Argument(help="The alert grouping rule YAML file path or name to push.")],
+) -> None:
+    """Push an alert grouping rule to the SOAR environment.
+
+    Raises:
+        typer.Exit: If the push fails.
+
+    """
+    rule_file = Path(rule_file_or_name)
+    if not rule_file.is_file():
+        # Try resolving by name in the default alert grouping rules directory
+        rules_root = mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir()
+        safe_name = rule_file_or_name.replace("/", "_").replace(" ", "_")
+        candidate_file = rules_root / f"{safe_name}.yaml"
+        if candidate_file.is_file():
+            rule_file = candidate_file
+        else:
+            logger.error("Alert grouping rule file not found at '%s' or '%s'", rule_file_or_name, candidate_file)
+            raise typer.Exit(1)
+
+    logger.info("Loading alert grouping rule YAML...")
+    try:
+        rule_data = mp.core.file_utils.load_yaml_file(rule_file)
+    except Exception as e:
+        logger.exception("Failed to parse alert grouping rule YAML")
+        raise typer.Exit(1) from e
+
+    if not isinstance(rule_data, dict):
+        logger.error("Alert grouping rule data must be a dictionary.")
+        raise typer.Exit(1)
+
+    config = load_dev_env_config()
+    backend_api = get_backend_api(config)
+
+    logger.info("Checking if alert grouping rule exists on server...")
+    try:
+        installed_rules = backend_api.list_alert_grouping_rules()
+    except Exception as e:
+        logger.exception("Failed to fetch installed alert grouping rules")
+        raise typer.Exit(1) from e
+
+    rule_name = rule_data.get("name")
+    if not rule_name:
+        logger.error("Alert grouping rule data is missing a 'name' field.")
+        raise typer.Exit(1)
+
+    existing_id = None
+    with contextlib.suppress(typer.Exit):
+        existing_id = find_entity_identifier(rule_name, installed_rules, "Alert Grouping Rule")
+
+    if existing_id is not None:
+        logger.info("Updating existing alert grouping rule (ID: %s)...", existing_id)
+        try:
+            backend_api.update_alert_grouping_rule(existing_id, rule_data)
+        except Exception as e:
+            logger.exception("Failed to update alert grouping rule '%s'", rule_name)
+            raise typer.Exit(1) from e
+    else:
+        logger.info("Creating new alert grouping rule...")
+        try:
+            backend_api.create_alert_grouping_rule(rule_data)
+        except Exception as e:
+            logger.exception("Failed to create alert grouping rule '%s'", rule_name)
+            raise typer.Exit(1) from e
+
+    logger.info("Alert grouping rule '%s' pushed successfully.", rule_name)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/__init__.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/__init__.py
@@ -1,1 +1,3 @@
 # Copyright 2026 Google LLC
+
+from __future__ import annotations

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/__init__.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2026 Google LLC

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -131,7 +131,7 @@ def _download_and_save_custom_field(
 
     logger.info("Saving custom field to %s...", actual_dst)
     try:
-        mp.core.file_utils.write_yaml_to_file(field_data, actual_dst)
+        mp.core.file_utils.save_yaml(field_data, actual_dst)
     except Exception as e:
         logger.exception("Failed to save custom field to '%s'", actual_dst)
         raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -21,6 +21,7 @@ from typing import Annotated
 import typer
 
 import mp.core.file_utils
+import mp.dev_env.api
 from mp.dev_env.sub_commands.pull import pull_app
 from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
 from mp.telemetry import track_command
@@ -30,7 +31,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @pull_app.command(name="custom-field")
 @track_command
-def pull_custom_field(
+def pull_custom_field(  # noqa: C901
     field_name_or_id: Annotated[
         str | None, typer.Argument(help="The custom field name or identifier to pull.")
     ] = None,
@@ -104,15 +105,17 @@ def pull_custom_field(
         logger.error("field_name_or_id is required if not pulling or listing all")
         raise typer.Exit(1)
     field_id = find_entity_identifier(field_name_or_id, installed_fields, "Custom Field")
+    if field_id is None:
+        raise typer.Exit(1)
     _download_and_save_custom_field(backend_api, field_id, dst)
 
 
 def _download_and_save_custom_field(
-    backend_api: mp.dev_env.api.BackendAPI, field_id: str, dst: Path | None
+    backend_api: mp.dev_env.api.BackendAPI, field_id: int | str, dst: Path | None
 ) -> None:
     logger.info("Downloading custom field (ID: %s)...", field_id)
     try:
-        field_data = backend_api.download_custom_field(field_id)
+        field_data = backend_api.download_custom_field(int(field_id))
     except Exception as e:
         logger.exception("Failed to download custom field '%s'", field_id)
         raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -23,10 +23,17 @@ import typer
 import mp.core.file_utils
 import mp.dev_env.api
 from mp.dev_env.sub_commands.pull import pull_app
-from mp.dev_env.utils import get_backend_api, load_dev_env_config
+from mp.dev_env.sub_commands.utils import get_backend_api_clean as get_backend_api
+from mp.dev_env.utils import load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
+def _normalize_scopes(val: str | list | None) -> set[str]:
+    if not val:
+        return set()
+    if isinstance(val, list):
+        return {str(x).strip().lower() for x in val}
+    return {x.strip().lower() for x in str(val).split(",") if x.strip()}
 
 
 @pull_app.command(name="custom-field")
@@ -75,8 +82,8 @@ def pull_custom_field(  # noqa: C901
     try:
         installed_fields = backend_api.list_custom_fields()
     except Exception as e:
-        logger.exception("Failed to fetch installed custom fields")
-        raise typer.Exit(1) from e
+        logger.error("Failed to fetch installed custom fields: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     if list_only:
         logger.info("Available Custom Fields:")
@@ -94,8 +101,8 @@ def pull_custom_field(  # noqa: C901
 
             try:
                 _download_and_save_custom_field(backend_api, field_id, dst)
-            except Exception:
-                logger.exception("Skipping custom field '%s' due to an error.", field_name)
+            except Exception as e:
+                logger.error("Skipping custom field '%s' due to an error: %s", field_name, e)  # noqa: TRY400
 
         logger.info("Successfully finished pulling all custom fields.")
         return
@@ -134,14 +141,7 @@ def pull_custom_field(  # noqa: C901
                 if target_scopes is not None:
                     server_scopes = field.get("scopes")
 
-                    def normalize_scopes(val: str | list | None) -> set[str]:
-                        if not val:
-                            return set()
-                        if isinstance(val, list):
-                            return {str(x).strip().lower() for x in val}
-                        return {x.strip().lower() for x in str(val).split(",") if x.strip()}
-
-                    if normalize_scopes(target_scopes) != normalize_scopes(server_scopes):
+                    if _normalize_scopes(target_scopes) != _normalize_scopes(server_scopes):
                         continue
                 matching_fields.append(field)
 
@@ -174,10 +174,10 @@ def _download_and_save_custom_field(
         field_data = backend_api.download_custom_field(numeric_id)
     except (ValueError, TypeError) as e:
         logger.error("Invalid field ID '%s': Must be a numeric value.", field_id)  # noqa: TRY400
-        raise typer.Exit(1) from e
+        raise typer.Exit(1) from None
     except Exception as e:
-        logger.exception("Failed to download custom field '%s'", field_id)
-        raise typer.Exit(1) from e
+        logger.error("Failed to download custom field '%s': %s", field_id, e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     # Determine destination path
     raw_name = str(field_data.get("displayName") or field_data.get("name") or field_id)
@@ -198,7 +198,21 @@ def _download_and_save_custom_field(
 
     if dst is None:
         custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
-        actual_dst = custom_fields_root / file_name
+        
+        scopes = _normalize_scopes(scopes_val)
+        if len(scopes) > 1:
+            subdir = "shared"
+        elif len(scopes) == 1:
+            if "case" in scopes:
+                subdir = "case"
+            elif "alert" in scopes:
+                subdir = "alert"
+            else:
+                subdir = "shared"
+        else:
+            subdir = "shared"
+            
+        actual_dst = custom_fields_root / subdir / file_name
     elif dst.is_dir() or dst.suffix not in {".yaml", ".yml"}:
         dst.mkdir(parents=True, exist_ok=True)
         actual_dst = dst / file_name
@@ -213,5 +227,5 @@ def _download_and_save_custom_field(
         actual_dst.parent.mkdir(parents=True, exist_ok=True)
         mp.core.file_utils.save_yaml(field_data, actual_dst)
     except Exception as e:
-        logger.exception("Failed to save custom field to '%s'", actual_dst)
-        raise typer.Exit(1) from e
+        logger.error("Failed to save custom field to '%s': %s", actual_dst, e)  # noqa: TRY400
+        raise typer.Exit(1) from None

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -140,6 +140,7 @@ def _download_and_save_custom_field(
 
     logger.info("Saving custom field to %s...", actual_dst)
     try:
+        actual_dst.parent.mkdir(parents=True, exist_ok=True)
         mp.core.file_utils.save_yaml(field_data, actual_dst)
     except Exception as e:
         logger.exception("Failed to save custom field to '%s'", actual_dst)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path  # noqa: TC003
+from typing import Annotated
+
+import typer
+
+import mp.core.file_utils
+from mp.dev_env.sub_commands.pull import pull_app
+from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.telemetry import track_command
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@pull_app.command(name="custom-field")
+@track_command
+def pull_custom_field(
+    field_name_or_id: Annotated[
+        str | None, typer.Argument(help="The custom field name or identifier to pull.")
+    ] = None,
+    dst: Annotated[
+        Path | None,
+        typer.Option(
+            "--custom",
+            help="Destination file. Defaults to 'content/custom_fields/<name>.yaml'.",
+        ),
+    ] = None,
+    *,
+    pull_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Pull all custom fields from the environment.",
+        ),
+    ] = False,
+    list_only: Annotated[
+        bool,
+        typer.Option(
+            "--list",
+            help="List all custom fields available in the environment without pulling.",
+        ),
+    ] = False,
+) -> None:
+    """Pull custom fields from the SOAR environment.
+
+    Raises:
+        typer.Exit: If the pull fails or invalid arguments are provided.
+
+    """
+    if field_name_or_id is None and not pull_all and not list_only:
+        logger.error("You must specify either a custom field name/identifier, or use the --all or --list flags.")
+        raise typer.Exit(1)
+
+    config = load_dev_env_config()
+    backend_api = get_backend_api(config)
+
+    logger.info("Fetching installed custom fields...")
+    try:
+        installed_fields = backend_api.list_custom_fields()
+    except Exception as e:
+        logger.exception("Failed to fetch installed custom fields")
+        raise typer.Exit(1) from e
+
+    if list_only:
+        logger.info("Available Custom Fields:")
+        for field in installed_fields:
+            logger.info("  - Name: '%s' (ID: %s)", field.get("name", "Unknown"), field.get("id", "Unknown"))
+        return
+
+    if pull_all:
+        logger.info("Pulling all %d custom fields...", len(installed_fields))
+        for field in installed_fields:
+            field_id = field.get("id")
+            field_name = field.get("name") or field_id
+            if not field_id:
+                continue
+
+            try:
+                _download_and_save_custom_field(backend_api, field_id, dst)
+            except Exception:
+                logger.exception("Skipping custom field '%s' due to an error.", field_name)
+
+        logger.info("Successfully finished pulling all custom fields.")
+        return
+
+    # Standard single pull
+    if field_name_or_id is None:
+        logger.error("field_name_or_id is required if not pulling or listing all")
+        raise typer.Exit(1)
+    field_id = find_entity_identifier(field_name_or_id, installed_fields, "Custom Field")
+    _download_and_save_custom_field(backend_api, field_id, dst)
+
+
+def _download_and_save_custom_field(
+    backend_api: mp.dev_env.api.BackendAPI, field_id: str, dst: Path | None
+) -> None:
+    logger.info("Downloading custom field (ID: %s)...", field_id)
+    try:
+        field_data = backend_api.download_custom_field(field_id)
+    except Exception as e:
+        logger.exception("Failed to download custom field '%s'", field_id)
+        raise typer.Exit(1) from e
+
+    # Determine destination path
+    actual_dst = dst
+    if actual_dst is None:
+        custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
+        raw_name = str(field_data.get("displayName") or field_data.get("name") or field_id)
+        safe_name = raw_name.replace("/", "_").replace(" ", "_")
+        file_name = f"{safe_name}.yaml"
+        actual_dst = custom_fields_root / file_name
+
+    logger.info("Saving custom field to %s...", actual_dst)
+    try:
+        mp.core.file_utils.write_yaml_to_file(field_data, actual_dst)
+    except Exception as e:
+        logger.exception("Failed to save custom field to '%s'", actual_dst)
+        raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -68,6 +68,10 @@ def pull_custom_field(  # noqa: C901
         logger.error("You must specify either a custom field name/identifier, or use the --all or --list flags.")
         raise typer.Exit(1)
 
+    if pull_all and dst is not None:
+        logger.error("The --custom option cannot be used when pulling all custom fields.")
+        raise typer.Exit(1)
+
     config = load_dev_env_config()
     backend_api = get_backend_api(config)
 
@@ -115,7 +119,11 @@ def _download_and_save_custom_field(
 ) -> None:
     logger.info("Downloading custom field (ID: %s)...", field_id)
     try:
-        field_data = backend_api.download_custom_field(int(field_id))
+        numeric_id = int(field_id)
+        field_data = backend_api.download_custom_field(numeric_id)
+    except (ValueError, TypeError) as e:
+        logger.error("Invalid field ID '%s': Must be a numeric value.", field_id)  # noqa: TRY400
+        raise typer.Exit(1) from e
     except Exception as e:
         logger.exception("Failed to download custom field '%s'", field_id)
         raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -104,10 +104,65 @@ def pull_custom_field(  # noqa: C901
     if field_name_or_id is None:
         logger.error("field_name_or_id is required if not pulling or listing all")
         raise typer.Exit(1)
-    field_id = find_entity_identifier(field_name_or_id, installed_fields, "Custom Field")
-    if field_id is None:
+
+    target_name = field_name_or_id
+    target_scopes = None
+
+    # Check if the input is a local file path
+    input_path = Path(field_name_or_id)
+    if input_path.is_file():
+        try:
+            local_data = mp.core.file_utils.load_yaml_file(input_path)
+            if isinstance(local_data, dict):
+                target_name = local_data.get("displayName") or target_name
+                target_scopes = local_data.get("scopes")
+                if not dst:
+                    dst = input_path
+        except Exception:
+            logger.warning("Failed to load local file '%s' to extract displayName.", field_name_or_id)
+
+    matching_fields = []
+    try:
+        numeric_id = int(field_name_or_id)
+        for field in installed_fields:
+            if field.get("id") == numeric_id:
+                matching_fields.append(field)
+                break
+    except ValueError:
+        for field in installed_fields:
+            if str(field.get("displayName")).lower() == target_name.lower():
+                if target_scopes is not None:
+                    server_scopes = field.get("scopes")
+
+                    def normalize_scopes(val) -> set[str]:
+                        if not val:
+                            return set()
+                        if isinstance(val, list):
+                            return {str(x).strip().lower() for x in val}
+                        return {x.strip().lower() for x in str(val).split(",") if x.strip()}
+
+                    if normalize_scopes(target_scopes) != normalize_scopes(server_scopes):
+                        continue
+                matching_fields.append(field)
+
+    if not matching_fields:
+        logger.error("Custom Field '%s' not found in installed entities in SOAR platform.", field_name_or_id)
         raise typer.Exit(1)
-    _download_and_save_custom_field(backend_api, field_id, dst)
+
+    if len(matching_fields) > 1:
+        if dst is not None and dst.suffix in {".yaml", ".yml"}:
+            logger.error(
+                "Multiple custom fields found matching '%s', but a single destination file was specified. "
+                "Please specify a directory path for --custom, or pull by ID.",
+                field_name_or_id,
+            )
+            raise typer.Exit(1)
+        logger.info("Found %d custom fields matching '%s'. Pulling all of them...", len(matching_fields), field_name_or_id)
+
+    for field in matching_fields:
+        field_id = field.get("id")
+        if field_id is not None:
+            _download_and_save_custom_field(backend_api, field_id, dst)
 
 
 def _download_and_save_custom_field(
@@ -127,7 +182,19 @@ def _download_and_save_custom_field(
     # Determine destination path
     raw_name = str(field_data.get("displayName") or field_data.get("name") or field_id)
     safe_name = raw_name.replace("/", "_").replace(" ", "_")
-    file_name = f"{safe_name}.yaml"
+    scopes_val = field_data.get("scopes")
+    if scopes_val:
+        def normalize_scopes_for_filename(val) -> str:
+            if isinstance(val, list):
+                parts = [str(x).strip().lower() for x in val]
+            else:
+                parts = [x.strip().lower() for x in str(val).split(",") if x.strip()]
+            return "_".join(sorted(parts))
+        
+        scopes_suffix = normalize_scopes_for_filename(scopes_val)
+        file_name = f"{safe_name}_{scopes_suffix}.yaml"
+    else:
+        file_name = f"{safe_name}.yaml"
 
     if dst is None:
         custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -68,10 +68,6 @@ def pull_custom_field(  # noqa: C901
         logger.error("You must specify either a custom field name/identifier, or use the --all or --list flags.")
         raise typer.Exit(1)
 
-    if pull_all and dst is not None:
-        logger.error("The --custom option cannot be used when pulling all custom fields.")
-        raise typer.Exit(1)
-
     config = load_dev_env_config()
     backend_api = get_backend_api(config)
 
@@ -129,13 +125,18 @@ def _download_and_save_custom_field(
         raise typer.Exit(1) from e
 
     # Determine destination path
-    actual_dst = dst
-    if actual_dst is None:
+    raw_name = str(field_data.get("displayName") or field_data.get("name") or field_id)
+    safe_name = raw_name.replace("/", "_").replace(" ", "_")
+    file_name = f"{safe_name}.yaml"
+
+    if dst is None:
         custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
-        raw_name = str(field_data.get("displayName") or field_data.get("name") or field_id)
-        safe_name = raw_name.replace("/", "_").replace(" ", "_")
-        file_name = f"{safe_name}.yaml"
         actual_dst = custom_fields_root / file_name
+    elif dst.is_dir() or dst.suffix not in {".yaml", ".yml"}:
+        dst.mkdir(parents=True, exist_ok=True)
+        actual_dst = dst / file_name
+    else:
+        actual_dst = dst
 
     logger.info("Saving custom field to %s...", actual_dst)
     try:

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -23,7 +23,7 @@ import typer
 import mp.core.file_utils
 import mp.dev_env.api
 from mp.dev_env.sub_commands.pull import pull_app
-from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.dev_env.utils import get_backend_api, load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ def pull_custom_field(  # noqa: C901
                 if target_scopes is not None:
                     server_scopes = field.get("scopes")
 
-                    def normalize_scopes(val) -> set[str]:
+                    def normalize_scopes(val: str | list | None) -> set[str]:
                         if not val:
                             return set()
                         if isinstance(val, list):
@@ -184,13 +184,13 @@ def _download_and_save_custom_field(
     safe_name = raw_name.replace("/", "_").replace(" ", "_")
     scopes_val = field_data.get("scopes")
     if scopes_val:
-        def normalize_scopes_for_filename(val) -> str:
+        def normalize_scopes_for_filename(val: str | list) -> str:
             if isinstance(val, list):
                 parts = [str(x).strip().lower() for x in val]
             else:
                 parts = [x.strip().lower() for x in str(val).split(",") if x.strip()]
             return "_".join(sorted(parts))
-        
+
         scopes_suffix = normalize_scopes_for_filename(scopes_val)
         file_name = f"{safe_name}_{scopes_suffix}.yaml"
     else:

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/pull.py
@@ -206,6 +206,9 @@ def _download_and_save_custom_field(
         actual_dst = dst
 
     logger.info("Saving custom field to %s...", actual_dst)
+    # Clean up environment-specific fields to keep the files environment-agnostic
+    field_data.pop("id", None)
+    field_data.pop("name", None)
     try:
         actual_dst.parent.mkdir(parents=True, exist_ok=True)
         mp.core.file_utils.save_yaml(field_data, actual_dst)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -42,11 +42,11 @@ def push_custom_field(  # noqa: C901
             help="Push all custom fields from the local directory to the environment.",
         ),
     ] = False,
-    allow_create: Annotated[
+    force: Annotated[
         bool,
         typer.Option(
-            "--allow-create",
-            help="Allow creating new custom fields if they do not exist on the platform.",
+            "--force",
+            help="Force creating new custom fields if they do not exist on the platform.",
         ),
     ] = False,
 ) -> None:
@@ -74,7 +74,7 @@ def push_custom_field(  # noqa: C901
             return
 
         for f in yaml_files:
-            _push_single_custom_field(f, allow_create)
+            _push_single_custom_field(f, force)
 
         logger.info("Successfully finished pushing all custom fields.")
         return
@@ -106,10 +106,10 @@ def push_custom_field(  # noqa: C901
         logger.info("Found %d files matching '%s'. Pushing all of them...", len(files_to_push), field_file_or_name)
 
     for f in files_to_push:
-        _push_single_custom_field(f, allow_create)
+        _push_single_custom_field(f, force)
 
 
-def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
+def _push_single_custom_field(field_file: Path, force: bool) -> None:
     logger.info("Loading custom field YAML from '%s'...", field_file)
     try:
         field_data = mp.core.file_utils.load_yaml_file(field_file)
@@ -177,8 +177,8 @@ def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
             logger.exception("Failed to update custom field '%s'", field_name)
             raise typer.Exit(1) from e
     else:
-        if not allow_create:
-            logger.error("Custom field '%s' not found on the platform. Skipping because --allow-create was not specified.", field_name)
+        if not force:
+            logger.error("Custom field '%s' not found on the platform. Skipping because --force was not specified.", field_name)
             raise typer.Exit(1)
 
         logger.info("Creating new custom field...")

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
 from pathlib import Path
 from typing import Annotated
@@ -31,7 +30,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @push_app.command(name="custom-field")
 @track_command
-def push_custom_field(  # noqa: C901, PLR0915
+def push_custom_field(  # noqa: C901
     field_file_or_name: Annotated[
         str | None, typer.Argument(help="The custom field YAML file path or name to push.")
     ] = None,
@@ -68,7 +67,7 @@ def push_custom_field(  # noqa: C901, PLR0915
         if not custom_fields_root.exists() or not custom_fields_root.is_dir():
             logger.error("Custom fields directory not found.")
             raise typer.Exit(1)
-        
+
         yaml_files = list(custom_fields_root.glob("*.yaml")) + list(custom_fields_root.glob("*.yml"))
         if not yaml_files:
             logger.info("No custom field files found to push.")
@@ -76,7 +75,7 @@ def push_custom_field(  # noqa: C901, PLR0915
 
         for f in yaml_files:
             _push_single_custom_field(f, allow_create)
-        
+
         logger.info("Successfully finished pushing all custom fields.")
         return
 
@@ -144,7 +143,7 @@ def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
             if local_scopes is not None:
                 server_scopes = field.get("scopes")
 
-                def normalize_scopes(val) -> set[str]:
+                def normalize_scopes(val: str | list | None) -> set[str]:
                     if not val:
                         return set()
                     if isinstance(val, list):
@@ -169,7 +168,7 @@ def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
             # Update the payload with the target environment's ID and name
             field_data["id"] = numeric_id
             field_data["name"] = f"projects//locations//instances//customFields/{numeric_id}"
-            
+
             backend_api.update_custom_field(numeric_id, field_data)
         except (ValueError, TypeError) as e:
             logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
@@ -181,7 +180,7 @@ def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
         if not allow_create:
             logger.error("Custom field '%s' not found on the platform. Skipping because --allow-create was not specified.", field_name)
             raise typer.Exit(1)
-            
+
         logger.info("Creating new custom field...")
         try:
             backend_api.create_custom_field(field_data)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+import mp.core.file_utils
+from mp.dev_env.sub_commands.push import push_app
+from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.telemetry import track_command
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@push_app.command(name="custom-field")
+@track_command
+def push_custom_field(
+    field_file_or_name: Annotated[str, typer.Argument(help="The custom field YAML file path or name to push.")],
+) -> None:
+    """Push a custom field to the SOAR environment.
+
+    Raises:
+        typer.Exit: If the push fails.
+
+    """
+    field_file = Path(field_file_or_name)
+    if not field_file.is_file():
+        # Try resolving by name in the default custom fields directory
+        custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
+        safe_name = field_file_or_name.replace("/", "_").replace(" ", "_")
+        candidate_file = custom_fields_root / f"{safe_name}.yaml"
+        if candidate_file.is_file():
+            field_file = candidate_file
+        else:
+            logger.error("Custom field file not found at '%s' or '%s'", field_file_or_name, candidate_file)
+            raise typer.Exit(1)
+
+    logger.info("Loading custom field YAML...")
+    try:
+        field_data = mp.core.file_utils.load_yaml_file(field_file)
+    except Exception as e:
+        logger.exception("Failed to parse custom field YAML")
+        raise typer.Exit(1) from e
+
+    if not isinstance(field_data, dict):
+        logger.error("Custom field data must be a dictionary.")
+        raise typer.Exit(1)
+
+    config = load_dev_env_config()
+    backend_api = get_backend_api(config)
+
+    logger.info("Checking if custom field exists on server...")
+    try:
+        installed_fields = backend_api.list_custom_fields()
+    except Exception as e:
+        logger.exception("Failed to fetch installed custom fields")
+        raise typer.Exit(1) from e
+
+    field_name = field_data.get("name")
+    if not field_name:
+        logger.error("Custom field data is missing a 'name' field.")
+        raise typer.Exit(1)
+
+    existing_id = None
+    with contextlib.suppress(typer.Exit):
+        existing_id = find_entity_identifier(field_name, installed_fields, "Custom Field")
+
+    if existing_id is not None:
+        logger.info("Updating existing custom field (ID: %s)...", existing_id)
+        # Avoid trying to mutate id in the patch payload unless strictly required,
+        # but passing it doesn't usually hurt.
+        try:
+            backend_api.update_custom_field(existing_id, field_data)
+        except Exception as e:
+            logger.exception("Failed to update custom field '%s'", field_name)
+            raise typer.Exit(1) from e
+    else:
+        logger.info("Creating new custom field...")
+        try:
+            backend_api.create_custom_field(field_data)
+        except Exception as e:
+            logger.exception("Failed to create custom field '%s'", field_name)
+            raise typer.Exit(1) from e
+
+    logger.info("Custom field '%s' pushed successfully.", field_name)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -87,7 +87,7 @@ def push_custom_field(
         # Avoid trying to mutate id in the patch payload unless strictly required,
         # but passing it doesn't usually hurt.
         try:
-            backend_api.update_custom_field(existing_id, field_data)
+            backend_api.update_custom_field(int(existing_id), field_data)
         except Exception as e:
             logger.exception("Failed to update custom field '%s'", field_name)
             raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -81,18 +81,33 @@ def push_custom_field(  # noqa: C901, PLR0915
         return
 
     # Standard single push
+    files_to_push = []
     field_file = Path(field_file_or_name)
-    if not field_file.is_file():
+    if field_file.is_file():
+        files_to_push.append(field_file)
+    else:
         # Try resolving by name in the default custom fields directory
         safe_name = field_file_or_name.replace("/", "_").replace(" ", "_")
         candidate_file = custom_fields_root / f"{safe_name}.yaml"
         if candidate_file.is_file():
-            field_file = candidate_file
+            files_to_push.append(candidate_file)
         else:
-            logger.error("Custom field file not found at '%s' or '%s'", field_file_or_name, candidate_file)
-            raise typer.Exit(1)
-    
-    _push_single_custom_field(field_file, allow_create)
+            # Look for suffix matching (e.g. name_scopes.yaml)
+            matching_files = [
+                f for f in custom_fields_root.iterdir()
+                if f.is_file() and f.suffix in {".yaml", ".yml"} and f.name.startswith(f"{safe_name}_")
+            ]
+            if matching_files:
+                files_to_push.extend(matching_files)
+            else:
+                logger.error("Custom field file not found at '%s' or '%s'", field_file_or_name, candidate_file)
+                raise typer.Exit(1)
+
+    if len(files_to_push) > 1:
+        logger.info("Found %d files matching '%s'. Pushing all of them...", len(files_to_push), field_file_or_name)
+
+    for f in files_to_push:
+        _push_single_custom_field(f, allow_create)
 
 
 def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
@@ -123,8 +138,22 @@ def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
         raise typer.Exit(1)
 
     existing_id = None
+    local_scopes = field_data.get("scopes")
     for field in installed_fields:
         if str(field.get("displayName")).lower() == field_name.lower():
+            if local_scopes is not None:
+                server_scopes = field.get("scopes")
+
+                def normalize_scopes(val) -> set[str]:
+                    if not val:
+                        return set()
+                    if isinstance(val, list):
+                        return {str(x).strip().lower() for x in val}
+                    return {x.strip().lower() for x in str(val).split(",") if x.strip()}
+
+                if normalize_scopes(local_scopes) != normalize_scopes(server_scopes):
+                    continue
+
             existing_id = field.get("id")
             break
 
@@ -132,6 +161,11 @@ def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
         logger.info("Updating existing custom field (ID: %s)...", existing_id)
         try:
             numeric_id = int(existing_id)
+            # Align the casing of displayName to match the server's to avoid validation errors (name change is forbidden)
+            server_field = next((f for f in installed_fields if f.get("id") == numeric_id), None)
+            if server_field and server_field.get("displayName"):
+                field_data["displayName"] = server_field["displayName"]
+
             # Update the payload with the target environment's ID and name
             field_data["id"] = numeric_id
             field_data["name"] = f"projects//locations//instances//customFields/{numeric_id}"

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -22,10 +22,17 @@ import typer
 
 import mp.core.file_utils
 from mp.dev_env.sub_commands.push import push_app
-from mp.dev_env.utils import get_backend_api, load_dev_env_config
+from mp.dev_env.sub_commands.utils import get_backend_api_clean as get_backend_api
+from mp.dev_env.utils import load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
+def _normalize_scopes(val: str | list | None) -> set[str]:
+    if not val:
+        return set()
+    if isinstance(val, list):
+        return {str(x).strip().lower() for x in val}
+    return {x.strip().lower() for x in str(val).split(",") if x.strip()}
 
 
 @push_app.command(name="custom-field")
@@ -68,12 +75,27 @@ def push_custom_field(  # noqa: C901
             logger.error("Custom fields directory not found.")
             raise typer.Exit(1)
 
-        yaml_files = list(custom_fields_root.glob("*.yaml")) + list(custom_fields_root.glob("*.yml"))
+        yaml_files = list(custom_fields_root.rglob("*.yaml")) + list(custom_fields_root.rglob("*.yml"))
         if not yaml_files:
             logger.info("No custom field files found to push.")
             return
 
+        pushed_keys = set()
         for f in yaml_files:
+            try:
+                field_data = mp.core.file_utils.load_yaml_file(f)
+                if isinstance(field_data, dict):
+                    display_name = field_data.get("displayName")
+                    scopes_val = field_data.get("scopes")
+                    if display_name:
+                        scopes_key = tuple(sorted(list(_normalize_scopes(scopes_val))))
+                        key = (display_name.lower(), scopes_key)
+                        if key in pushed_keys:
+                            logger.info("Custom field '%s' with scopes %s already pushed, skipping duplicate file '%s'", display_name, scopes_key, f)
+                            continue
+                        pushed_keys.add(key)
+            except Exception:
+                pass
             _push_single_custom_field(f, force)
 
         logger.info("Successfully finished pushing all custom fields.")
@@ -85,21 +107,25 @@ def push_custom_field(  # noqa: C901
     if field_file.is_file():
         files_to_push.append(field_file)
     else:
-        # Try resolving by name in the default custom fields directory
+        # Try resolving by name in the custom fields directory and subdirectories
         safe_name = field_file_or_name.replace("/", "_").replace(" ", "_")
-        candidate_file = custom_fields_root / f"{safe_name}.yaml"
-        if candidate_file.is_file():
-            files_to_push.append(candidate_file)
+        candidate_files = [
+            f for f in custom_fields_root.rglob(f"{safe_name}.yaml")
+        ] + [
+            f for f in custom_fields_root.rglob(f"{safe_name}.yml")
+        ]
+        if candidate_files:
+            files_to_push.extend(candidate_files)
         else:
             # Look for suffix matching (e.g. name_scopes.yaml)
             matching_files = [
-                f for f in custom_fields_root.iterdir()
+                f for f in custom_fields_root.rglob("*")
                 if f.is_file() and f.suffix in {".yaml", ".yml"} and f.name.startswith(f"{safe_name}_")
             ]
             if matching_files:
                 files_to_push.extend(matching_files)
             else:
-                logger.error("Custom field file not found at '%s' or '%s'", field_file_or_name, candidate_file)
+                logger.error("Custom field file not found for '%s'", field_file_or_name)
                 raise typer.Exit(1)
 
     if len(files_to_push) > 1:
@@ -114,8 +140,8 @@ def _push_single_custom_field(field_file: Path, force: bool) -> None:
     try:
         field_data = mp.core.file_utils.load_yaml_file(field_file)
     except Exception as e:
-        logger.exception("Failed to parse custom field YAML")
-        raise typer.Exit(1) from e
+        logger.error("Failed to parse custom field YAML: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     if not isinstance(field_data, dict):
         logger.error("Custom field data must be a dictionary.")
@@ -128,8 +154,8 @@ def _push_single_custom_field(field_file: Path, force: bool) -> None:
     try:
         installed_fields = backend_api.list_custom_fields()
     except Exception as e:
-        logger.exception("Failed to fetch installed custom fields")
-        raise typer.Exit(1) from e
+        logger.error("Failed to fetch installed custom fields: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     field_name = field_data.get("displayName")
     if not field_name:
@@ -174,18 +200,22 @@ def _push_single_custom_field(field_file: Path, force: bool) -> None:
             logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
             raise typer.Exit(1) from e
         except Exception as e:
-            logger.exception("Failed to update custom field '%s'", field_name)
-            raise typer.Exit(1) from e
+            logger.error("Failed to update custom field '%s': %s", field_name, e)  # noqa: TRY400
+            raise typer.Exit(1) from None
     else:
         if not force:
-            logger.error("Custom field '%s' not found on the platform. Skipping because --force was not specified.", field_name)
+            logger.error("=" * 80)
+            logger.error("[VALIDATION ERROR] Custom Field Not Installed")
+            logger.error("Custom field '%s' not found on the platform.", field_name)
+            logger.error("Creation of new custom fields is blocked by default. Use the --force flag to force creation.")
+            logger.error("=" * 80)
             raise typer.Exit(1)
 
         logger.info("Creating new custom field...")
         try:
             backend_api.create_custom_field(field_data)
         except Exception as e:
-            logger.exception("Failed to create custom field '%s'", field_name)
-            raise typer.Exit(1) from e
+            logger.error("Failed to create custom field '%s': %s", field_name, e)  # noqa: TRY400
+            raise typer.Exit(1) from None
 
     logger.info("Custom field '%s' pushed successfully.", field_name)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -23,7 +23,7 @@ import typer
 
 import mp.core.file_utils
 from mp.dev_env.sub_commands.push import push_app
-from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.dev_env.utils import get_backend_api, load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -32,18 +32,58 @@ logger: logging.Logger = logging.getLogger(__name__)
 @push_app.command(name="custom-field")
 @track_command
 def push_custom_field(  # noqa: C901, PLR0915
-    field_file_or_name: Annotated[str, typer.Argument(help="The custom field YAML file path or name to push.")],
+    field_file_or_name: Annotated[
+        str | None, typer.Argument(help="The custom field YAML file path or name to push.")
+    ] = None,
+    *,
+    push_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Push all custom fields from the local directory to the environment.",
+        ),
+    ] = False,
+    allow_create: Annotated[
+        bool,
+        typer.Option(
+            "--allow-create",
+            help="Allow creating new custom fields if they do not exist on the platform.",
+        ),
+    ] = False,
 ) -> None:
-    """Push a custom field to the SOAR environment.
+    """Push custom field(s) to the SOAR environment.
 
     Raises:
         typer.Exit: If the push fails.
 
     """
+    if field_file_or_name is None and not push_all:
+        logger.error("You must specify either a custom field name/file, or use the --all flag.")
+        raise typer.Exit(1)
+
+    custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
+
+    if push_all:
+        logger.info("Pushing all custom fields from '%s'...", custom_fields_root)
+        if not custom_fields_root.exists() or not custom_fields_root.is_dir():
+            logger.error("Custom fields directory not found.")
+            raise typer.Exit(1)
+        
+        yaml_files = list(custom_fields_root.glob("*.yaml")) + list(custom_fields_root.glob("*.yml"))
+        if not yaml_files:
+            logger.info("No custom field files found to push.")
+            return
+
+        for f in yaml_files:
+            _push_single_custom_field(f, allow_create)
+        
+        logger.info("Successfully finished pushing all custom fields.")
+        return
+
+    # Standard single push
     field_file = Path(field_file_or_name)
     if not field_file.is_file():
         # Try resolving by name in the default custom fields directory
-        custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
         safe_name = field_file_or_name.replace("/", "_").replace(" ", "_")
         candidate_file = custom_fields_root / f"{safe_name}.yaml"
         if candidate_file.is_file():
@@ -51,8 +91,12 @@ def push_custom_field(  # noqa: C901, PLR0915
         else:
             logger.error("Custom field file not found at '%s' or '%s'", field_file_or_name, candidate_file)
             raise typer.Exit(1)
+    
+    _push_single_custom_field(field_file, allow_create)
 
-    logger.info("Loading custom field YAML...")
+
+def _push_single_custom_field(field_file: Path, allow_create: bool) -> None:
+    logger.info("Loading custom field YAML from '%s'...", field_file)
     try:
         field_data = mp.core.file_utils.load_yaml_file(field_file)
     except Exception as e:
@@ -73,21 +117,25 @@ def push_custom_field(  # noqa: C901, PLR0915
         logger.exception("Failed to fetch installed custom fields")
         raise typer.Exit(1) from e
 
-    field_name = field_data.get("name")
+    field_name = field_data.get("displayName")
     if not field_name:
-        logger.error("Custom field data is missing a 'name' field.")
+        logger.error("Custom field data is missing a 'displayName' field.")
         raise typer.Exit(1)
 
     existing_id = None
-    with contextlib.suppress(typer.Exit):
-        existing_id = find_entity_identifier(field_name, installed_fields, "Custom Field")
+    for field in installed_fields:
+        if str(field.get("displayName")).lower() == field_name.lower():
+            existing_id = field.get("id")
+            break
 
     if existing_id is not None:
         logger.info("Updating existing custom field (ID: %s)...", existing_id)
-        # Avoid trying to mutate id in the patch payload unless strictly required,
-        # but passing it doesn't usually hurt.
         try:
             numeric_id = int(existing_id)
+            # Update the payload with the target environment's ID and name
+            field_data["id"] = numeric_id
+            field_data["name"] = f"projects//locations//instances//customFields/{numeric_id}"
+            
             backend_api.update_custom_field(numeric_id, field_data)
         except (ValueError, TypeError) as e:
             logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
@@ -96,6 +144,10 @@ def push_custom_field(  # noqa: C901, PLR0915
             logger.exception("Failed to update custom field '%s'", field_name)
             raise typer.Exit(1) from e
     else:
+        if not allow_create:
+            logger.error("Custom field '%s' not found on the platform. Skipping because --allow-create was not specified.", field_name)
+            raise typer.Exit(1)
+            
         logger.info("Creating new custom field...")
         try:
             backend_api.create_custom_field(field_data)

--- a/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/custom_field/push.py
@@ -31,7 +31,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @push_app.command(name="custom-field")
 @track_command
-def push_custom_field(
+def push_custom_field(  # noqa: C901, PLR0915
     field_file_or_name: Annotated[str, typer.Argument(help="The custom field YAML file path or name to push.")],
 ) -> None:
     """Push a custom field to the SOAR environment.
@@ -87,7 +87,11 @@ def push_custom_field(
         # Avoid trying to mutate id in the patch payload unless strictly required,
         # but passing it doesn't usually hurt.
         try:
-            backend_api.update_custom_field(int(existing_id), field_data)
+            numeric_id = int(existing_id)
+            backend_api.update_custom_field(numeric_id, field_data)
+        except (ValueError, TypeError) as e:
+            logger.error("Invalid existing ID '%s': Must be a numeric value.", existing_id)  # noqa: TRY400
+            raise typer.Exit(1) from e
         except Exception as e:
             logger.exception("Failed to update custom field '%s'", field_name)
             raise typer.Exit(1) from e

--- a/packages/mp/src/mp/dev_env/sub_commands/utils.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/utils.py
@@ -15,14 +15,27 @@
 """Helper utilities for developer environment subcommands."""
 
 import logging
+import requests
 import typer
+
 from mp.dev_env import api
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 
 def get_backend_api_clean(config: dict[str, str]) -> api.BackendAPI:
-    """Initialize and authenticates the backend API client without logging tracebacks on failure."""
+    """Initialize and authenticates the backend API client without logging tracebacks on failure.
+
+    Args:
+        config: Environment configuration containing api_root and credentials.
+
+    Returns:
+        The authenticated BackendAPI client.
+
+    Raises:
+        typer.Exit: If authentication fails.
+
+    """
     try:
         if config.get("api_key"):
             backend_api = api.BackendAPI(api_root=config["api_root"], api_key=config["api_key"])
@@ -34,7 +47,23 @@ def get_backend_api_clean(config: dict[str, str]) -> api.BackendAPI:
             )
 
         backend_api.login()
-    except Exception as e:
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code in {401, 403}:
+            logger.error("=" * 80)
+            logger.error(
+                "[AUTHENTICATION ERROR] Invalid API Key or Unauthorized Access (Status Code %s)",
+                e.response.status_code,
+            )
+            logger.error(
+                "The API key or credentials configured for '%s' are invalid or expired.",
+                config.get("api_root"),
+            )
+            logger.error("Please update your credentials using: uv run --project packages/mp mp login")
+            logger.error("=" * 80)
+            raise typer.Exit(1) from None
+        logger.error("Authentication failed: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
+    except Exception as e:  # noqa: BLE001
         logger.error("Authentication failed: %s", e)  # noqa: TRY400
         raise typer.Exit(1) from None
     else:

--- a/packages/mp/src/mp/dev_env/sub_commands/utils.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/utils.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper utilities for developer environment subcommands."""
+
+import logging
+import typer
+from mp.dev_env import api
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def get_backend_api_clean(config: dict[str, str]) -> api.BackendAPI:
+    """Initialize and authenticates the backend API client without logging tracebacks on failure."""
+    try:
+        if config.get("api_key"):
+            backend_api = api.BackendAPI(api_root=config["api_root"], api_key=config["api_key"])
+        else:
+            backend_api = api.BackendAPI(
+                api_root=config["api_root"],
+                username=config["username"],
+                password=config["password"],
+            )
+
+        backend_api.login()
+    except Exception as e:
+        logger.error("Authentication failed: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
+    else:
+        return backend_api

--- a/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
@@ -63,7 +63,10 @@ def pull_view(
         logger.exception("Failed to fetch installed views")
         raise typer.Exit(1) from e
 
-    view_identifier = find_entity_identifier(view_name_or_id, installed_views, "View")
+    view_identifier_raw = find_entity_identifier(view_name_or_id, installed_views, "View")
+    if view_identifier_raw is None:
+        raise typer.Exit(1)
+    view_identifier = str(view_identifier_raw)
 
     # Determine destination path
     if dst is None:

--- a/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
@@ -25,7 +25,7 @@ import mp.core.file_utils
 from mp.build_project.restructure.views.deconstruct import ViewDeconstructor
 from mp.core.data_models.common.overview.metadata import Overview
 from mp.dev_env.sub_commands.pull import pull_app
-from mp.dev_env.utils import get_backend_api, load_dev_env_config
+from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ def pull_view(
         logger.exception("Failed to fetch installed views")
         raise typer.Exit(1) from e
 
-    view_identifier = _find_view_identifier(view_name_or_id, installed_views)
+    view_identifier = find_entity_identifier(view_name_or_id, installed_views, "View")
 
     # Determine destination path
     if dst is None:
@@ -103,31 +103,6 @@ def download_and_deconstruct_view(backend_api: BackendAPI, view_identifier: str,
     except Exception as e:
         logger.exception("Deconstruction failed for view '%s'", view_identifier)
         raise typer.Exit(1) from e
-
-
-def _find_view_identifier(view_name_or_id: str, installed_views: list[dict[str, Any]] | None) -> str:
-    """Find the view identifier matching the given name or identifier.
-
-    Args:
-        view_name_or_id: The view name or identifier to search for.
-        installed_views: The list of installed views fetched from SOAR.
-
-    Returns:
-        The matching view identifier.
-
-    Raises:
-        typer.Exit: If the view is not found in the installed views.
-
-    """
-    for view in installed_views or []:
-        identifier = view.get("Identifier") or view.get("identifier")
-        name = view.get("Name") or view.get("name")
-
-        if identifier and (view_name_or_id.lower() == identifier.lower() or view_name_or_id == name):
-            return cast("str", identifier)
-
-    logger.error("View '%s' not found in installed views in SOAR platform.", view_name_or_id)
-    raise typer.Exit(1)
 
 
 def _normalize_downloaded_view(flat_view: dict[str, Any]) -> BuiltOverview:

--- a/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
@@ -25,7 +25,8 @@ import mp.core.file_utils
 from mp.build_project.restructure.views.deconstruct import ViewDeconstructor
 from mp.core.data_models.common.overview.metadata import Overview
 from mp.dev_env.sub_commands.pull import pull_app
-from mp.dev_env.utils import find_entity_identifier, get_backend_api, load_dev_env_config
+from mp.dev_env.sub_commands.utils import get_backend_api_clean as get_backend_api
+from mp.dev_env.utils import find_entity_identifier, load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 @pull_app.command(name="view")
 @track_command
 def pull_view(
-    view_name_or_id: Annotated[str, typer.Argument(help="The view name or identifier to pull.")],
+    view_name_or_id: Annotated[str | None, typer.Argument(help="The view name or identifier to pull.")] = None,
     dst: Annotated[
         Path | None,
         typer.Option(
@@ -46,6 +47,13 @@ def pull_view(
             help="Destination folder. Defaults to 'content/views/<view_identifier>'.",
         ),
     ] = None,
+    all_views: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Pull all views from the platform.",
+        ),
+    ] = False,
 ) -> None:
     """Pull and deconstruct a view template from the SOAR environment.
 
@@ -53,6 +61,10 @@ def pull_view(
         typer.Exit: If the pull or deconstruction fails.
 
     """
+    if not all_views and not view_name_or_id:
+        logger.error("Error: You must provide a view name or ID, or specify the --all option.")
+        raise typer.Exit(1)
+
     config = load_dev_env_config()
     backend_api = get_backend_api(config)
 
@@ -60,9 +72,62 @@ def pull_view(
     try:
         installed_views = backend_api.list_views()
     except Exception as e:
-        logger.exception("Failed to fetch installed views")
-        raise typer.Exit(1) from e
+        logger.error("Failed to fetch installed views: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
+    views_root = mp.core.file_utils.create_or_get_views_root_dir()
+
+    if all_views:
+        if dst is not None:
+            logger.error("Error: --custom destination option cannot be used when pulling all views.")
+            raise typer.Exit(1)
+
+        logger.info("Pulling all %d views...", len(installed_views))
+        for view in installed_views:
+            view_id = None
+            for key in ("Identifier", "identifier", "Id", "id"):
+                if key in view and view[key] is not None:
+                    view_id = str(view[key])
+                    break
+
+            view_name = None
+            for key in ("Name", "name", "DisplayName", "displayName"):
+                if key in view and view[key] is not None:
+                    view_name = str(view[key])
+                    break
+
+            if view_id:
+                # Find matching local folder
+                existing_local_folder = None
+                if views_root.is_dir():
+                    for folder in views_root.iterdir():
+                        if not folder.is_dir():
+                            continue
+                        view_yaml_path = folder / mp.core.constants.VIEW_FILE_NAME
+                        if not view_yaml_path.exists():
+                            continue
+                        try:
+                            view_meta = mp.core.file_utils.load_yaml_file(view_yaml_path)
+                            if isinstance(view_meta, dict):
+                                local_uuid = view_meta.get("identifier")
+                                local_name = view_meta.get("name")
+                                if (local_uuid and local_uuid.lower() == view_id.lower()) or (
+                                    view_name and local_name and local_name.lower() == view_name.lower()
+                                ):
+                                    existing_local_folder = folder
+                                    break
+                        except Exception:
+                            pass
+
+                view_dst = existing_local_folder if existing_local_folder else views_root / view_id
+                try:
+                    download_and_deconstruct_view(backend_api, view_id, view_dst)
+                    logger.info("View '%s' (ID: %s) pulled successfully to %s.", view_name or view_id, view_id, view_dst)
+                except Exception as e:
+                    logger.error("Failed to pull view '%s' (ID: %s): %s", view_name or view_id, view_id, e)
+        return
+
+    # Standard single pull
     view_identifier_raw = find_entity_identifier(view_name_or_id, installed_views, "View")
     if view_identifier_raw is None:
         raise typer.Exit(1)
@@ -70,8 +135,32 @@ def pull_view(
 
     # Determine destination path
     if dst is None:
-        views_root = mp.core.file_utils.create_or_get_views_root_dir()
-        dst = views_root / view_identifier
+        existing_local_folder = None
+        if views_root.is_dir():
+            for folder in views_root.iterdir():
+                if not folder.is_dir():
+                    continue
+                view_yaml_path = folder / mp.core.constants.VIEW_FILE_NAME
+                if not view_yaml_path.exists():
+                    continue
+                try:
+                    view_meta = mp.core.file_utils.load_yaml_file(view_yaml_path)
+                    if isinstance(view_meta, dict):
+                        local_uuid = view_meta.get("identifier")
+                        local_name = view_meta.get("name")
+                        if (local_uuid and local_uuid.lower() == view_identifier.lower()) or (
+                            local_name and local_name.lower() == view_name_or_id.lower()
+                        ):
+                            existing_local_folder = folder
+                            break
+                except Exception:
+                    pass
+
+        if existing_local_folder:
+            dst = existing_local_folder
+            logger.info("Matching local view folder found at '%s'. Overwriting it in-place.", dst)
+        else:
+            dst = views_root / view_identifier
     else:
         dst /= view_identifier
 
@@ -90,8 +179,8 @@ def download_and_deconstruct_view(backend_api: BackendAPI, view_identifier: str,
     try:
         built_view_data = backend_api.download_view(view_identifier)
     except Exception as e:
-        logger.exception("Failed to download view '%s'", view_identifier)
-        raise typer.Exit(1) from e
+        logger.error("Failed to download view '%s': %s", view_identifier, e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     if not isinstance(built_view_data, dict):
         logger.error("Downloaded view data is not a valid JSON object.")
@@ -104,8 +193,8 @@ def download_and_deconstruct_view(backend_api: BackendAPI, view_identifier: str,
         deconstructor = ViewDeconstructor(overview, dst)
         deconstructor.deconstruct()
     except Exception as e:
-        logger.exception("Deconstruction failed for view '%s'", view_identifier)
-        raise typer.Exit(1) from e
+        logger.error("Deconstruction failed for view '%s': %s", view_identifier, e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
 
 def _normalize_downloaded_view(flat_view: dict[str, Any], backend_api: BackendAPI) -> BuiltOverview:

--- a/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/pull.py
@@ -98,7 +98,7 @@ def download_and_deconstruct_view(backend_api: BackendAPI, view_identifier: str,
         raise typer.Exit(1)
 
     try:
-        normalized_view_data = _normalize_downloaded_view(built_view_data)
+        normalized_view_data = _normalize_downloaded_view(built_view_data, backend_api)
         overview = Overview.from_built(normalized_view_data)
         logger.info("Deconstructing view to %s...", dst)
         deconstructor = ViewDeconstructor(overview, dst)
@@ -108,23 +108,53 @@ def download_and_deconstruct_view(backend_api: BackendAPI, view_identifier: str,
         raise typer.Exit(1) from e
 
 
-def _normalize_downloaded_view(flat_view: dict[str, Any]) -> BuiltOverview:
+def _normalize_downloaded_view(flat_view: dict[str, Any], backend_api: BackendAPI) -> BuiltOverview:
     """Normalize flat camelCase view payload from SOAR REST API into BuiltOverview.
 
     Args:
         flat_view: The flat camelCase dictionary representing the view downloaded from SOAR.
+        backend_api: The backend API client to fetch installed entities like Custom Fields.
 
     Returns:
         The normalized BuiltOverview structure.
 
     """
+    installed_cf = []
+    try:
+        installed_cf = backend_api.list_custom_fields()
+    except Exception as e:
+        logger.warning(f"Failed to fetch installed custom fields during view normalization: {e}")
+
+    id_to_cf_name = {cf.get("id"): cf.get("displayName") for cf in installed_cf if cf.get("id") is not None}
+
     built_widgets = []
     for w in flat_view.get("widgets") or []:
         meta = w.get("metadata") or {}
         config = w.get("config") or {}
 
-        # If data is HTML, we must include the htmlContent in config
-        # Actually in widgets list, htmlContent was inside DataDefinitionJson
+        # Resolve Custom Fields
+        cfs = config.get("customFields")
+        if isinstance(cfs, list):
+            for cf_item in cfs:
+                if isinstance(cf_item, dict) and "id" in cf_item:
+                    cf_id = cf_item.pop("id")
+                    cf_name = id_to_cf_name.get(cf_id)
+                    if cf_name:
+                        cf_item["displayName"] = cf_name
+                        # Auto-pull the dependent custom field
+                        try:
+                            from mp.dev_env.sub_commands.custom_field.pull import _download_and_save_custom_field
+                            import typer
+                            
+                            _download_and_save_custom_field(backend_api, cf_id, None)
+                        except typer.Exit:
+                            logger.warning("Failed to auto-pull dependent custom field '%s' (ID: %s).", cf_name, cf_id)
+                        except Exception as e:
+                            logger.warning("Error auto-pulling custom field '%s' (ID: %s): %s", cf_name, cf_id, e)
+                    else:
+                        logger.warning(f"Could not resolve custom field ID {cf_id} to a displayName.")
+                        cf_item["id"] = cf_id # Put it back
+
         # Serialize the config back into DataDefinitionJson
         data_definition_json = json.dumps(config)
 
@@ -181,13 +211,27 @@ def _normalize_downloaded_view(flat_view: dict[str, Any]) -> BuiltOverview:
         }
         built_widgets.append(built_widget)
 
+    alert_rule_type = flat_view.get("alertRuleType")
+    if alert_rule_type is not None:
+        try:
+            from mp.dev_env.sub_commands.alert_grouping_rule.pull import _save_alert_grouping_rule
+            # It's a small list, so fetching all is fine
+            rules = backend_api.list_alert_grouping_rules()
+            rule_data = next((r for r in rules if str(r.get("id")) == str(alert_rule_type)), None)
+            if rule_data:
+                _save_alert_grouping_rule(rule_data, None)
+            else:
+                logger.warning("Alert Grouping Rule ID %s not found on server during auto-pull.", alert_rule_type)
+        except Exception as e:
+            logger.warning("Failed to auto-pull dependent alert grouping rule (ID: %s): %s", alert_rule_type, e)
+
     overview_template: dict[str, Any] = {
         "Identifier": flat_view.get("identifier") or "",
         "Name": flat_view.get("name") or "",
         "Creator": flat_view.get("creator"),
         "PlaybookDefinitionIdentifier": flat_view.get("playbookIdentifier") or "",
         "Type": flat_view.get("type") or 0,
-        "AlertRuleType": flat_view.get("alertRuleType"),
+        "AlertRuleType": alert_rule_type,
         "Widgets": built_widgets,
         "Roles": flat_view.get("roles") or [],
     }

--- a/packages/mp/src/mp/dev_env/sub_commands/view/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/push.py
@@ -145,16 +145,25 @@ def push_view(
         download_and_deconstruct_view(backend_api, final_identifier, target_path)
 
 
-def _denormalize_pushed_view(built_view: BuiltOverview) -> dict[str, Any]:
+def _denormalize_pushed_view(built_view: BuiltOverview, backend_api: BackendAPI) -> dict[str, Any]:
     """Convert wrapped PascalCase BuiltOverview back into flat camelCase payload expected by SOAR.
 
     Args:
         built_view: The BuiltOverview dictionary structure representing the view.
+        backend_api: The backend API client to fetch installed entities like Custom Fields.
 
     Returns:
         The flat camelCase dictionary payload.
 
     """
+    installed_cf = []
+    try:
+        installed_cf = backend_api.list_custom_fields()
+    except Exception as e:
+        logger.warning(f"Failed to fetch installed custom fields during view denormalization: {e}")
+
+    name_to_cf_id = {cf.get("displayName"): cf.get("id") for cf in installed_cf if cf.get("displayName") and cf.get("id") is not None}
+
     template = built_view.get("OverviewTemplate") or {}
 
     # 1. Map widgets
@@ -165,6 +174,23 @@ def _denormalize_pushed_view(built_view: BuiltOverview) -> dict[str, Any]:
         if isinstance(data_def, str):
             with contextlib.suppress(json.JSONDecodeError):
                 config_dict = json.loads(data_def)
+
+        # Resolve Custom Fields
+        cfs = config_dict.get("customFields")
+        if isinstance(cfs, list):
+            for cf_item in cfs:
+                if isinstance(cf_item, dict) and "displayName" in cf_item:
+                    cf_name = cf_item.pop("displayName")
+                    cf_id = name_to_cf_id.get(cf_name)
+                    if cf_id is not None:
+                        cf_item["id"] = cf_id
+                    else:
+                        logger.error(
+                            "Custom field '%s' not found on the target platform. "
+                            "Please push this custom field before pushing the view.",
+                            cf_name,
+                        )
+                        raise typer.Exit(1)
 
         cg = w.get("ConditionsGroup")
         flat_cg = None
@@ -380,6 +406,12 @@ def _validate_push_preconditions(
         )
         logger.error("Failed to push view '%s'.", view_name_or_id)
         raise typer.Exit(1)
+    else:
+        if not flat_view_data.get("identifier"):
+            import uuid
+            new_uuid = str(uuid.uuid4())
+            logger.info("Generating new UUID '%s' for new view.", new_uuid)
+            flat_view_data["identifier"] = new_uuid
 
 
 def _upload_built_view_data(
@@ -406,7 +438,7 @@ def _upload_built_view_data(
     backend_api = get_backend_api(config)
 
     logger.info("Uploading view to SOAR platform...")
-    flat_view_data = _denormalize_pushed_view(cast("BuiltOverview", view_data))
+    flat_view_data = _denormalize_pushed_view(cast("BuiltOverview", view_data), backend_api)
 
     _validate_push_preconditions(
         backend_api,

--- a/packages/mp/src/mp/dev_env/sub_commands/view/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/push.py
@@ -20,6 +20,7 @@ import logging
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
+import requests
 import typer
 
 import mp.core.constants
@@ -27,8 +28,8 @@ import mp.core.file_utils
 from mp.build_project.restructure.views.build import ViewBuilder
 from mp.core.utils import to_snake_case
 from mp.dev_env.sub_commands.push import push_app
-from mp.dev_env.sub_commands.view.pull import download_and_deconstruct_view
-from mp.dev_env.utils import get_backend_api, load_dev_env_config
+from mp.dev_env.sub_commands.utils import get_backend_api_clean as get_backend_api
+from mp.dev_env.utils import load_dev_env_config
 from mp.telemetry import track_command
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -41,7 +42,10 @@ if TYPE_CHECKING:
 @push_app.command(name="view")
 @track_command
 def push_view(
-    view_name_or_id: Annotated[str, typer.Argument(help="The view name or identifier to build and push.")],
+    view_name_or_id: Annotated[
+        str | None,
+        typer.Argument(help="The view name or identifier to build and push."),
+    ] = None,
     *,
     src: Annotated[
         Path | None,
@@ -64,6 +68,13 @@ def push_view(
             help="Validate the view locally without uploading it to the server.",
         ),
     ] = False,
+    all_views: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Push all views from the local repository.",
+        ),
+    ] = False,
 ) -> None:
     """Build and push a view template to the SOAR environment.
 
@@ -71,18 +82,62 @@ def push_view(
         typer.Exit: If the built view file cannot be found or parsed.
 
     """
-    # 1. Locate source path
+    if not all_views and not view_name_or_id:
+        logger.error("Error: You must provide a view name or ID, or specify the --all option.")
+        raise typer.Exit(1)
+
+    if all_views:
+        if view_name_or_id:
+            logger.error("Error: View name or ID cannot be specified when using --all option.")
+            raise typer.Exit(1)
+
+        views_root = src or mp.core.file_utils.create_or_get_views_root_dir()
+        if not views_root.exists() or not views_root.is_dir():
+            logger.error("Views directory '%s' not found.", views_root)
+            raise typer.Exit(1)
+
+        local_views = [
+            folder
+            for folder in views_root.iterdir()
+            if folder.is_dir() and (folder / mp.core.constants.VIEW_FILE_NAME).exists()
+        ]
+
+        if not local_views:
+            logger.info("No views found to push.")
+            return
+
+        logger.info("Found %d views to push. Pushing all of them...", len(local_views))
+        for view_dir in local_views:
+            try:
+                _push_single_view(view_dir, force=force, validate=validate)
+                logger.info("View directory '%s' pushed successfully.", view_dir.name)
+            except Exception as e:
+                logger.error("Failed to push view directory '%s': %s", view_dir.name, e)  # noqa: TRY400
+                raise typer.Exit(1) from None
+        return
+
+    # Standard single push
     view_src_path = _get_view_path_by_name(view_name_or_id, src)
+    _push_single_view(view_src_path, force=force, validate=validate)
+
+
+def _push_single_view(view_src_path: Path, *, force: bool = False, validate: bool = False) -> None:
+    """Build and push a single view directory.
+
+    Raises:
+        typer.Exit: If build, parsing, or upload fails.
+
+    """
     logger.info("Found source view path at: %s", view_src_path)
 
-    # 2. Build the view to a temp or output directory
+    # Build the view to a temp or output directory
     out_dir = mp.core.file_utils.get_view_out_dir()
     builder = ViewBuilder(view_src_path, out_dir)
     try:
         builder.build()
     except Exception as e:
-        logger.exception("Failed to build/validate view")
-        raise typer.Exit(1) from e
+        logger.error("Failed to build/validate view: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     # The built JSON name is to_snake_case(view_src_path.stem).json
     built_json_name = f"{to_snake_case(view_src_path.stem)}{mp.core.constants.JSON_SUFFIX}"
@@ -95,54 +150,111 @@ def push_view(
     if not mp.core.file_utils.is_built_view(built_json_path):
         raise typer.Exit(1)
 
-    # 3. Load built JSON data
+    # Load built JSON data
     logger.info("Loading built view JSON...")
     try:
         view_data: dict[str, Any] = json.loads(built_json_path.read_text(encoding="utf-8"))
     except Exception as e:
-        logger.exception("Failed to parse built view JSON")
-        raise typer.Exit(1) from e
+        logger.error("Failed to parse built view JSON: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     if validate:
-        logger.info("✅ View '%s' is valid.", view_name_or_id)
+        _validate_view(view_data)
+        logger.info("✅ View '%s' is valid.", view_src_path.name)
         return
 
-    # 4. Upload to SOAR
-    final_identifier = _upload_built_view_data(view_data, view_name_or_id, force=force)
+    # Upload to SOAR
+    _upload_built_view_data(view_data, view_src_path.name, force=force)
 
-    # 5. Automatically pull back the view from the server to sync local changes (e.g. order, system predefined details)
-    if final_identifier:
-        local_identifier = view_data.get("OverviewTemplate", {}).get("Identifier")
-        target_path = view_src_path
-        if local_identifier and local_identifier.lower() != final_identifier.lower():
-            new_folder_name = final_identifier.lower()
-            new_view_src_path = view_src_path.parent / new_folder_name
-            logger.info(
-                "Local UUID '%s' differs from server UUID '%s'. Renaming folder '%s' to '%s' to align with server.",
-                local_identifier,
-                final_identifier,
-                view_src_path.name,
-                new_folder_name,
-            )
+
+def _validate_view(view_data: dict[str, Any]) -> None:
+    """Validate view's custom fields against target environment.
+
+    Raises:
+        typer.Exit: If validation fails.
+
+    """
+    config = load_dev_env_config()
+    backend_api = get_backend_api(config)
+    try:
+        _denormalize_pushed_view(cast("BuiltOverview", view_data), backend_api)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        logger.error("Validation failed with an unexpected error: %s", e)  # noqa: TRY400
+        raise typer.Exit(1) from None
+
+
+def _get_local_custom_fields() -> dict[str, Path]:
+    """Find all local custom field files and map their displayName to file path.
+
+    Returns:
+        A dictionary mapping the display name of local custom fields to their file Path.
+
+    """
+    try:
+        custom_fields_root = mp.core.file_utils.create_or_get_custom_fields_root_dir()
+    except Exception:  # noqa: BLE001
+        return {}
+
+    local_fields = {}
+    if custom_fields_root.exists() and custom_fields_root.is_dir():
+        for f in custom_fields_root.rglob("*.yaml"):
             try:
-                view_src_path.rename(new_view_src_path)
-                target_path = new_view_src_path
-            except Exception as ex:
-                logger.exception(
-                    "Failed to rename local view folder from '%s' to '%s'",
-                    view_src_path,
-                    new_view_src_path,
-                )
-                raise typer.Exit(1) from ex
+                data = mp.core.file_utils.load_yaml_file(f)
+                if isinstance(data, dict) and "displayName" in data:
+                    local_fields[data["displayName"]] = f
+            except Exception as ex:  # noqa: BLE001
+                logger.debug("Failed to load local custom field file %s: %s", f, ex)
+    return local_fields
 
-        logger.info(
-            "Automatically pulling back view '%s' (ID: %s) to sync local folder...",
-            view_name_or_id,
-            final_identifier,
-        )
-        config = load_dev_env_config()
-        backend_api = get_backend_api(config)
-        download_and_deconstruct_view(backend_api, final_identifier, target_path)
+
+def _resolve_widget_custom_fields(config_dict: dict[str, Any], name_to_cf_id: dict[str, int]) -> None:
+    """Resolve custom field displayNames to IDs, checking local workspace if missing on server.
+
+    Raises:
+        typer.Exit: If a custom field is not found on the platform.
+
+    """
+    cfs = config_dict.get("customFields")
+    if not isinstance(cfs, list):
+        return
+    for cf_item in cfs:
+        if isinstance(cf_item, dict) and "displayName" in cf_item:
+            cf_name = cf_item.pop("displayName")
+            cf_id = name_to_cf_id.get(cf_name)
+            if cf_id is not None:
+                cf_item["id"] = cf_id
+            else:
+                local_cf_files = _get_local_custom_fields()
+                local_file = local_cf_files.get(cf_name)
+                if local_file:
+                    content_root = mp.core.file_utils.create_or_get_content_dir()
+                    relative_path = local_file.relative_to(content_root.parent)
+                    logger.error("=" * 80)
+                    logger.error("[VALIDATION ERROR] Custom Field Not Installed")
+                    logger.error(
+                        "Custom field '%s' referenced in the view exists locally in your workspace "
+                        "at '%s', but it is not installed on the SOAR platform.",
+                        cf_name,
+                        relative_path,
+                    )
+                    logger.error(
+                        'Please push this custom field first using:\n'
+                        '  uv run --project packages/mp mp push custom-field "%s"',
+                        cf_name,
+                    )
+                    logger.error("=" * 80)
+                else:
+                    logger.error("=" * 80)
+                    logger.error("[VALIDATION ERROR] Custom Field Not Found")
+                    logger.error(
+                        "Custom field '%s' referenced in the view was not found on the SOAR platform, "
+                        "and no local file was found under 'content/custom_fields/' directory.",
+                        cf_name,
+                    )
+                    logger.error("=" * 80)
+                raise typer.Exit(1)
 
 
 def _denormalize_pushed_view(built_view: BuiltOverview, backend_api: BackendAPI) -> dict[str, Any]:
@@ -160,7 +272,7 @@ def _denormalize_pushed_view(built_view: BuiltOverview, backend_api: BackendAPI)
     try:
         installed_cf = backend_api.list_custom_fields()
     except Exception as e:
-        logger.warning(f"Failed to fetch installed custom fields during view denormalization: {e}")
+        logger.warning("Failed to fetch installed custom fields during view denormalization: %s", e)
 
     name_to_cf_id = {cf.get("displayName"): cf.get("id") for cf in installed_cf if cf.get("displayName") and cf.get("id") is not None}
 
@@ -176,21 +288,7 @@ def _denormalize_pushed_view(built_view: BuiltOverview, backend_api: BackendAPI)
                 config_dict = json.loads(data_def)
 
         # Resolve Custom Fields
-        cfs = config_dict.get("customFields")
-        if isinstance(cfs, list):
-            for cf_item in cfs:
-                if isinstance(cf_item, dict) and "displayName" in cf_item:
-                    cf_name = cf_item.pop("displayName")
-                    cf_id = name_to_cf_id.get(cf_name)
-                    if cf_id is not None:
-                        cf_item["id"] = cf_id
-                    else:
-                        logger.error(
-                            "Custom field '%s' not found on the target platform. "
-                            "Please push this custom field before pushing the view.",
-                            cf_name,
-                        )
-                        raise typer.Exit(1)
+        _resolve_widget_custom_fields(config_dict, name_to_cf_id)
 
         cg = w.get("ConditionsGroup")
         flat_cg = None
@@ -340,6 +438,8 @@ def _verify_widgets(
             meta = w.get("metadata") or {}
             w_id = meta.get("identifier")
             if (not w_id or w_id.lower() not in existing_widget_ids) and not force:
+                logger.error("=" * 80)
+                logger.error("[VALIDATION ERROR] Missing Widget on Platform")
                 logger.error(
                     "Widget '%s' (UUID: '%s') does not exist in the view on the platform.",
                     meta.get("title") or "unnamed",
@@ -350,6 +450,7 @@ def _verify_widgets(
                     "Use the --force flag to force creation."
                 )
                 logger.error("Failed to push view '%s'.", view_name_or_id)
+                logger.error("=" * 80)
                 raise typer.Exit(1)
 
 
@@ -406,12 +507,11 @@ def _validate_push_preconditions(
         )
         logger.error("Failed to push view '%s'.", view_name_or_id)
         raise typer.Exit(1)
-    else:
-        if not flat_view_data.get("identifier"):
-            import uuid
-            new_uuid = str(uuid.uuid4())
-            logger.info("Generating new UUID '%s' for new view.", new_uuid)
-            flat_view_data["identifier"] = new_uuid
+    elif not flat_view_data.get("identifier"):
+        import uuid
+        new_uuid = str(uuid.uuid4())
+        logger.info("Generating new UUID '%s' for new view.", new_uuid)
+        flat_view_data["identifier"] = new_uuid
 
 
 def _upload_built_view_data(
@@ -450,9 +550,21 @@ def _upload_built_view_data(
     try:
         result = backend_api.upload_view(flat_view_data)
         logger.debug("Upload response: %s", result)
+    except requests.exceptions.HTTPError as e:
+        try:
+            err_data = e.response.json()
+            err_msg = err_data.get("errorMessage") or e.response.text
+        except Exception:  # noqa: BLE001
+            err_msg = e.response.text
+
+        logger.error("=" * 80)  # noqa: TRY400
+        logger.error("[SERVER VALIDATION ERROR] View Upload Failed (Status Code %s)", e.response.status_code)  # noqa: TRY400
+        logger.error("%s", err_msg)  # noqa: TRY400
+        logger.error("=" * 80)  # noqa: TRY400
+        raise typer.Exit(1) from None
     except Exception as e:
-        logger.exception("Upload failed for view '%s'", view_name_or_id)
-        raise typer.Exit(1) from e
+        logger.error("Upload failed for view '%s': %s", view_name_or_id, e)  # noqa: TRY400
+        raise typer.Exit(1) from None
 
     logger.info("View '%s' pushed successfully.", view_name_or_id)
     return flat_view_data.get("identifier")

--- a/packages/mp/src/mp/dev_env/sub_commands/view/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/push.py
@@ -110,8 +110,7 @@ def push_view(
         for view_dir in local_views:
             try:
                 _push_single_view(view_dir, force=force, validate=validate)
-                logger.info("View directory '%s' pushed successfully.", view_dir.name)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.error("Failed to push view directory '%s': %s", view_dir.name, e)  # noqa: TRY400
                 raise typer.Exit(1) from None
         return
@@ -158,13 +157,17 @@ def _push_single_view(view_src_path: Path, *, force: bool = False, validate: boo
         logger.error("Failed to parse built view JSON: %s", e)  # noqa: TRY400
         raise typer.Exit(1) from None
 
+    view_name = view_data.get("name")
     if validate:
         _validate_view(view_data)
-        logger.info("✅ View '%s' is valid.", view_src_path.name)
+        if view_name and view_name != view_src_path.name:
+            logger.info("✅ View '%s' (from directory '%s') is valid.", view_name, view_src_path.name)
+        else:
+            logger.info("✅ View '%s' is valid.", view_src_path.name)
         return
 
     # Upload to SOAR
-    _upload_built_view_data(view_data, view_src_path.name, force=force)
+    _upload_built_view_data(view_data, view_src_path, force=force)
 
 
 def _validate_view(view_data: dict[str, Any]) -> None:
@@ -516,7 +519,7 @@ def _validate_push_preconditions(
 
 def _upload_built_view_data(
     view_data: dict[str, Any],
-    view_name_or_id: str,
+    view_src_path: Path,
     *,
     force: bool = False,
 ) -> str | None:
@@ -524,7 +527,7 @@ def _upload_built_view_data(
 
     Args:
         view_data: The built view template dictionary structure.
-        view_name_or_id: The view name or identifier.
+        view_src_path: Path to the view source directory.
         force: Force creating a new view if it doesn't exist.
 
     Returns:
@@ -539,10 +542,11 @@ def _upload_built_view_data(
 
     logger.info("Uploading view to SOAR platform...")
     flat_view_data = _denormalize_pushed_view(cast("BuiltOverview", view_data), backend_api)
+    view_name = flat_view_data.get("name") or view_src_path.name
 
     _validate_push_preconditions(
         backend_api,
-        view_name_or_id,
+        view_name,
         flat_view_data,
         force=force,
     )
@@ -563,10 +567,17 @@ def _upload_built_view_data(
         logger.error("=" * 80)  # noqa: TRY400
         raise typer.Exit(1) from None
     except Exception as e:
-        logger.error("Upload failed for view '%s': %s", view_name_or_id, e)  # noqa: TRY400
+        logger.error("Upload failed for view '%s': %s", view_name, e)  # noqa: TRY400
         raise typer.Exit(1) from None
 
-    logger.info("View '%s' pushed successfully.", view_name_or_id)
+    if view_name != view_src_path.name:
+        logger.info(
+            "View '%s' (from directory '%s') pushed successfully.",
+            view_name,
+            view_src_path.name,
+        )
+    else:
+        logger.info("View '%s' pushed successfully.", view_name)
     return flat_view_data.get("identifier")
 
 

--- a/packages/mp/src/mp/dev_env/sub_commands/view/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/push.py
@@ -50,11 +50,11 @@ def push_view(
             help="Source folder containing the view directory.",
         ),
     ] = None,
-    allow_create: Annotated[
+    force: Annotated[
         bool,
         typer.Option(
-            "--allow-create",
-            help="Allow creating a new view if it does not already exist on the platform.",
+            "--force",
+            help="Force creating a new view if it does not already exist on the platform.",
         ),
     ] = False,
     validate: Annotated[
@@ -108,7 +108,7 @@ def push_view(
         return
 
     # 4. Upload to SOAR
-    final_identifier = _upload_built_view_data(view_data, view_name_or_id, allow_create=allow_create)
+    final_identifier = _upload_built_view_data(view_data, view_name_or_id, force=force)
 
     # 5. Automatically pull back the view from the server to sync local changes (e.g. order, system predefined details)
     if final_identifier:
@@ -314,12 +314,12 @@ def _verify_widgets(
     existing_identifier: str,
     flat_view_data: dict[str, Any],
     *,
-    allow_create: bool,
+    force: bool,
 ) -> None:
-    """Verify that pushed widgets exist on the server unless allow_create is True.
+    """Verify that pushed widgets exist on the server unless force is True.
 
     Raises:
-        typer.Exit: If a widget doesn't exist on the server and allow_create is False.
+        typer.Exit: If a widget doesn't exist on the server and force is False.
 
     """
     existing_view = None
@@ -339,7 +339,7 @@ def _verify_widgets(
         for w in flat_view_data.get("widgets") or []:
             meta = w.get("metadata") or {}
             w_id = meta.get("identifier")
-            if (not w_id or w_id.lower() not in existing_widget_ids) and not allow_create:
+            if (not w_id or w_id.lower() not in existing_widget_ids) and not force:
                 logger.error(
                     "Widget '%s' (UUID: '%s') does not exist in the view on the platform.",
                     meta.get("title") or "unnamed",
@@ -347,7 +347,7 @@ def _verify_widgets(
                 )
                 logger.error(
                     "Creation of new widgets is blocked by default. "
-                    "Use the --allow-create flag to force creation."
+                    "Use the --force flag to force creation."
                 )
                 logger.error("Failed to push view '%s'.", view_name_or_id)
                 raise typer.Exit(1)
@@ -358,12 +358,12 @@ def _validate_push_preconditions(
     view_name_or_id: str,
     flat_view_data: dict[str, Any],
     *,
-    allow_create: bool,
+    force: bool,
 ) -> None:
     """Validate push preconditions, resolving view ID and verifying widgets.
 
     Raises:
-        typer.Exit: If the view doesn't exist and allow_create is False, or if a widget check fails.
+        typer.Exit: If the view doesn't exist and force is False, or if a widget check fails.
 
     """
     local_identifier = flat_view_data.get("identifier")
@@ -392,9 +392,9 @@ def _validate_push_preconditions(
             view_name_or_id,
             server_uuid,
             flat_view_data,
-            allow_create=allow_create,
+            force=force,
         )
-    elif not allow_create:
+    elif not force:
         logger.error(
             "View '%s' (UUID: '%s') does not exist on the platform (checked by UUID and Name).",
             view_name_or_id,
@@ -402,7 +402,7 @@ def _validate_push_preconditions(
         )
         logger.error(
             "Creation of new views is blocked by default. "
-            "Use the --allow-create flag to force creation."
+            "Use the --force flag to force creation."
         )
         logger.error("Failed to push view '%s'.", view_name_or_id)
         raise typer.Exit(1)
@@ -418,14 +418,14 @@ def _upload_built_view_data(
     view_data: dict[str, Any],
     view_name_or_id: str,
     *,
-    allow_create: bool = False,
+    force: bool = False,
 ) -> str | None:
     """Upload built view template data to the SOAR environment.
 
     Args:
         view_data: The built view template dictionary structure.
         view_name_or_id: The view name or identifier.
-        allow_create: Allow creating a new view if it doesn't exist.
+        force: Force creating a new view if it doesn't exist.
 
     Returns:
         The final identifier of the view template used for upload if successful, otherwise None.
@@ -444,7 +444,7 @@ def _upload_built_view_data(
         backend_api,
         view_name_or_id,
         flat_view_data,
-        allow_create=allow_create,
+        force=force,
     )
 
     try:

--- a/packages/mp/src/mp/dev_env/sub_commands/view/push.py
+++ b/packages/mp/src/mp/dev_env/sub_commands/view/push.py
@@ -103,15 +103,22 @@ def push_view(
         ]
 
         if not local_views:
-            logger.info("No views found to push.")
+            logger.info("No views found to %s.", "validate" if validate else "push")
             return
 
-        logger.info("Found %d views to push. Pushing all of them...", len(local_views))
+        if validate:
+            logger.info("Found %d views to validate. Validating all of them...", len(local_views))
+        else:
+            logger.info("Found %d views to push. Pushing all of them...", len(local_views))
+
         for view_dir in local_views:
             try:
                 _push_single_view(view_dir, force=force, validate=validate)
             except Exception as e:  # noqa: BLE001
-                logger.error("Failed to push view directory '%s': %s", view_dir.name, e)  # noqa: TRY400
+                if validate:
+                    logger.error("Validation failed for view directory '%s': %s", view_dir.name, e)  # noqa: TRY400
+                else:
+                    logger.error("Failed to push view directory '%s': %s", view_dir.name, e)  # noqa: TRY400
                 raise typer.Exit(1) from None
         return
 
@@ -157,21 +164,25 @@ def _push_single_view(view_src_path: Path, *, force: bool = False, validate: boo
         logger.error("Failed to parse built view JSON: %s", e)  # noqa: TRY400
         raise typer.Exit(1) from None
 
-    view_name = view_data.get("name")
+    overview_tpl = view_data.get("OverviewTemplate")
+    view_name = (overview_tpl.get("Name") if isinstance(overview_tpl, dict) else None) or view_data.get("name")
     if validate:
-        _validate_view(view_data)
+        _validate_view(view_data, view_src_path)
         if view_name and view_name != view_src_path.name:
             logger.info("✅ View '%s' (from directory '%s') is valid.", view_name, view_src_path.name)
         else:
-            logger.info("✅ View '%s' is valid.", view_src_path.name)
+            logger.info("✅ View '%s' is valid.", view_name or view_src_path.name)
         return
 
     # Upload to SOAR
     _upload_built_view_data(view_data, view_src_path, force=force)
 
 
-def _validate_view(view_data: dict[str, Any]) -> None:
-    """Validate view's custom fields against target environment.
+def _validate_view(
+    view_data: dict[str, Any],
+    view_src_path: Path,
+) -> None:
+    """Validate view's custom fields, widgets, and integration dependencies against target environment.
 
     Raises:
         typer.Exit: If validation fails.
@@ -180,7 +191,14 @@ def _validate_view(view_data: dict[str, Any]) -> None:
     config = load_dev_env_config()
     backend_api = get_backend_api(config)
     try:
-        _denormalize_pushed_view(cast("BuiltOverview", view_data), backend_api)
+        flat_view_data = _denormalize_pushed_view(cast("BuiltOverview", view_data), backend_api)
+        view_name = flat_view_data.get("name") or view_src_path.name
+        _validate_push_preconditions(
+            backend_api,
+            view_name,
+            flat_view_data,
+            force=True,
+        )
     except typer.Exit:
         raise
     except Exception as e:
@@ -515,6 +533,111 @@ def _validate_push_preconditions(
         new_uuid = str(uuid.uuid4())
         logger.info("Generating new UUID '%s' for new view.", new_uuid)
         flat_view_data["identifier"] = new_uuid
+
+    _verify_integration_dependencies(
+        backend_api,
+        view_name_or_id,
+        flat_view_data,
+    )
+
+
+def _extract_required_integrations(flat_view_data: dict[str, Any]) -> set[str]:
+    """Extract all required integration names from view widgets.
+
+    Returns:
+        A set of required integration names.
+
+    """
+    required_integrations: set[str] = set()
+    for w in flat_view_data.get("widgets") or []:
+        meta = w.get("metadata") or {}
+        config = w.get("config") or {}
+        for key in ("integrationName", "stepIntegration"):
+            val = meta.get(key) or config.get(key)
+            if val and isinstance(val, str) and val.strip():
+                required_integrations.add(val.strip())
+    return required_integrations
+
+
+def _check_unconfigured_instances(
+    backend_api: BackendAPI,
+    installed_required: list[str],
+    installed_map: dict[str, dict[str, Any]],
+) -> None:
+    """Log warnings for required integrations that have no configured instance."""
+    try:
+        all_instances = backend_api.list_integration_instances("$all")
+    except Exception as ex:  # noqa: BLE001
+        logger.debug("Failed to verify integration instances configuration: %s", ex)
+        return
+
+    configured_integrations: set[str] = {
+        str(inst.get("integrationIdentifier") or inst.get("integrationName")).lower()
+        for inst in all_instances
+        if inst.get("isConfigured") and (inst.get("integrationIdentifier") or inst.get("integrationName"))
+    }
+
+    for integration in installed_required:
+        matched_item = installed_map.get(integration.lower()) or {}
+        target_ident = (matched_item.get("identifier") or integration).lower()
+        if target_ident not in configured_integrations and integration.lower() not in configured_integrations:
+            logger.warning(
+                "[VALIDATION WARNING] Integration '%s' is installed, "
+                "but has no configured instance in SOAR Settings.",
+                integration,
+            )
+
+
+def _verify_integration_dependencies(
+    backend_api: BackendAPI,
+    view_name_or_id: str,
+    flat_view_data: dict[str, Any],
+) -> None:
+    """Verify that required integrations are installed on the platform and log warnings for unconfigured instances.
+
+    Raises:
+        typer.Exit: If a required integration is not installed on the platform.
+
+    """
+    required_integrations = _extract_required_integrations(flat_view_data)
+    if not required_integrations:
+        return
+
+    try:
+        installed = backend_api.list_installed_integrations()
+    except Exception as ex:  # noqa: BLE001
+        logger.warning("Failed to fetch installed integrations from server: %s. Skipping dependency check.", ex)
+        return
+
+    installed_map: dict[str, dict[str, Any]] = {}
+    for item in installed:
+        for key in ("identifier", "name", "displayName"):
+            val = item.get(key)
+            if val:
+                installed_map[str(val).lower()] = item
+
+    missing_integrations: list[str] = []
+    installed_required: list[str] = []
+
+    for integration in sorted(required_integrations):
+        if integration.lower() in installed_map:
+            installed_required.append(integration)
+        else:
+            missing_integrations.append(integration)
+
+    if missing_integrations:
+        for missing in missing_integrations:
+            logger.error("=" * 80)
+            logger.error("[VALIDATION ERROR] Missing Integration on Platform")
+            logger.error(
+                "Integration '%s' referenced in view '%s' is not installed on the platform.",
+                missing,
+                view_name_or_id,
+            )
+            logger.error("=" * 80)
+        raise typer.Exit(1)
+
+    _check_unconfigured_instances(backend_api, installed_required, installed_map)
 
 
 def _upload_built_view_data(

--- a/packages/mp/src/mp/dev_env/utils.py
+++ b/packages/mp/src/mp/dev_env/utils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -76,3 +77,48 @@ def get_backend_api(config: dict[str, str]) -> api.BackendAPI:
         raise typer.Exit(1) from e
     else:
         return backend_api
+
+
+def find_entity_identifier(
+    entity_name_or_id: str | int,
+    installed_entities: list[dict[str, Any]] | None,
+    entity_type_name: str,
+    id_keys: tuple[str, ...] = ("Identifier", "identifier", "Id", "id"),
+    name_keys: tuple[str, ...] = ("Name", "name", "DisplayName", "displayName"),
+) -> int | str | None:
+    """Find the entity identifier matching the given name or identifier.
+
+    Args:
+        entity_name_or_id: The entity name or identifier to search for.
+        installed_entities: The list of installed entities fetched from SOAR.
+        entity_type_name: Name of the entity type for logging (e.g., 'View', 'Custom Field').
+        id_keys: Keys to check for the identifier.
+        name_keys: Keys to check for the name.
+
+    Returns:
+        The matching entity identifier.
+
+    Raises:
+        typer.Exit: If the entity is not found in the installed entities.
+
+    """
+    str_entity_name_or_id = str(entity_name_or_id)
+
+    for entity in installed_entities or []:
+        identifier = None
+        for key in id_keys:
+            if key in entity and entity[key] is not None:
+                identifier = entity[key]
+                break
+
+        name_values = [str(entity[key]) for key in name_keys if key in entity and entity[key] is not None]
+
+        str_identifier = str(identifier) if identifier is not None else None
+
+        if str_identifier and (
+            str_entity_name_or_id.lower() == str_identifier.lower() or str_entity_name_or_id in name_values
+        ):
+            return identifier
+
+    logger.error("%s '%s' not found in installed entities in SOAR platform.", entity_type_name, entity_name_or_id)
+    raise typer.Exit(1)

--- a/packages/mp/src/mp/dev_env/utils.py
+++ b/packages/mp/src/mp/dev_env/utils.py
@@ -111,12 +111,17 @@ def find_entity_identifier(
                 identifier = entity[key]
                 break
 
-        name_values = [str(entity[key]) for key in name_keys if key in entity and entity[key] is not None]
+        name_values_lower = [
+            str(entity[key]).lower()
+            for key in name_keys
+            if key in entity and entity[key] is not None
+        ]
 
         str_identifier = str(identifier) if identifier is not None else None
 
         if str_identifier and (
-            str_entity_name_or_id.lower() == str_identifier.lower() or str_entity_name_or_id in name_values
+            str_entity_name_or_id.lower() == str_identifier.lower()
+            or str_entity_name_or_id.lower() in name_values_lower
         ):
             return identifier
 

--- a/packages/mp/src/mp/telemetry/constants.py
+++ b/packages/mp/src/mp/telemetry/constants.py
@@ -57,6 +57,10 @@ NAME_MAPPER: dict[str, str] = {
     "describe_action_with_ai": "describe action",
     "update": "self update",
     "pack_integration": "pack integration",
+    "pull_custom_field": "dev-env pull custom-field",
+    "push_custom_field": "dev-env push custom-field",
+    "pull_alert_grouping_rule": "dev-env pull alert-grouping-rule",
+    "push_alert_grouping_rule": "dev-env push alert-grouping-rule",
 }
 
 ALLOWED_COMMAND_ARGUMENTS: set[str] = {

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
@@ -135,3 +135,26 @@ def test_push_alert_grouping_rule_create(
         {"name": "projects//locations//instances//alertGroupingRules/new", "displayName": "Rule New"},
     )
     mock_api.update_alert_grouping_rule.assert_not_called()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.get_backend_api")
+def test_pull_alert_grouping_rule_with_custom_missing_dirs(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = [
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+    ]
+
+    custom_dir = tmp_path / "missing" / "dirs"
+    custom_path = custom_dir / "rule.yaml"
+
+    result = runner.invoke(pull_app, ["alert-grouping-rule", "Rule One", "--custom", str(custom_path)])
+
+    assert result.exit_code == 0
+    assert custom_path.exists()

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+from unittest import mock
+
+import yaml
+from typer.testing import CliRunner
+
+from mp.dev_env.sub_commands.pull import pull_app
+from mp.dev_env.sub_commands.push import push_app
+
+runner = CliRunner()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.get_backend_api")
+def test_pull_alert_grouping_rule(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = [
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+    ]
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(pull_app, ["alert-grouping-rule", "Rule One"])
+
+    assert result.exit_code == 0
+
+    saved_file = tmp_path / "Rule_One.yaml"
+    assert saved_file.exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.get_backend_api")
+def test_pull_all_alert_grouping_rules(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = [
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+    ]
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(pull_app, ["alert-grouping-rule", "--all"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / "Rule_One.yaml").exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.get_backend_api")
+def test_push_alert_grouping_rule_update(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = [
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+    ]
+
+    rule_file = tmp_path / "Rule_One.yaml"
+    rule_file.write_text(yaml.dump({
+        "name": "projects//locations//instances//alertGroupingRules/1",
+        "displayName": "Rule One",
+    }))
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(push_app, ["alert-grouping-rule", "Rule One"])
+
+    assert result.exit_code == 0
+    mock_api.update_alert_grouping_rule.assert_called_once_with(
+        1,
+        {"name": "projects//locations//instances//alertGroupingRules/1", "displayName": "Rule One"},
+    )
+    mock_api.create_alert_grouping_rule.assert_not_called()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.get_backend_api")
+def test_push_alert_grouping_rule_create(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = []
+
+    rule_file = tmp_path / "Rule_New.yaml"
+    rule_file.write_text(yaml.dump({
+        "name": "projects//locations//instances//alertGroupingRules/new",
+        "displayName": "Rule New",
+    }))
+
+    result = runner.invoke(push_app, ["alert-grouping-rule", str(rule_file)])
+
+    assert result.exit_code == 0
+    mock_api.create_alert_grouping_rule.assert_called_once_with(
+        {"name": "projects//locations//instances//alertGroupingRules/new", "displayName": "Rule New"},
+    )
+    mock_api.update_alert_grouping_rule.assert_not_called()

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
@@ -105,7 +105,7 @@ def test_push_alert_grouping_rule_update(
     assert result.exit_code == 0
     mock_api.update_alert_grouping_rule.assert_called_once_with(
         1,
-        {"name": "projects//locations//instances//alertGroupingRules/1", "displayName": "Rule One"},
+        {"name": "projects//locations//instances//alertGroupingRules/1", "displayName": "Rule One", "id": 1},
     )
     mock_api.create_alert_grouping_rule.assert_not_called()
 
@@ -128,7 +128,7 @@ def test_push_alert_grouping_rule_create(
         "displayName": "Rule New",
     }))
 
-    result = runner.invoke(push_app, ["alert-grouping-rule", str(rule_file)])
+    result = runner.invoke(push_app, ["alert-grouping-rule", str(rule_file), "--allow-create"])
 
     assert result.exit_code == 0
     mock_api.create_alert_grouping_rule.assert_called_once_with(

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_alert_grouping_rules.py
@@ -37,19 +37,24 @@ def test_pull_alert_grouping_rule(
     mock_get_backend_api.return_value = mock_api
 
     mock_api.list_alert_grouping_rules.return_value = [
-        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "category": "All"},
     ]
 
     with mock.patch(
         "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
         return_value=tmp_path,
     ):
-        result = runner.invoke(pull_app, ["alert-grouping-rule", "Rule One"])
+        result = runner.invoke(pull_app, ["alert-grouping-rule", "All"])
 
     assert result.exit_code == 0
 
-    saved_file = tmp_path / "Rule_One.yaml"
+    saved_file = tmp_path / "All.yaml"
     assert saved_file.exists()
+    with saved_file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        assert "id" not in data
+        assert "name" not in data
+        assert data["category"] == "All"
 
 
 @mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.load_dev_env_config")
@@ -63,7 +68,7 @@ def test_pull_all_alert_grouping_rules(
     mock_get_backend_api.return_value = mock_api
 
     mock_api.list_alert_grouping_rules.return_value = [
-        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "category": "All"},
     ]
 
     with mock.patch(
@@ -73,7 +78,12 @@ def test_pull_all_alert_grouping_rules(
         result = runner.invoke(pull_app, ["alert-grouping-rule", "--all"])
 
     assert result.exit_code == 0
-    assert (tmp_path / "Rule_One.yaml").exists()
+    saved_file = tmp_path / "All.yaml"
+    assert saved_file.exists()
+    with saved_file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        assert "id" not in data
+        assert "name" not in data
 
 
 @mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.load_dev_env_config")
@@ -87,25 +97,25 @@ def test_push_alert_grouping_rule_update(
     mock_get_backend_api.return_value = mock_api
 
     mock_api.list_alert_grouping_rules.return_value = [
-        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "category": "All"},
     ]
 
-    rule_file = tmp_path / "Rule_One.yaml"
+    rule_file = tmp_path / "All.yaml"
     rule_file.write_text(yaml.dump({
-        "name": "projects//locations//instances//alertGroupingRules/1",
-        "displayName": "Rule One",
+        "category": "All",
+        "groupingType": "Entities",
     }))
 
     with mock.patch(
         "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
         return_value=tmp_path,
     ):
-        result = runner.invoke(push_app, ["alert-grouping-rule", "Rule One"])
+        result = runner.invoke(push_app, ["alert-grouping-rule", "All"])
 
     assert result.exit_code == 0
     mock_api.update_alert_grouping_rule.assert_called_once_with(
         1,
-        {"name": "projects//locations//instances//alertGroupingRules/1", "displayName": "Rule One", "id": 1},
+        {"category": "All", "groupingType": "Entities", "id": 1, "name": "projects//locations//instances//alertGroupingRules/1"},
     )
     mock_api.create_alert_grouping_rule.assert_not_called()
 
@@ -122,17 +132,17 @@ def test_push_alert_grouping_rule_create(
 
     mock_api.list_alert_grouping_rules.return_value = []
 
-    rule_file = tmp_path / "Rule_New.yaml"
+    rule_file = tmp_path / "AlertType.yaml"
     rule_file.write_text(yaml.dump({
-        "name": "projects//locations//instances//alertGroupingRules/new",
-        "displayName": "Rule New",
+        "category": "AlertType",
+        "groupingType": "Entities",
     }))
 
-    result = runner.invoke(push_app, ["alert-grouping-rule", str(rule_file), "--allow-create"])
+    result = runner.invoke(push_app, ["alert-grouping-rule", str(rule_file), "--force"])
 
     assert result.exit_code == 0
     mock_api.create_alert_grouping_rule.assert_called_once_with(
-        {"name": "projects//locations//instances//alertGroupingRules/new", "displayName": "Rule New"},
+        {"category": "AlertType", "groupingType": "Entities"},
     )
     mock_api.update_alert_grouping_rule.assert_not_called()
 
@@ -148,13 +158,104 @@ def test_pull_alert_grouping_rule_with_custom_missing_dirs(
     mock_get_backend_api.return_value = mock_api
 
     mock_api.list_alert_grouping_rules.return_value = [
-        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "displayName": "Rule One"},
+        {"name": "projects//locations//instances//alertGroupingRules/1", "id": 1, "category": "All"},
     ]
 
     custom_dir = tmp_path / "missing" / "dirs"
     custom_path = custom_dir / "rule.yaml"
 
-    result = runner.invoke(pull_app, ["alert-grouping-rule", "Rule One", "--custom", str(custom_path)])
+    result = runner.invoke(pull_app, ["alert-grouping-rule", "All", "--custom", str(custom_path)])
 
     assert result.exit_code == 0
     assert custom_path.exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.pull.get_backend_api")
+def test_pull_multiple_rules_same_category(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = [
+        {
+            "name": "projects//locations//instances//alertGroupingRules/1",
+            "id": 1,
+            "category": "AlertType",
+            "categoryDetails": [{"identifier": "Phishing", "displayName": "Phishing"}]
+        },
+        {
+            "name": "projects//locations//instances//alertGroupingRules/2",
+            "id": 2,
+            "category": "AlertType",
+            "categoryDetails": [{"identifier": "Brute Force", "displayName": "Brute Force"}]
+        },
+    ]
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(pull_app, ["alert-grouping-rule", "Alert Type"])
+
+    assert result.exit_code == 0
+    
+    file_1 = tmp_path / "AlertType_phishing.yaml"
+    file_2 = tmp_path / "AlertType_brute_force.yaml"
+    assert file_1.exists()
+    assert file_2.exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.alert_grouping_rule.push.get_backend_api")
+def test_push_multiple_rules_same_category(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_alert_grouping_rules.return_value = [
+        {
+            "name": "projects//locations//instances//alertGroupingRules/1",
+            "id": 1,
+            "category": "AlertType",
+            "categoryDetails": [{"identifier": "Phishing", "displayName": "Phishing"}]
+        },
+        {
+            "name": "projects//locations//instances//alertGroupingRules/2",
+            "id": 2,
+            "category": "AlertType",
+            "categoryDetails": [{"identifier": "Brute Force", "displayName": "Brute Force"}]
+        },
+    ]
+
+    # Create two files
+    file_1 = tmp_path / "AlertType_phishing.yaml"
+    file_1.write_text(yaml.dump({
+        "category": "AlertType",
+        "categoryDetails": [{"identifier": "Phishing", "displayName": "Phishing"}],
+        "groupingType": "Entities",
+    }))
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_alert_grouping_rules_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(push_app, ["alert-grouping-rule", "AlertType"])
+
+    assert result.exit_code == 0
+    mock_api.update_alert_grouping_rule.assert_called_once_with(
+        1,
+        {
+            "category": "AlertType",
+            "categoryDetails": [{"identifier": "Phishing", "displayName": "Phishing"}],
+            "groupingType": "Entities",
+            "id": 1,
+            "name": "projects//locations//instances//alertGroupingRules/1"
+        },
+    )

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
@@ -127,7 +127,7 @@ def test_push_custom_field_update(
     assert result.exit_code == 0
     mock_api.update_custom_field.assert_called_once_with(
         1,
-        {"name": "projects//locations//instances//customFields/1", "displayName": "Test Field", "type": "String"},
+        {"name": "projects//locations//instances//customFields/1", "displayName": "Test Field", "type": "String", "id": 1},
     )
     mock_api.create_custom_field.assert_not_called()
 
@@ -151,7 +151,7 @@ def test_push_custom_field_create(
         "type": "String",
     }))
 
-    result = runner.invoke(push_app, ["custom-field", str(field_file)])
+    result = runner.invoke(push_app, ["custom-field", str(field_file), "--allow-create"])
 
     assert result.exit_code == 0
     mock_api.create_custom_field.assert_called_once_with(

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
@@ -57,7 +57,7 @@ def test_pull_custom_field(
     assert result.exit_code == 0
     mock_api.download_custom_field.assert_called_once_with(1)
 
-    saved_file = tmp_path / "Test_Field.yaml"
+    saved_file = tmp_path / "shared" / "Test_Field.yaml"
     assert saved_file.exists()
 
     with saved_file.open("r", encoding="utf-8") as f:
@@ -97,7 +97,7 @@ def test_pull_all_custom_fields(
     assert result.exit_code == 0
     mock_api.download_custom_field.assert_called_once_with(1)
     
-    saved_file = tmp_path / "Test_Field.yaml"
+    saved_file = tmp_path / "shared" / "Test_Field.yaml"
     assert saved_file.exists()
     with saved_file.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
@@ -230,8 +230,8 @@ def test_pull_custom_field_multiple_matches(
     mock_api.download_custom_field.assert_any_call(1)
     mock_api.download_custom_field.assert_any_call(2)
 
-    assert (tmp_path / "Test_Field_alert.yaml").exists()
-    assert (tmp_path / "Test_Field_case.yaml").exists()
+    assert (tmp_path / "alert" / "Test_Field_alert.yaml").exists()
+    assert (tmp_path / "case" / "Test_Field_case.yaml").exists()
 
 
 @mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
@@ -63,6 +63,8 @@ def test_pull_custom_field(
     with saved_file.open("r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
         assert data["displayName"] == "Test Field"
+        assert "id" not in data
+        assert "name" not in data
 
 
 @mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
@@ -94,7 +96,13 @@ def test_pull_all_custom_fields(
 
     assert result.exit_code == 0
     mock_api.download_custom_field.assert_called_once_with(1)
-    assert (tmp_path / "Test_Field.yaml").exists()
+    
+    saved_file = tmp_path / "Test_Field.yaml"
+    assert saved_file.exists()
+    with saved_file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        assert "id" not in data
+        assert "name" not in data
 
 
 @mock.patch("mp.dev_env.sub_commands.custom_field.push.load_dev_env_config")
@@ -151,7 +159,7 @@ def test_push_custom_field_create(
         "type": "String",
     }))
 
-    result = runner.invoke(push_app, ["custom-field", str(field_file), "--allow-create"])
+    result = runner.invoke(push_app, ["custom-field", str(field_file), "--force"])
 
     assert result.exit_code == 0
     mock_api.create_custom_field.assert_called_once_with(

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+from unittest import mock
+
+import yaml
+from typer.testing import CliRunner
+
+from mp.dev_env.sub_commands.pull import pull_app
+from mp.dev_env.sub_commands.push import push_app
+
+runner = CliRunner()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.get_backend_api")
+def test_pull_custom_field(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field"},
+        {"name": "projects//locations//instances//customFields/2", "id": 2, "displayName": "Other Field"},
+    ]
+
+    mock_api.download_custom_field.return_value = {
+        "name": "projects//locations//instances//customFields/1",
+        "id": 1,
+        "displayName": "Test Field",
+        "type": "String",
+    }
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_custom_fields_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(pull_app, ["custom-field", "Test Field"])
+
+    assert result.exit_code == 0
+    mock_api.download_custom_field.assert_called_once_with(1)
+
+    saved_file = tmp_path / "Test_Field.yaml"
+    assert saved_file.exists()
+
+    with saved_file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        assert data["displayName"] == "Test Field"
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.get_backend_api")
+def test_pull_all_custom_fields(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field"},
+    ]
+
+    mock_api.download_custom_field.return_value = {
+        "name": "projects//locations//instances//customFields/1",
+        "id": 1,
+        "displayName": "Test Field",
+        "type": "String",
+    }
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_custom_fields_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(pull_app, ["custom-field", "--all"])
+
+    assert result.exit_code == 0
+    mock_api.download_custom_field.assert_called_once_with(1)
+    assert (tmp_path / "Test_Field.yaml").exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.push.get_backend_api")
+def test_push_custom_field_update(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field"},
+    ]
+
+    field_file = tmp_path / "Test_Field.yaml"
+    field_file.write_text(yaml.dump({
+        "name": "projects//locations//instances//customFields/1",
+        "displayName": "Test Field",
+        "type": "String",
+    }))
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_custom_fields_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(push_app, ["custom-field", "Test Field"])
+
+    assert result.exit_code == 0
+    mock_api.update_custom_field.assert_called_once_with(
+        1,
+        {"name": "projects//locations//instances//customFields/1", "displayName": "Test Field", "type": "String"},
+    )
+    mock_api.create_custom_field.assert_not_called()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.push.get_backend_api")
+def test_push_custom_field_create(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = []
+
+    field_file = tmp_path / "New_Field.yaml"
+    field_file.write_text(yaml.dump({
+        "name": "projects//locations//instances//customFields/new",
+        "displayName": "New Field",
+        "type": "String",
+    }))
+
+    result = runner.invoke(push_app, ["custom-field", str(field_file)])
+
+    assert result.exit_code == 0
+    mock_api.create_custom_field.assert_called_once_with(
+        {"name": "projects//locations//instances//customFields/new", "displayName": "New Field", "type": "String"},
+    )
+    mock_api.update_custom_field.assert_not_called()

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
@@ -189,3 +189,147 @@ def test_pull_custom_field_with_custom_missing_dirs(
     assert result.exit_code == 0
     mock_api.download_custom_field.assert_called_once_with(1)
     assert custom_path.exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.get_backend_api")
+def test_pull_custom_field_multiple_matches(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field", "scopes": "Alert"},
+        {"name": "projects//locations//instances//customFields/2", "id": 2, "displayName": "Test Field", "scopes": "Case"},
+    ]
+
+    mock_api.download_custom_field.side_effect = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field", "scopes": "Alert"},
+        {"name": "projects//locations//instances//customFields/2", "id": 2, "displayName": "Test Field", "scopes": "Case"},
+    ]
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_custom_fields_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(pull_app, ["custom-field", "Test Field"])
+
+    assert result.exit_code == 0
+    assert mock_api.download_custom_field.call_count == 2
+    mock_api.download_custom_field.assert_any_call(1)
+    mock_api.download_custom_field.assert_any_call(2)
+
+    assert (tmp_path / "Test_Field_alert.yaml").exists()
+    assert (tmp_path / "Test_Field_case.yaml").exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.get_backend_api")
+def test_pull_custom_field_multiple_matches_error_if_destination(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field", "scopes": "Alert"},
+        {"name": "projects//locations//instances//customFields/2", "id": 2, "displayName": "Test Field", "scopes": "Case"},
+    ]
+
+    custom_path = tmp_path / "out.yaml"
+
+    result = runner.invoke(pull_app, ["custom-field", "Test Field", "--custom", str(custom_path)])
+
+    assert result.exit_code == 1
+    mock_api.download_custom_field.assert_not_called()
+    assert not custom_path.exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.get_backend_api")
+def test_pull_custom_field_path_based(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field", "scopes": "Alert"},
+        {"name": "projects//locations//instances//customFields/2", "id": 2, "displayName": "Test Field", "scopes": "Case"},
+    ]
+
+    mock_api.download_custom_field.return_value = {
+        "name": "projects//locations//instances//customFields/2",
+        "id": 2,
+        "displayName": "Test Field",
+        "scopes": "Case",
+        "description": "Updated",
+    }
+
+    local_file = tmp_path / "Test_Field_case.yaml"
+    local_file.write_text(yaml.dump({
+        "displayName": "Test Field",
+        "scopes": "Case",
+        "description": "Old",
+    }))
+
+    result = runner.invoke(pull_app, ["custom-field", str(local_file)])
+
+    assert result.exit_code == 0
+    mock_api.download_custom_field.assert_called_once_with(2)
+    
+    with local_file.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        assert data["description"] == "Updated"
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.push.get_backend_api")
+def test_push_custom_field_multiple_matching_files(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field", "scopes": "Alert"},
+        {"name": "projects//locations//instances//customFields/2", "id": 2, "displayName": "Test Field", "scopes": "Case"},
+    ]
+
+    file1 = tmp_path / "Test_Field_alert.yaml"
+    file1.write_text(yaml.dump({
+        "displayName": "Test Field",
+        "scopes": "Alert",
+        "description": "Alert Desc",
+    }))
+
+    file2 = tmp_path / "Test_Field_case.yaml"
+    file2.write_text(yaml.dump({
+        "displayName": "Test Field",
+        "scopes": "Case",
+        "description": "Case Desc",
+    }))
+
+    with mock.patch(
+        "mp.core.file_utils.create_or_get_custom_fields_root_dir",
+        return_value=tmp_path,
+    ):
+        result = runner.invoke(push_app, ["custom-field", "Test Field"])
+
+    assert result.exit_code == 0
+    assert mock_api.update_custom_field.call_count == 2
+    mock_api.update_custom_field.assert_any_call(
+        1, {"displayName": "Test Field", "scopes": "Alert", "description": "Alert Desc", "id": 1, "name": "projects//locations//instances//customFields/1"}
+    )
+    mock_api.update_custom_field.assert_any_call(
+        2, {"displayName": "Test Field", "scopes": "Case", "description": "Case Desc", "id": 2, "name": "projects//locations//instances//customFields/2"}
+    )

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_custom_fields.py
@@ -158,3 +158,34 @@ def test_push_custom_field_create(
         {"name": "projects//locations//instances//customFields/new", "displayName": "New Field", "type": "String"},
     )
     mock_api.update_custom_field.assert_not_called()
+
+
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.custom_field.pull.get_backend_api")
+def test_pull_custom_field_with_custom_missing_dirs(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_custom_fields.return_value = [
+        {"name": "projects//locations//instances//customFields/1", "id": 1, "displayName": "Test Field"},
+    ]
+
+    mock_api.download_custom_field.return_value = {
+        "name": "projects//locations//instances//customFields/1",
+        "id": 1,
+        "displayName": "Test Field",
+        "type": "String",
+    }
+
+    custom_dir = tmp_path / "missing" / "dirs"
+    custom_path = custom_dir / "field.yaml"
+
+    result = runner.invoke(pull_app, ["custom-field", "Test Field", "--custom", str(custom_path)])
+
+    assert result.exit_code == 0
+    mock_api.download_custom_field.assert_called_once_with(1)
+    assert custom_path.exists()

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_views.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_views.py
@@ -106,6 +106,146 @@ def test_pull_view_cli(
     assert (view_folder / "widgets" / "Widget One.html").read_text(encoding="utf-8") == "<h1>Hello</h1>"
 
 
+@mock.patch("mp.dev_env.sub_commands.view.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.view.pull.get_backend_api")
+def test_pull_view_matches_local_folder(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    # Setup mock backend API
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_views.return_value = [
+        {"Identifier": "system_case_default", "Name": "Default Case View"}
+    ]
+
+    mock_api.download_view.return_value = {
+        "identifier": "system_case_default",
+        "name": "Default Case View",
+        "creator": "system",
+        "playbookIdentifier": "playbook_1",
+        "type": 3,
+        "widgets": [],
+        "roles": [],
+    }
+
+    # Pre-create local view folder with a custom name but matching view name
+    custom_folder = tmp_path / "my_custom_folder_name"
+    custom_folder.mkdir()
+    (custom_folder / "view.yaml").write_text(yaml.dump({
+        "identifier": "old_identifier",
+        "name": "Default Case View",
+        "type": "system_case",
+        "creator": "system",
+        "widgets_details": []
+    }), encoding="utf-8")
+
+    with mock.patch("mp.core.file_utils.create_or_get_views_root_dir", return_value=tmp_path):
+        result = runner.invoke(pull_app, ["view", "Default Case View"])
+
+    assert result.exit_code == 0
+    # Overwrote local folder in-place
+    assert (custom_folder / "view.yaml").exists()
+    with (custom_folder / "view.yaml").open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+        assert data["identifier"] == "system_case_default"
+
+    # No duplicate folder was created
+    assert not (tmp_path / "system_case_default").exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.view.pull.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.view.pull.get_backend_api")
+def test_pull_view_all(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+
+    mock_api.list_views.return_value = [
+        {"identifier": "view_id_1", "name": "View One"},
+        {"identifier": "view_id_2", "name": "View Two"},
+    ]
+
+    mock_api.download_view.side_effect = [
+        {"identifier": "view_id_1", "name": "View One", "type": 3, "widgets": [], "roles": []},
+        {"identifier": "view_id_2", "name": "View Two", "type": 3, "widgets": [], "roles": []},
+    ]
+
+    with mock.patch("mp.core.file_utils.create_or_get_views_root_dir", return_value=tmp_path):
+        result = runner.invoke(pull_app, ["view", "--all"])
+
+    assert result.exit_code == 0
+    assert mock_api.download_view.call_count == 2
+    mock_api.download_view.assert_any_call("view_id_1")
+    mock_api.download_view.assert_any_call("view_id_2")
+
+    assert (tmp_path / "view_id_1" / "view.yaml").exists()
+    assert (tmp_path / "view_id_2" / "view.yaml").exists()
+
+
+@mock.patch("mp.dev_env.sub_commands.view.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.view.push.get_backend_api")
+def test_push_view_all(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+    mock_api.upload_view.return_value = {"success": True}
+    mock_api.list_views.return_value = [
+        {"identifier": "view_id_1", "id": 1},
+        {"identifier": "view_id_2", "id": 2},
+    ]
+    mock_api.download_view.side_effect = [
+        {"identifier": "view_id_1", "name": "View One", "type": 3, "widgets": []},
+        {"identifier": "view_id_2", "name": "View Two", "type": 3, "widgets": []},
+        # For the post-push download_and_deconstruct_view calls:
+        {"identifier": "view_id_1", "name": "View One", "type": 3, "widgets": [], "roles": []},
+        {"identifier": "view_id_2", "name": "View Two", "type": 3, "widgets": [], "roles": []},
+    ]
+
+    # Create dummy local view directories
+    view_1_dir = tmp_path / "view_id_1"
+    view_1_dir.mkdir()
+    (view_1_dir / "view.yaml").write_text(yaml.dump({
+        "identifier": "view_id_1",
+        "name": "View One",
+        "type": "system_case",
+        "creator": "system",
+        "playbook_id": "playbook_1",
+        "alert_rule_type": None,
+        "roles": [1, 2],
+        "role_names": ["Tier 1", "Tier 2"],
+        "widgets_details": []
+    }), encoding="utf-8")
+
+    view_2_dir = tmp_path / "view_id_2"
+    view_2_dir.mkdir()
+    (view_2_dir / "view.yaml").write_text(yaml.dump({
+        "identifier": "view_id_2",
+        "name": "View Two",
+        "type": "system_case",
+        "creator": "system",
+        "playbook_id": "playbook_1",
+        "alert_rule_type": None,
+        "roles": [1, 2],
+        "role_names": ["Tier 1", "Tier 2"],
+        "widgets_details": []
+    }), encoding="utf-8")
+
+    with mock.patch("mp.core.file_utils.create_or_get_views_root_dir", return_value=tmp_path):
+        result = runner.invoke(push_app, ["view", "--all"])
+
+    assert result.exit_code == 0
+    assert mock_api.upload_view.call_count == 2
+
+
 @mock.patch("mp.dev_env.sub_commands.view.push.load_dev_env_config")
 @mock.patch("mp.dev_env.sub_commands.view.push.get_backend_api")
 def test_push_view_cli(
@@ -232,15 +372,9 @@ def test_push_view_cli(
     assert widgets[0]["metadata"]["title"] == "Widget One"
     assert widgets[0]["config"]["htmlContent"] == "<h1>Hello from push</h1>"
 
-    # Verify automatic pull-back updated local directory with server values
-    assert mock_api.download_view.call_count == 2
+    # Verify download_view was only called once during widget verification
+    assert mock_api.download_view.call_count == 1
     assert (view_folder / "view.yaml").exists()
-    with (view_folder / "view.yaml").open(encoding="utf-8") as f:
-        updated_view_data = yaml.safe_load(f)
-    assert updated_view_data["name"] == "Default Case View - Server Updated Name"
-
-    assert (view_folder / "widgets" / "Widget One.html").exists()
-    assert (view_folder / "widgets" / "Widget One.html").read_text(encoding="utf-8") == "<h1>Hello from server</h1>"
 
 
 @mock.patch("mp.dev_env.sub_commands.view.push.load_dev_env_config")
@@ -495,14 +629,13 @@ def test_push_view_fallback_to_name_and_type_matching(
     assert called_args["id"] == 100                 # Server ID is injected
     assert called_args["type"] == 3
 
-    # Verify download_view was called twice with "server_uuid"
-    assert mock_api.download_view.call_count == 2
-    assert mock_api.download_view.call_args_list[0][0][0] == "server_uuid"
-    assert mock_api.download_view.call_args_list[1][0][0] == "server_uuid"
+    # Verify download_view was only called once during widget verification
+    assert mock_api.download_view.call_count == 1
+    mock_api.download_view.assert_called_once_with("server_uuid")
 
-    # Verify local folder was renamed to match server UUID
-    assert not (src_dir / "local_uuid").exists()
-    assert (src_dir / "server_uuid").exists()
+    # Verify local folder was not renamed
+    assert (src_dir / "local_uuid").exists()
+    assert not (src_dir / "server_uuid").exists()
 
 
 @mock.patch("mp.dev_env.sub_commands.view.push.load_dev_env_config")

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_views.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_views.py
@@ -728,3 +728,83 @@ def test_push_view_missing_widget_fails(
     # Should fail due to missing widget validation error
     assert result.exit_code != 0
     mock_api.upload_view.assert_not_called()
+
+
+@mock.patch("mp.dev_env.sub_commands.view.push.load_dev_env_config")
+@mock.patch("mp.dev_env.sub_commands.view.push.get_backend_api")
+def test_push_view_missing_integration_fails(
+    mock_get_backend_api: mock.MagicMock,
+    mock_load_config: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_api = mock.MagicMock()
+    mock_get_backend_api.return_value = mock_api
+    mock_api.list_views.return_value = [{"identifier": "test_uuid", "id": 100}]
+    mock_api.download_view.return_value = {
+        "widgets": [
+            {
+                "metadata": {
+                    "title": "Widget One",
+                    "identifier": "widget_one_id",
+                }
+            }
+        ]
+    }
+    mock_api.list_installed_integrations.return_value = [
+        {"identifier": "OtherIntegration", "displayName": "Other Integration"}
+    ]
+
+    src_dir = tmp_path / "views"
+    view_folder = src_dir / "test_uuid"
+    view_folder.mkdir(parents=True)
+
+    view_yaml_data = {
+        "identifier": "test_uuid",
+        "name": "Test View",
+        "creator": "system",
+        "playbook_id": "playbook_1",
+        "type": "system_case",
+        "alert_rule_type": None,
+        "roles": [1, 2],
+        "role_names": ["Tier 1", "Tier 2"],
+        "widgets_details": [{"title": "Widget One", "size": "half_width", "order": 1}],
+    }
+    with (view_folder / "view.yaml").open("w", encoding="utf-8") as f:
+        yaml.dump(view_yaml_data, f)
+
+    widgets_dir = view_folder / "widgets"
+    widgets_dir.mkdir()
+    widget_yaml_data = {
+        "title": "Widget One",
+        "description": "HTML Widget",
+        "identifier": "widget_one_id",
+        "order": 1,
+        "template_identifier": "temp_one",
+        "type": "html",
+        "data_definition": {
+            "html_height": 100,
+            "safe_rendering": True,
+            "widget_definition_scope": "alert",
+            "type": "html",
+        },
+        "widget_size": "half_width",
+        "action_widget_template_id": None,
+        "step_id": None,
+        "step_integration": None,
+        "block_step_id": None,
+        "block_step_instance_name": None,
+        "present_if_empty": False,
+        "conditions_group": {"logical_operator": "and", "conditions": []},
+        "integration_name": "MissingIntegration",
+    }
+    with (widgets_dir / "Widget One.yaml").open("w", encoding="utf-8") as f:
+        yaml.dump(widget_yaml_data, f)
+
+    with mock.patch("mp.core.file_utils.get_view_out_dir", return_value=tmp_path / "out"):
+        result = runner.invoke(
+            push_app,
+            ["view", "test_uuid", "--custom", str(src_dir)],
+        )
+
+    assert result.exit_code != 0
+    mock_api.upload_view.assert_not_called()

--- a/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_views.py
+++ b/packages/mp/tests/test_mp/test_dev_env/test_sub_commands/test_views.py
@@ -429,10 +429,10 @@ def test_push_view_allows_new_widget_with_flag(
     with mock.patch("mp.core.file_utils.get_view_out_dir", return_value=tmp_path / "out"):
         result = runner.invoke(
             push_app,
-            ["view", "system_case_default", "--custom", str(src_dir), "--allow-create"],
+            ["view", "system_case_default", "--custom", str(src_dir), "--force"],
         )
 
-    # Should succeed with the --allow-create flag
+    # Should succeed with the --force flag
     assert result.exit_code == 0
     mock_api.upload_view.assert_called_once()
 

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.32.0"
+version = "1.32.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**  
Currently, the `mp` tool lacks synchronization commands for Custom Fields and Alert Grouping Rules. This forces developers to use older systems like GitSync or manual UI creation. This PR bridges the gap by implementing `mp pull` and `mp push` commands for both entity types, enabling version control through local YAML files.

**How does this PR solve the problem?**  
*   **API Client Extensions**: Added `list_custom_fields`, `download_custom_field`, `upload_custom_field` (and their equivalents for Alert Grouping Rules) endpoints to `BackendAPI` client using internal `1p/external` routes.
*   **CLI Subcommands**: Registered `pull custom-field`, `push custom-field`, `pull alert-grouping-rule`, and `push alert-grouping-rule` subcommands inside `pull_app` and `push_app`.
*   **Enhanced Entity Resolution**: Upgraded `find_entity_identifier` to gracefully handle fields without string UUIDs, safely casting numeric IDs to strings. It also supports fallback lookups across `displayName` and `name` properties (critical since API returns Google Cloud resource paths in `name`).
*   **Robust File Utilities**: Created dedicated `mp.core.file_utils` directories to handle reading and writing YAML payloads. Paths are aggressively sanitized to prevent `projects//...` strings from generating recursive directory trees.
*   **Dynamic ID Resolution**: Added server-side ID resolution during `push`. If the field exists on the remote environment, it injects the integer ID into the payload to perform an *update*. If it does not exist, it removes the ID to trigger a *create* operation.
*   **Testing**: Added 100% unit and integration CLI test coverage leveraging `typer.testing.CliRunner`.
*   **Telemetry Registration**: Tracked all new commands in `constants.py` to prevent execution crashes on missing command metrics.

**Any other relevant information (e.g., design choices, tradeoffs, known issues):**  
Unlike Playbooks and Views which use UUIDs, Custom Fields and Alert Grouping Rules utilize sequential database integer IDs that vary per environment. Therefore, the implementation relies heavily on dynamic resolution by `Name`/`DisplayName` during `push` to avoid collision conflicts between instances. 
Also, Custom Fields API returns the technical Google Cloud resource path in the `name` property. We had to ensure `find_entity_identifier` scans multiple `name_values` to allow the user to easily search by `displayName` (e.g. `Threat Type`).

### Usage Instructions

#### Custom Fields

**Pull from SOAR to local Git repository**
```bash
mp pull custom-field "Threat Type"
# Or pull all custom fields:
mp pull custom-field --all
# List all available fields on remote:
mp pull custom-field --list
```

**Push local changes back to SOAR**
```bash
mp push custom-field "Threat Type"
# Or push all custom fields:
mp push custom-field --all
```

#### Alert Grouping Rules

**Pull from SOAR to local Git repository**
```bash
mp pull alert-grouping-rule "Rule Name"
mp pull alert-grouping-rule --all
```

**Push local changes back to SOAR**
```bash
mp push alert-grouping-rule "Rule Name"
mp push alert-grouping-rule --all
```

### Workflow Sequence Diagrams

#### `mp pull custom-field` Workflow
```mermaid
sequenceDiagram
    autonumber
    actor Dev as Developer
    participant CLI as mp CLI (pull)
    participant API as SOAR Backend API
    participant FS as Local Filesystem

    Dev->>CLI: mp pull custom-field "Threat Type"
    CLI->>API: list_custom_fields()
    API-->>CLI: Installed fields list (IDs, names, displayNames)
    Note over CLI: Searches for "Threat Type" across name/displayName values
    Note over CLI: Resolves string to Entity Integer ID
    CLI->>API: download_custom_field(ID)
    API-->>CLI: Custom Field JSON Payload
    Note over CLI: Sanitizes slashes from names for file paths
    CLI->>FS: Save content/custom_fields/Threat_Type.yaml
    CLI-->>Dev: Print Success ✅
```

#### `mp push custom-field` Workflow
```mermaid
sequenceDiagram
    autonumber
    actor Dev as Developer
    participant CLI as mp CLI (push)
    participant FS as Local Filesystem
    participant API as SOAR Backend API

    Dev->>CLI: mp push custom-field "Threat Type"
    Note over CLI: Matches "Threat Type" to local file Threat_Type.yaml
    CLI->>FS: Read content/custom_fields/Threat_Type.yaml
    FS-->>CLI: Local YAML Payload
    CLI->>API: list_custom_fields()
    API-->>CLI: Installed fields list
    Note over CLI: Resolves entity name to Server DB integer ID
    alt Existing Entity (ID found)
        Note over CLI: Set payload["id"] = resolved_id (Updates)
    else New Entity
        Note over CLI: Deletes payload["id"] (Creates)
    end
    CLI->>API: upload_custom_field(payload)
    API-->>CLI: Upload status response
    CLI-->>Dev: Print Success ✅
```

---

## Checklist:

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes.
- [x] I have updated the documentation where necessary (e.g., README, API docs).

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.

---

## Screenshots (If Applicable)

N/A

---

## Further Comments / Questions

This PR introduces parallel CLI commands mirroring the GitSync coverage gaps for views and playbooks. All logic is heavily unit tested using `typer.testing.CliRunner`.
