### PR TITLE
Migrating BMC_HELIX_DISCOVERY with synthetic_agent

### DIFF
--- a/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/metadata.json
+++ b/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/metadata.json
@@ -1,7 +1,7 @@
 {
   "log_type": "BMC_HELIX_DISCOVERY",
   "product": "BMC_HELIX_DISCOVERY",
-  "vendor": "BMC",
+  "vendor": "BMC_HELIX_DISCOVERY",
   "description": "Parser for BMC_HELIX_DISCOVERY logs",
   "supported_format": "SYSLOG",
   "category": "bmc helix discovery",

--- a/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/testdata/expected_events/default_events.json
+++ b/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/testdata/expected_events/default_events.json
@@ -1,0 +1,153 @@
+{
+  "events": [
+    {
+      "event": {
+        "timestamp": "2024-07-13T10:00:01Z",
+        "idm": {
+          "readOnlyUdm": {
+            "extensions": {
+              "auth": {}
+            },
+            "metadata": {
+              "description": "User logged on from IP 1.1.1.1",
+              "eventTimestamp": "2024-07-13T10:00:01Z",
+              "eventType": "USER_LOGIN",
+              "logType": "BMC_HELIX_DISCOVERY",
+              "productEventType": "LOGON",
+              "productName": "BMC_HELIX_DISCOVERY",
+              "vendorName": "BMC_HELIX_DISCOVERY"
+            },
+            "principal": {
+              "asset": {
+                "ip": [
+                  "1.1.1.1"
+                ]
+              },
+              "ip": [
+                "1.1.1.1"
+              ]
+            },
+            "securityResult": [
+              {
+                "summary": "Successful Login"
+              }
+            ],
+            "target": {
+              "user": {
+                "userid": "test_username"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "event": {
+        "timestamp": "2024-07-13T10:05:02Z",
+        "idm": {
+          "readOnlyUdm": {
+            "extensions": {
+              "auth": {}
+            },
+            "metadata": {
+              "description": "User logged off from IP 2.2.2.2",
+              "eventTimestamp": "2024-07-13T10:05:02Z",
+              "eventType": "USER_LOGOUT",
+              "logType": "BMC_HELIX_DISCOVERY",
+              "productEventType": "LOGOFF",
+              "productName": "BMC_HELIX_DISCOVERY",
+              "vendorName": "BMC_HELIX_DISCOVERY"
+            },
+            "principal": {
+              "asset": {
+                "ip": [
+                  "2.2.2.2"
+                ]
+              },
+              "ip": [
+                "2.2.2.2"
+              ]
+            },
+            "securityResult": [
+              {
+                "summary": "Successful Logout"
+              }
+            ],
+            "target": {
+              "user": {
+                "userid": "test_username"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "event": {
+        "timestamp": "2024-07-13T10:10:03Z",
+        "idm": {
+          "readOnlyUdm": {
+            "extensions": {
+              "auth": {}
+            },
+            "metadata": {
+              "description": "Device status updated from IP 3.3.3.3",
+              "eventTimestamp": "2024-07-13T10:10:03Z",
+              "eventType": "STATUS_UPDATE",
+              "logType": "BMC_HELIX_DISCOVERY",
+              "productEventType": "STATUS",
+              "productName": "BMC_HELIX_DISCOVERY",
+              "vendorName": "BMC_HELIX_DISCOVERY"
+            },
+            "principal": {
+              "asset": {
+                "ip": [
+                  "3.3.3.3"
+                ]
+              },
+              "ip": [
+                "3.3.3.3"
+              ]
+            },
+            "securityResult": [
+              {
+                "summary": "Status Check"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "event": {
+        "timestamp": "2024-07-13T10:15:04Z",
+        "idm": {
+          "readOnlyUdm": {
+            "extensions": {
+              "auth": {}
+            },
+            "metadata": {
+              "description": "Routine discovery scan completed without IP address",
+              "eventTimestamp": "2024-07-13T10:15:04Z",
+              "eventType": "GENERIC_EVENT",
+              "logType": "BMC_HELIX_DISCOVERY",
+              "productEventType": "DISCOVERY",
+              "productName": "BMC_HELIX_DISCOVERY",
+              "vendorName": "BMC_HELIX_DISCOVERY"
+            },
+            "securityResult": [
+              {
+                "summary": "General Event"
+              }
+            ],
+            "target": {
+              "user": {
+                "userid": "test_username"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/testdata/raw_logs/default_log.json
+++ b/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/testdata/raw_logs/default_log.json
@@ -1,0 +1,24 @@
+{
+  "create_time": "2026-07-13T10:00:00.000000000Z",
+  "raw_logs": {
+    "entries": [
+      {
+        "collection_time": "2026-07-13T10:00:00.000000000Z",
+        "data": "<134>Jul 13 10:00:01 hostname: LOGON,Successful Login,test_username,auth_session,User logged on from IP 1.1.1.1"
+      },
+      {
+        "collection_time": "2026-07-13T10:00:00.000000000Z",
+        "data": "<134>Jul 13 10:05:02 hostname: LOGOFF,Successful Logout,test_username,auth_session,User logged off from IP 2.2.2.2"
+      },
+      {
+        "collection_time": "2026-07-13T10:00:00.000000000Z",
+        "data": "<134>Jul 13 10:10:03 hostname: STATUS,Status Check,,system_service,Device status updated from IP 3.3.3.3"
+      },
+      {
+        "collection_time": "2026-07-13T10:00:00.000000000Z",
+        "data": "<134>Jul 13 10:15:04 hostname: DISCOVERY,General Event,test_username,scan_service,Routine discovery scan completed without IP address"
+      }
+    ],
+    "start_time": "2026-07-13T10:00:00.000000000Z"
+  }
+}

--- a/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/testdata/raw_logs/default_log.json
+++ b/content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/testdata/raw_logs/default_log.json
@@ -1,24 +1,24 @@
 {
-  "create_time": "2026-07-13T10:00:00.000000000Z",
+  "create_time": "2026-07-13T10:00:00.000000Z",
   "raw_logs": {
+    "start_time": "2026-07-13T10:00:00.000000Z",
     "entries": [
       {
-        "collection_time": "2026-07-13T10:00:00.000000000Z",
-        "data": "<134>Jul 13 10:00:01 hostname: LOGON,Successful Login,test_username,auth_session,User logged on from IP 1.1.1.1"
+        "data": "<134>Jul 13 10:00:01 hostname: LOGON,Successful Login,test_username,auth_session,User logged on from IP 1.1.1.1",
+        "collection_time": "2026-07-13T10:00:01.000000Z"
       },
       {
-        "collection_time": "2026-07-13T10:00:00.000000000Z",
-        "data": "<134>Jul 13 10:05:02 hostname: LOGOFF,Successful Logout,test_username,auth_session,User logged off from IP 2.2.2.2"
+        "data": "<134>Jul 13 10:05:02 hostname: LOGOFF,Successful Logout,test_username,auth_session,User logged off from IP 2.2.2.2",
+        "collection_time": "2026-07-13T10:05:02.000000Z"
       },
       {
-        "collection_time": "2026-07-13T10:00:00.000000000Z",
-        "data": "<134>Jul 13 10:10:03 hostname: STATUS,Status Check,,system_service,Device status updated from IP 3.3.3.3"
+        "data": "<134>Jul 13 10:10:03 hostname: STATUS,Status Check,,system_service,Device status updated from IP 3.3.3.3",
+        "collection_time": "2026-07-13T10:10:03.000000Z"
       },
       {
-        "collection_time": "2026-07-13T10:00:00.000000000Z",
-        "data": "<134>Jul 13 10:15:04 hostname: DISCOVERY,General Event,test_username,scan_service,Routine discovery scan completed without IP address"
+        "data": "<134>Jul 13 10:15:04 hostname: DISCOVERY,General Event,test_username,scan_service,Routine discovery scan completed without IP address",
+        "collection_time": "2026-07-13T10:15:04.000000Z"
       }
-    ],
-    "start_time": "2026-07-13T10:00:00.000000000Z"
+    ]
   }
 }


### PR DESCRIPTION
## Overview
Migrating `BMC_HELIX_DISCOVERY` parser package to the community GitHub repository using the synthetic log generation, masking, and migration pipeline (`jetski-synthetic-mask-migrator`).

### Key Changes
- **Parser Name:** `BMC_HELIX_DISCOVERY`
- **Supported Format:** `SYSLOG`
- **Sanitization Status:** PII-masked and structurally sanitized synthetic logs covering all branches.
- **Validation Status:** PASSED (4/4 events matched expected output).

### References
- **Piper CL:** http://cl/946935684