### PR TITLE
Update the Script to include latest commits of .config files in our index files.

### DIFF
--- a/.github/workflows/update_index.yml
+++ b/.github/workflows/update_index.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Fetch all history so git log can find commit SHAs and timestamps for parser files
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/content/parsers/third_party/COMMUNITY_INDEX.json
+++ b/content/parsers/third_party/COMMUNITY_INDEX.json
@@ -5,7 +5,9 @@
     "metadata_path": "content/parsers/third_party/community/ACCELLION/cbn/metadata.json",
     "vendor": "ACCELLION",
     "product": "Accellion",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   },
   {
     "log_type": "AGILOFT",
@@ -13,7 +15,9 @@
     "metadata_path": "content/parsers/third_party/community/AGILOFT/cbn/metadata.json",
     "vendor": "AGILOFT",
     "product": "AGILOFT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "a86865cfa5916b9f92ac166998882492758054aa",
+    "latest_commit_time": 1781173232
   },
   {
     "log_type": "ALVEO_RDM",
@@ -21,7 +25,9 @@
     "metadata_path": "content/parsers/third_party/community/ALVEO_RDM/cbn/metadata.json",
     "vendor": "ALVEO",
     "product": "ALVEO RDM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "9003d90c4bcf155526c09402ae7d994406fc85a0",
+    "latest_commit_time": 1781172621
   },
   {
     "log_type": "ARBOR_SIGHTLINE",
@@ -29,7 +35,9 @@
     "metadata_path": "content/parsers/third_party/community/ARBOR_SIGHTLINE/cbn/metadata.json",
     "vendor": "ARBOR",
     "product": "ARBOR_SIGHTLINE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "ARCHER_IRM",
@@ -37,7 +45,9 @@
     "metadata_path": "content/parsers/third_party/community/ARCHER_IRM/cbn/metadata.json",
     "vendor": "ARCHER",
     "product": "Archer",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   },
   {
     "log_type": "ARMIS_VULNERABILITIES",
@@ -45,7 +55,9 @@
     "metadata_path": "content/parsers/third_party/community/ARMIS_VULNERABILITIES/cbn/metadata.json",
     "vendor": "ARMIS",
     "product": "ARMIS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "a86865cfa5916b9f92ac166998882492758054aa",
+    "latest_commit_time": 1781173232
   },
   {
     "log_type": "ARRAYNETWORKS_VPN",
@@ -53,7 +65,9 @@
     "metadata_path": "content/parsers/third_party/community/ARRAYNETWORKS_VPN/cbn/metadata.json",
     "vendor": "ARRAYNETWORKS",
     "product": "ARRAYNETWORKS_VPN",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "a86865cfa5916b9f92ac166998882492758054aa",
+    "latest_commit_time": 1781173232
   },
   {
     "log_type": "ASSET_PANDA",
@@ -61,7 +75,9 @@
     "metadata_path": "content/parsers/third_party/community/ASSET_PANDA/cbn/metadata.json",
     "vendor": "ASSET_PANDA",
     "product": "ASSET_PANDA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "9003d90c4bcf155526c09402ae7d994406fc85a0",
+    "latest_commit_time": 1781172621
   },
   {
     "log_type": "ASSET_STATIC_IP",
@@ -69,7 +85,9 @@
     "metadata_path": "content/parsers/third_party/community/ASSET_STATIC_IP/cbn/metadata.json",
     "vendor": "ASSET_STATIC_IP",
     "product": "PCAP DHCP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   },
   {
     "log_type": "AVATIER",
@@ -77,7 +95,9 @@
     "metadata_path": "content/parsers/third_party/community/AVATIER/cbn/metadata.json",
     "vendor": "AVATIER",
     "product": "Avatier Identity Management Suite (AIMS)",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   },
   {
     "log_type": "AVIGILON_ACCESS_LOGS",
@@ -85,7 +105,9 @@
     "metadata_path": "content/parsers/third_party/community/AVIGILON_ACCESS_LOGS/cbn/metadata.json",
     "vendor": "AVIGILON",
     "product": "AVIGILON_ACCESS_LOGS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "9003d90c4bcf155526c09402ae7d994406fc85a0",
+    "latest_commit_time": 1781172621
   },
   {
     "log_type": "AWARE_AUDIT",
@@ -93,7 +115,9 @@
     "metadata_path": "content/parsers/third_party/community/AWARE_AUDIT/cbn/metadata.json",
     "vendor": "AWARE_AUDIT",
     "product": "AWARE_AUDIT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "306c0da8fd0a638794c34d7627b44990063a0bca",
+    "latest_commit_time": 1781172603
   },
   {
     "log_type": "AWARE_SIGNALS",
@@ -101,7 +125,9 @@
     "metadata_path": "content/parsers/third_party/community/AWARE_SIGNALS/cbn/metadata.json",
     "vendor": "AWARE SIGNALS",
     "product": "AWARE SIGNALS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "306c0da8fd0a638794c34d7627b44990063a0bca",
+    "latest_commit_time": 1781172603
   },
   {
     "log_type": "AWS_ECS_METRICS",
@@ -109,7 +135,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_ECS_METRICS/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS_ECS_METRICS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "2cee2c0831f804daa3c326724cffbf4f2b42b69d",
+    "latest_commit_time": 1779709186
   },
   {
     "log_type": "AWS_INSPECTOR",
@@ -117,7 +145,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_INSPECTOR/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS INSPECTOR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "9003d90c4bcf155526c09402ae7d994406fc85a0",
+    "latest_commit_time": 1781172621
   },
   {
     "log_type": "AWS_KMS",
@@ -125,7 +155,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_KMS/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS KEY MANAGEMENT SERVICE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "306c0da8fd0a638794c34d7627b44990063a0bca",
+    "latest_commit_time": 1781172603
   },
   {
     "log_type": "AWS_LAMBDA_FUNCTION",
@@ -133,7 +165,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_LAMBDA_FUNCTION/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS_LAMBDA_FUNCTION",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "AWS_REDSHIFT",
@@ -141,7 +175,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_REDSHIFT/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS REDSHIFT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "a86865cfa5916b9f92ac166998882492758054aa",
+    "latest_commit_time": 1781173232
   },
   {
     "log_type": "AWS_VPC_FLOW_CSV",
@@ -149,7 +185,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_VPC_FLOW_CSV/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS VPC FLOW CSV",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "306c0da8fd0a638794c34d7627b44990063a0bca",
+    "latest_commit_time": 1781172603
   },
   {
     "log_type": "AWS_VPC_TRANSIT_GATEWAY",
@@ -157,7 +195,9 @@
     "metadata_path": "content/parsers/third_party/community/AWS_VPC_TRANSIT_GATEWAY/cbn/metadata.json",
     "vendor": "AWS",
     "product": "AWS VPC Transit Gateway",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "2e24d8f627737107542db02684c303b0d9c07e5e",
+    "latest_commit_time": 1779708294
   },
   {
     "log_type": "AZURE_COSMOS_DB",
@@ -165,7 +205,9 @@
     "metadata_path": "content/parsers/third_party/community/AZURE_COSMOS_DB/cbn/metadata.json",
     "vendor": "Microsoft",
     "product": "Azure Cosmos DB",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "BARRACUDA_CLOUDGEN_FIREWALL",
@@ -173,7 +215,9 @@
     "metadata_path": "content/parsers/third_party/community/BARRACUDA_CLOUDGEN_FIREWALL/cbn/metadata.json",
     "vendor": "BARRACUDA NETWORKS",
     "product": "BARRACUDA CLOUDGEN FIREWALL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "306c0da8fd0a638794c34d7627b44990063a0bca",
+    "latest_commit_time": 1781172603
   },
   {
     "log_type": "BMC_CLIENT_MANAGEMENT",
@@ -181,7 +225,9 @@
     "metadata_path": "content/parsers/third_party/community/BMC_CLIENT_MANAGEMENT/cbn/metadata.json",
     "vendor": "BMC",
     "product": "BMC_CLIENT_MANAGEMENT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "edf4580019d7dd27904861ec974e01c74348bcfa",
+    "latest_commit_time": 1781172588
   },
   {
     "log_type": "BMC_HELIX_DISCOVERY",
@@ -189,7 +235,9 @@
     "metadata_path": "content/parsers/third_party/community/BMC_HELIX_DISCOVERY/cbn/metadata.json",
     "vendor": "BMC",
     "product": "BMC_HELIX_DISCOVERY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "03a10f17a408a9f3b00d874ae8a22c593fd19520",
+    "latest_commit_time": 1781172904
   },
   {
     "log_type": "BROADCOM_CA_PAM",
@@ -197,7 +245,9 @@
     "metadata_path": "content/parsers/third_party/community/BROADCOM_CA_PAM/cbn/metadata.json",
     "vendor": "BROADCOM",
     "product": "BROADCOM CA PAM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "03a10f17a408a9f3b00d874ae8a22c593fd19520",
+    "latest_commit_time": 1781172904
   },
   {
     "log_type": "BROADCOM_SUPPORT_PORTAL",
@@ -205,7 +255,9 @@
     "metadata_path": "content/parsers/third_party/community/BROADCOM_SUPPORT_PORTAL/cbn/metadata.json",
     "vendor": "BROADCOM",
     "product": "BROADCOM_SUPPORT_PORTAL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "edf4580019d7dd27904861ec974e01c74348bcfa",
+    "latest_commit_time": 1781172588
   },
   {
     "log_type": "BRO_TSV",
@@ -213,7 +265,9 @@
     "metadata_path": "content/parsers/third_party/community/BRO_TSV/cbn/metadata.json",
     "vendor": "TSV",
     "product": "BRO",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "CAMBIUM_NETWORKS",
@@ -221,7 +275,9 @@
     "metadata_path": "content/parsers/third_party/community/CAMBIUM_NETWORKS/cbn/metadata.json",
     "vendor": "CAMBIUM NETWORKS",
     "product": "CAMBIUM NETWORKS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "03a10f17a408a9f3b00d874ae8a22c593fd19520",
+    "latest_commit_time": 1781172904
   },
   {
     "log_type": "CASSANDRA",
@@ -229,7 +285,9 @@
     "metadata_path": "content/parsers/third_party/community/CASSANDRA/cbn/metadata.json",
     "vendor": "CASSANDRA",
     "product": "CASSANDRA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "03a10f17a408a9f3b00d874ae8a22c593fd19520",
+    "latest_commit_time": 1781172904
   },
   {
     "log_type": "CA_ACCESS_CONTROL",
@@ -237,7 +295,9 @@
     "metadata_path": "content/parsers/third_party/community/CA_ACCESS_CONTROL/cbn/metadata.json",
     "vendor": "CA Technologies",
     "product": "CA Access Control",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "CA_ACF2",
@@ -245,7 +305,9 @@
     "metadata_path": "content/parsers/third_party/community/CA_ACF2/cbn/metadata.json",
     "vendor": "CA",
     "product": "ACF2",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "CA_LDAP",
@@ -253,7 +315,9 @@
     "metadata_path": "content/parsers/third_party/community/CA_LDAP/cbn/metadata.json",
     "vendor": "BROADCOM",
     "product": "CA_LDAP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "03a10f17a408a9f3b00d874ae8a22c593fd19520",
+    "latest_commit_time": 1781172904
   },
   {
     "log_type": "CA_SSO_WEB",
@@ -261,7 +325,9 @@
     "metadata_path": "content/parsers/third_party/community/CA_SSO_WEB/cbn/metadata.json",
     "vendor": "SITEMINDER",
     "product": "WEB ACCESS MANAGEMENT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "CENSYS",
@@ -269,7 +335,9 @@
     "metadata_path": "content/parsers/third_party/community/CENSYS/cbn/metadata.json",
     "vendor": "CENSYS",
     "product": "CENSYS_ASM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "CENTRIFY_SSO",
@@ -277,7 +345,9 @@
     "metadata_path": "content/parsers/third_party/community/CENTRIFY_SSO/cbn/metadata.json",
     "vendor": "CENTRIFY",
     "product": "SSO",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "CEQUENCE_BOT_DEFENSE",
@@ -285,7 +355,9 @@
     "metadata_path": "content/parsers/third_party/community/CEQUENCE_BOT_DEFENSE/cbn/metadata.json",
     "vendor": "CEQUENCE",
     "product": "CEQUENCE_BOT_DEFENSE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "CIENA_ROUTER",
@@ -293,7 +365,9 @@
     "metadata_path": "content/parsers/third_party/community/CIENA_ROUTER/cbn/metadata.json",
     "vendor": "CIENA",
     "product": "CIENA_ROUTER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "edf4580019d7dd27904861ec974e01c74348bcfa",
+    "latest_commit_time": 1781172588
   },
   {
     "log_type": "CIMCOR",
@@ -301,7 +375,9 @@
     "metadata_path": "content/parsers/third_party/community/CIMCOR/cbn/metadata.json",
     "vendor": "Cimcor",
     "product": "CimTrak",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "CIRCLECI",
@@ -309,7 +385,9 @@
     "metadata_path": "content/parsers/third_party/community/CIRCLECI/cbn/metadata.json",
     "vendor": "CIRCLECI",
     "product": "CIRCLECI",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "CISCO_ACE",
@@ -317,7 +395,9 @@
     "metadata_path": "content/parsers/third_party/community/CISCO_ACE/cbn/metadata.json",
     "vendor": "CISCO",
     "product": "CISCO APPLICATION CONTROL ENGINE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "edf4580019d7dd27904861ec974e01c74348bcfa",
+    "latest_commit_time": 1781172588
   },
   {
     "log_type": "CISCO_CALL_MANAGER",
@@ -325,7 +405,9 @@
     "metadata_path": "content/parsers/third_party/community/CISCO_CALL_MANAGER/cbn/metadata.json",
     "vendor": "CISCO",
     "product": "CISCO_CALL_MANAGER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c563d7831a53fad5f90668fa4ff29149368f5616",
+    "latest_commit_time": 1779780736
   },
   {
     "log_type": "CISCO_PIX_FIREWALL",
@@ -333,7 +415,9 @@
     "metadata_path": "content/parsers/third_party/community/CISCO_PIX_FIREWALL/cbn/metadata.json",
     "vendor": "CISCO",
     "product": "CISCO_FWSM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "edf4580019d7dd27904861ec974e01c74348bcfa",
+    "latest_commit_time": 1781172588
   },
   {
     "log_type": "CISCO_UMBRELLA_SWG_DLP",
@@ -341,7 +425,9 @@
     "metadata_path": "content/parsers/third_party/community/CISCO_UMBRELLA_SWG_DLP/cbn/metadata.json",
     "vendor": "CISCO",
     "product": "UMBRELLA_SWG_DLP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "32344b4c87f60c4bce7924ac8e81266b72effc7e",
+    "latest_commit_time": 1781168011
   },
   {
     "log_type": "CIS_ALBERT_ALERT",
@@ -349,7 +435,9 @@
     "metadata_path": "content/parsers/third_party/community/CIS_ALBERT_ALERT/cbn/metadata.json",
     "vendor": "CIS",
     "product": "Albert",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "CITRIX_ANALYTICS",
@@ -357,7 +445,9 @@
     "metadata_path": "content/parsers/third_party/community/CITRIX_ANALYTICS/cbn/metadata.json",
     "vendor": "CITRIX_ANALYTICS",
     "product": "Windows",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "CITRIX_MONITOR",
@@ -365,7 +455,9 @@
     "metadata_path": "content/parsers/third_party/community/CITRIX_MONITOR/cbn/metadata.json",
     "vendor": "CITRIX",
     "product": "CITRIX_MONITOR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c563d7831a53fad5f90668fa4ff29149368f5616",
+    "latest_commit_time": 1779780736
   },
   {
     "log_type": "CITRIX_STOREFRONT",
@@ -373,7 +465,9 @@
     "metadata_path": "content/parsers/third_party/community/CITRIX_STOREFRONT/cbn/metadata.json",
     "vendor": "Citrix",
     "product": "Monitor Service OData",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "CLEARSWIFT",
@@ -381,7 +475,9 @@
     "metadata_path": "content/parsers/third_party/community/CLEARSWIFT/cbn/metadata.json",
     "vendor": "CLEARSWIFT",
     "product": "CLEARSWIFT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c563d7831a53fad5f90668fa4ff29149368f5616",
+    "latest_commit_time": 1779780736
   },
   {
     "log_type": "CLOUDFLARE_PAGESHIELD",
@@ -389,7 +485,9 @@
     "metadata_path": "content/parsers/third_party/community/CLOUDFLARE_PAGESHIELD/cbn/metadata.json",
     "vendor": "Cloudflare",
     "product": "Cloudflare PageShield",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8e04164a2697bb3551955b2feb6e68b4ee8e7639",
+    "latest_commit_time": 1779706655
   },
   {
     "log_type": "CLOUDIAN_HYPERSTORE",
@@ -397,7 +495,9 @@
     "metadata_path": "content/parsers/third_party/community/CLOUDIAN_HYPERSTORE/cbn/metadata.json",
     "vendor": "Cloudian",
     "product": "Cloudian Hyperstore",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "COMFORTE_SECURDPS",
@@ -405,7 +505,9 @@
     "metadata_path": "content/parsers/third_party/community/COMFORTE_SECURDPS/cbn/metadata.json",
     "vendor": "COMFORTE_SECURDPS",
     "product": "Comforte SecureDPS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "CT_GAUS_SEGUROS",
@@ -413,7 +515,9 @@
     "metadata_path": "content/parsers/third_party/community/CT_GAUS_SEGUROS/cbn/metadata.json",
     "vendor": "COLINET TROTTA",
     "product": "GAUS SEGUROS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0fc91c58fe7372a7900a320c44144ffd162388ce",
+    "latest_commit_time": 1781515692
   },
   {
     "log_type": "CYBERGATEKEEPER_NAC",
@@ -421,7 +525,9 @@
     "metadata_path": "content/parsers/third_party/community/CYBERGATEKEEPER_NAC/cbn/metadata.json",
     "vendor": "CYBERGATEKEEPER_NAC",
     "product": "CYBERGATEKEEPER_NAC",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0fc91c58fe7372a7900a320c44144ffd162388ce",
+    "latest_commit_time": 1781515692
   },
   {
     "log_type": "CYBER_2_IDS",
@@ -429,7 +535,9 @@
     "metadata_path": "content/parsers/third_party/community/CYBER_2_IDS/cbn/metadata.json",
     "vendor": "Cyber 2.0",
     "product": "Cyber 2.0 IDS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "CYNET_360_AUTOXDR",
@@ -437,7 +545,9 @@
     "metadata_path": "content/parsers/third_party/community/CYNET_360_AUTOXDR/cbn/metadata.json",
     "vendor": "Cynet",
     "product": "Cynet 360 AutoXDR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c563d7831a53fad5f90668fa4ff29149368f5616",
+    "latest_commit_time": 1779780736
   },
   {
     "log_type": "DATTO_FILE_PROTECTION",
@@ -445,7 +555,9 @@
     "metadata_path": "content/parsers/third_party/community/DATTO_FILE_PROTECTION/cbn/metadata.json",
     "vendor": "Datto",
     "product": "S4P4",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "351b5f183780c522669ed6e4a58766a1c421618a",
+    "latest_commit_time": 1781168998
   },
   {
     "log_type": "DEEP_INSTINCT_EDR",
@@ -453,7 +565,9 @@
     "metadata_path": "content/parsers/third_party/community/DEEP_INSTINCT_EDR/cbn/metadata.json",
     "vendor": "Deep Instinct",
     "product": "Deep Instinct EDR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "DELINEA_DISTRIBUTED_ENGINE",
@@ -461,7 +575,9 @@
     "metadata_path": "content/parsers/third_party/community/DELINEA_DISTRIBUTED_ENGINE/cbn/metadata.json",
     "vendor": "Delinea",
     "product": "DELINEA_DISTRIBUTED_ENGINE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c563d7831a53fad5f90668fa4ff29149368f5616",
+    "latest_commit_time": 1779780736
   },
   {
     "log_type": "DIGICERT",
@@ -469,7 +585,9 @@
     "metadata_path": "content/parsers/third_party/community/DIGICERT/cbn/metadata.json",
     "vendor": "Digicert",
     "product": "Digicert",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "DIGITALGUARDIAN_DLP",
@@ -477,7 +595,9 @@
     "metadata_path": "content/parsers/third_party/community/DIGITALGUARDIAN_DLP/cbn/metadata.json",
     "vendor": "DIGITALGUARDIAN",
     "product": "DIGITALGUARDIAN_DLP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "DIGITALGUARDIAN_EDR",
@@ -485,7 +605,9 @@
     "metadata_path": "content/parsers/third_party/community/DIGITALGUARDIAN_EDR/cbn/metadata.json",
     "vendor": "DIGITALGUARDIAN",
     "product": "ENTERPRISE_DLP_PLATFORM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0fc91c58fe7372a7900a320c44144ffd162388ce",
+    "latest_commit_time": 1781515692
   },
   {
     "log_type": "DIGITAL_SHADOWS_IOC",
@@ -493,7 +615,9 @@
     "metadata_path": "content/parsers/third_party/community/DIGITAL_SHADOWS_IOC/cbn/metadata.json",
     "vendor": "Digital Shadows",
     "product": "Indicators",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "DIGITAL_SHADOWS_SEARCHLIGHT",
@@ -501,7 +625,9 @@
     "metadata_path": "content/parsers/third_party/community/DIGITAL_SHADOWS_SEARCHLIGHT/cbn/metadata.json",
     "vendor": "Digital Shadows",
     "product": "Triage",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "DIGI_MODEMS",
@@ -509,7 +635,9 @@
     "metadata_path": "content/parsers/third_party/community/DIGI_MODEMS/cbn/metadata.json",
     "vendor": "DIGI_MODEMS",
     "product": "DIGI_MODEMS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0fc91c58fe7372a7900a320c44144ffd162388ce",
+    "latest_commit_time": 1781515692
   },
   {
     "log_type": "DMP_ENTRE",
@@ -517,7 +645,9 @@
     "metadata_path": "content/parsers/third_party/community/DMP_ENTRE/cbn/metadata.json",
     "vendor": "DMP",
     "product": "ENTRE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0fc91c58fe7372a7900a320c44144ffd162388ce",
+    "latest_commit_time": 1781515692
   },
   {
     "log_type": "DOMAINTOOLS_THREATINTEL",
@@ -525,7 +655,9 @@
     "metadata_path": "content/parsers/third_party/community/DOMAINTOOLS_THREATINTEL/cbn/metadata.json",
     "vendor": "DOMAINTOOLS",
     "product": "DOMAINTOOLS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8870c1cc6c4c7ee3530aad9c0dccb2313e509bbc",
+    "latest_commit_time": 1781515640
   },
   {
     "log_type": "DOPE_SWG",
@@ -533,7 +665,9 @@
     "metadata_path": "content/parsers/third_party/community/DOPE_SWG/cbn/metadata.json",
     "vendor": "DOPE SECURITY",
     "product": "SWG",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8870c1cc6c4c7ee3530aad9c0dccb2313e509bbc",
+    "latest_commit_time": 1781515640
   },
   {
     "log_type": "ELASTIC_DEFEND",
@@ -541,7 +675,9 @@
     "metadata_path": "content/parsers/third_party/community/ELASTIC_DEFEND/cbn/metadata.json",
     "vendor": "ELASTIC",
     "product": "ELASTIC DEFEND",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8870c1cc6c4c7ee3530aad9c0dccb2313e509bbc",
+    "latest_commit_time": 1781515640
   },
   {
     "log_type": "ENTRUST_HSM",
@@ -549,7 +685,9 @@
     "metadata_path": "content/parsers/third_party/community/ENTRUST_HSM/cbn/metadata.json",
     "vendor": "ENTRUST HSM",
     "product": "Entrust nShield HSM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "4b222a2e69bc68d8d7c9c37750574fe1e9da4851",
+    "latest_commit_time": 1779772338
   },
   {
     "log_type": "ERGON_INFORMATIK_AIRLOCK_IAM",
@@ -557,7 +695,9 @@
     "metadata_path": "content/parsers/third_party/community/ERGON_INFORMATIK_AIRLOCK_IAM/cbn/metadata.json",
     "vendor": "AIRLOCK IAM",
     "product": "AIRLOCK IAM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8870c1cc6c4c7ee3530aad9c0dccb2313e509bbc",
+    "latest_commit_time": 1781515640
   },
   {
     "log_type": "ESET_IOC",
@@ -565,7 +705,9 @@
     "metadata_path": "content/parsers/third_party/community/ESET_IOC/cbn/metadata.json",
     "vendor": "ESET",
     "product": "ESET_IOC",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8870c1cc6c4c7ee3530aad9c0dccb2313e509bbc",
+    "latest_commit_time": 1781515640
   },
   {
     "log_type": "EVISION_FIRCOSOFT",
@@ -573,7 +715,9 @@
     "metadata_path": "content/parsers/third_party/community/EVISION_FIRCOSOFT/cbn/metadata.json",
     "vendor": "EVISION",
     "product": "FIRCOSOFT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "26f73baca2c53bab5e742dd749b98f5a655e0eb1",
+    "latest_commit_time": 1781515666
   },
   {
     "log_type": "F5_SHAPE",
@@ -581,7 +725,9 @@
     "metadata_path": "content/parsers/third_party/community/F5_SHAPE/cbn/metadata.json",
     "vendor": "F5",
     "product": "Shape",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "ba883e19ae751b2c81104d379a7773d813844c32",
+    "latest_commit_time": 1779708030
   },
   {
     "log_type": "FILEZILLA_FTP",
@@ -589,7 +735,9 @@
     "metadata_path": "content/parsers/third_party/community/FILEZILLA_FTP/cbn/metadata.json",
     "vendor": "FILEZILLA",
     "product": "FILEZILLA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "FINGERPRINT_JS",
@@ -597,7 +745,9 @@
     "metadata_path": "content/parsers/third_party/community/FINGERPRINT_JS/cbn/metadata.json",
     "vendor": "FINGERPRINT_JS",
     "product": "FINGERPRINT_JS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "26f73baca2c53bab5e742dd749b98f5a655e0eb1",
+    "latest_commit_time": 1781515666
   },
   {
     "log_type": "FIREEYE_NX_AUDIT",
@@ -605,7 +755,9 @@
     "metadata_path": "content/parsers/third_party/community/FIREEYE_NX_AUDIT/cbn/metadata.json",
     "vendor": "FIREEYE",
     "product": "FIREEYE NX AUDIT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "FIVETRAN",
@@ -613,7 +765,9 @@
     "metadata_path": "content/parsers/third_party/community/FIVETRAN/cbn/metadata.json",
     "vendor": "FIVETRAN",
     "product": "FIVETRAN",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "26f73baca2c53bab5e742dd749b98f5a655e0eb1",
+    "latest_commit_time": 1781515666
   },
   {
     "log_type": "FORCEPOINT_CASB",
@@ -621,7 +775,9 @@
     "metadata_path": "content/parsers/third_party/community/FORCEPOINT_CASB/cbn/metadata.json",
     "vendor": "Frocepoint",
     "product": "Frocepoint CASB",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "FORCEPOINT_MAIL_RELAY",
@@ -629,7 +785,9 @@
     "metadata_path": "content/parsers/third_party/community/FORCEPOINT_MAIL_RELAY/cbn/metadata.json",
     "vendor": "FORCEPOINT_MAIL_RELAY",
     "product": "FORCEPOINT_MAIL_RELAY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "26f73baca2c53bab5e742dd749b98f5a655e0eb1",
+    "latest_commit_time": 1781515666
   },
   {
     "log_type": "FORGEROCK_IDENTITY_CLOUD",
@@ -637,7 +795,9 @@
     "metadata_path": "content/parsers/third_party/community/FORGEROCK_IDENTITY_CLOUD/cbn/metadata.json",
     "vendor": "FORGEROCK",
     "product": "FORGEROCK_IDENTITY_CLOUD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "26f73baca2c53bab5e742dd749b98f5a655e0eb1",
+    "latest_commit_time": 1781515666
   },
   {
     "log_type": "FORTINET_FORTIDDOS",
@@ -645,7 +805,9 @@
     "metadata_path": "content/parsers/third_party/community/FORTINET_FORTIDDOS/cbn/metadata.json",
     "vendor": "FORTINET",
     "product": "FORTINET FORTIDDOS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "51af716cf88866fa8164937f8e38acaa0a1dd4f6",
+    "latest_commit_time": 1781172652
   },
   {
     "log_type": "GITGUARDIAN_ENTERPRISE",
@@ -653,7 +815,9 @@
     "metadata_path": "content/parsers/third_party/community/GITGUARDIAN_ENTERPRISE/cbn/metadata.json",
     "vendor": "GITGUARDIAN",
     "product": "GITGUARDIAN ENTERPRISE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "51af716cf88866fa8164937f8e38acaa0a1dd4f6",
+    "latest_commit_time": 1781172652
   },
   {
     "log_type": "GITHUB_DEPENDABOT",
@@ -661,7 +825,9 @@
     "metadata_path": "content/parsers/third_party/community/GITHUB_DEPENDABOT/cbn/metadata.json",
     "vendor": "GITHUB",
     "product": "GITHUB_DEPENDABOT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "GREYNOISE",
@@ -669,7 +835,9 @@
     "metadata_path": "content/parsers/third_party/community/GREYNOISE/cbn/metadata.json",
     "vendor": "GreyNoise",
     "product": "GreyNoise Intelligence",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "HACKERONE",
@@ -677,7 +845,9 @@
     "metadata_path": "content/parsers/third_party/community/HACKERONE/cbn/metadata.json",
     "vendor": "HACKERONE",
     "product": "HACKERONE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "51af716cf88866fa8164937f8e38acaa0a1dd4f6",
+    "latest_commit_time": 1781172652
   },
   {
     "log_type": "HADOOP",
@@ -685,7 +855,9 @@
     "metadata_path": "content/parsers/third_party/community/HADOOP/cbn/metadata.json",
     "vendor": "HADOOP",
     "product": "HADOOP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "HCL_BIGFIX",
@@ -693,7 +865,9 @@
     "metadata_path": "content/parsers/third_party/community/HCL_BIGFIX/cbn/metadata.json",
     "vendor": "HCL SOFTWARE",
     "product": "HCL BIGFIX",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "51af716cf88866fa8164937f8e38acaa0a1dd4f6",
+    "latest_commit_time": 1781172652
   },
   {
     "log_type": "HCNET_ACCOUNT_ADAPTER",
@@ -701,7 +875,9 @@
     "metadata_path": "content/parsers/third_party/community/HCNET_ACCOUNT_ADAPTER/cbn/metadata.json",
     "vendor": "HCNET",
     "product": "ACCOUNT ADAPTER PLUS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "HID_DIGITALPERSONA",
@@ -709,7 +885,9 @@
     "metadata_path": "content/parsers/third_party/community/HID_DIGITALPERSONA/cbn/metadata.json",
     "vendor": "HID",
     "product": "DIGITALPERSONA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "HILLSTONE_NGFW",
@@ -717,7 +895,9 @@
     "metadata_path": "content/parsers/third_party/community/HILLSTONE_NGFW/cbn/metadata.json",
     "vendor": "HILLSTONE",
     "product": "HILLSTONE_NGFW",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d1bf25a7ff3fa17bbca2e42ffcf9f0c02b40f52f",
+    "latest_commit_time": 1779781190
   },
   {
     "log_type": "HITACHI_CLOUD_PLATFORM",
@@ -725,7 +905,9 @@
     "metadata_path": "content/parsers/third_party/community/HITACHI_CLOUD_PLATFORM/cbn/metadata.json",
     "vendor": "HITACHI",
     "product": "HITACHI CLOUD PLATFORM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "51af716cf88866fa8164937f8e38acaa0a1dd4f6",
+    "latest_commit_time": 1781172652
   },
   {
     "log_type": "IBM_B2B_INTEGRATOR",
@@ -733,7 +915,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_B2B_INTEGRATOR/cbn/metadata.json",
     "vendor": "IBM B2B INTEGRATOR",
     "product": "IBM B2B INTEGRATOR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c734ab262730917de880cc9ef7f80f578722d544",
+    "latest_commit_time": 1783312850
   },
   {
     "log_type": "IBM_DS8000",
@@ -741,7 +925,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_DS8000/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM DS8000",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "IBM_MAAS360",
@@ -749,7 +935,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_MAAS360/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM MAAS360",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0a81597af7be10798452a74bcb3d75263cabcb0d",
+    "latest_commit_time": 1781515583
   },
   {
     "log_type": "IBM_OPENPAGES",
@@ -757,7 +945,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_OPENPAGES/cbn/metadata.json",
     "vendor": "IBM",
     "product": "OPENPAGES",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0a81597af7be10798452a74bcb3d75263cabcb0d",
+    "latest_commit_time": 1781515583
   },
   {
     "log_type": "IBM_QRADAR",
@@ -765,7 +955,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_QRADAR/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM QRADAR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "71810022173db3f5a9376880a21776554c4d9af2",
+    "latest_commit_time": 1781169717
   },
   {
     "log_type": "IBM_SAFENET",
@@ -773,7 +965,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_SAFENET/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM_SAFENET",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "IBM_SECURITY_VERIFY",
@@ -781,7 +975,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_SECURITY_VERIFY/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM_SECURITY_VERIFY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3ac42fd1ad714e762d1fbf25449060742e935837",
+    "latest_commit_time": 1779772630
   },
   {
     "log_type": "IBM_SECURITY_VERIFY_SAAS",
@@ -789,7 +985,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_SECURITY_VERIFY_SAAS/cbn/metadata.json",
     "vendor": "IBM",
     "product": "SECURITY_VERIFY_SAAS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "edd0b20a6094ddee9d513cbeb7871d261d395dba",
+    "latest_commit_time": 1779708622
   },
   {
     "log_type": "IBM_SIM",
@@ -797,7 +995,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_SIM/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM_SIM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "IBM_SOAR",
@@ -805,7 +1005,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_SOAR/cbn/metadata.json",
     "vendor": "IBM",
     "product": "IBM SOAR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0a81597af7be10798452a74bcb3d75263cabcb0d",
+    "latest_commit_time": 1781515583
   },
   {
     "log_type": "IBM_SVA",
@@ -813,7 +1015,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_SVA/cbn/metadata.json",
     "vendor": "IBM",
     "product": "SECURITY VERIFY ACCESS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "0a81597af7be10798452a74bcb3d75263cabcb0d",
+    "latest_commit_time": 1781515583
   },
   {
     "log_type": "IBM_WEBSEAL",
@@ -821,7 +1025,9 @@
     "metadata_path": "content/parsers/third_party/community/IBM_WEBSEAL/cbn/metadata.json",
     "vendor": "IBM",
     "product": "Webseal",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3ac42fd1ad714e762d1fbf25449060742e935837",
+    "latest_commit_time": 1779772630
   },
   {
     "log_type": "IMPERVA_ABP",
@@ -829,7 +1035,9 @@
     "metadata_path": "content/parsers/third_party/community/IMPERVA_ABP/cbn/metadata.json",
     "vendor": "Imperva",
     "product": "IMPERVA_ABP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "IMPERVA_DRA",
@@ -837,7 +1045,9 @@
     "metadata_path": "content/parsers/third_party/community/IMPERVA_DRA/cbn/metadata.json",
     "vendor": "IMPERVA",
     "product": "IMPERVA_DRA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "INTEL471_WATCHER_ALERTS",
@@ -845,7 +1055,9 @@
     "metadata_path": "content/parsers/third_party/community/INTEL471_WATCHER_ALERTS/cbn/metadata.json",
     "vendor": "INTEL",
     "product": "INTEL471_WATCHER_ALERTS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "24eedb32a82ae77ffbedde71425e1952e5e5ac73",
+    "latest_commit_time": 1781173460
   },
   {
     "log_type": "INTEL_EMA",
@@ -853,7 +1065,9 @@
     "metadata_path": "content/parsers/third_party/community/INTEL_EMA/cbn/metadata.json",
     "vendor": "INTEL_EMA",
     "product": "INTEL_EMA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "24eedb32a82ae77ffbedde71425e1952e5e5ac73",
+    "latest_commit_time": 1781173460
   },
   {
     "log_type": "ION_SPECTRUM",
@@ -861,7 +1075,9 @@
     "metadata_path": "content/parsers/third_party/community/ION_SPECTRUM/cbn/metadata.json",
     "vendor": "ION_SPECTRUM",
     "product": "ION_SPECTRUM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "24eedb32a82ae77ffbedde71425e1952e5e5ac73",
+    "latest_commit_time": 1781173460
   },
   {
     "log_type": "IPSWITCH_SFTP",
@@ -869,7 +1085,9 @@
     "metadata_path": "content/parsers/third_party/community/IPSWITCH_SFTP/cbn/metadata.json",
     "vendor": "IPSWITCH",
     "product": "SFTP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "IRONSTREAM_ZOS",
@@ -877,7 +1095,9 @@
     "metadata_path": "content/parsers/third_party/community/IRONSTREAM_ZOS/cbn/metadata.json",
     "vendor": "IRONSTREAM",
     "product": "ZOS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3ac42fd1ad714e762d1fbf25449060742e935837",
+    "latest_commit_time": 1779772630
   },
   {
     "log_type": "IVANTI_ENDPOINT_MANAGER_MOBILE",
@@ -885,7 +1105,9 @@
     "metadata_path": "content/parsers/third_party/community/IVANTI_ENDPOINT_MANAGER_MOBILE/cbn/metadata.json",
     "vendor": "IVANTI",
     "product": "IVANTI ENDPOINT MANAGER MOBILE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "16c490c20f1c22db3eadadda97b573f8bc885c8d",
+    "latest_commit_time": 1780907492
   },
   {
     "log_type": "JUNIPER_IPS",
@@ -893,7 +1115,9 @@
     "metadata_path": "content/parsers/third_party/community/JUNIPER_IPS/cbn/metadata.json",
     "vendor": "JUNIPER",
     "product": "JUNIPER_IPS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "KEA_DHCP",
@@ -901,7 +1125,9 @@
     "metadata_path": "content/parsers/third_party/community/KEA_DHCP/cbn/metadata.json",
     "vendor": "KEA",
     "product": "KEA_DHCP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "24eedb32a82ae77ffbedde71425e1952e5e5ac73",
+    "latest_commit_time": 1781173460
   },
   {
     "log_type": "KERIOCONTROL",
@@ -909,7 +1135,9 @@
     "metadata_path": "content/parsers/third_party/community/KERIOCONTROL/cbn/metadata.json",
     "vendor": "KERIOCONTROL",
     "product": "KERIOCONTROL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "KEYFACTOR",
@@ -917,7 +1145,9 @@
     "metadata_path": "content/parsers/third_party/community/KEYFACTOR/cbn/metadata.json",
     "vendor": "KEYFACTOR",
     "product": "KEYFACTOR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cad7681cffae37a43b687584f16edc94cd681ed",
+    "latest_commit_time": 1782213528
   },
   {
     "log_type": "KISI",
@@ -925,7 +1155,9 @@
     "metadata_path": "content/parsers/third_party/community/KISI/cbn/metadata.json",
     "vendor": "KISI",
     "product": "KISI",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "KOLIDE",
@@ -933,7 +1165,9 @@
     "metadata_path": "content/parsers/third_party/community/KOLIDE/cbn/metadata.json",
     "vendor": "KOLIDE",
     "product": "KOLIDE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "KUBERNETES_AUTH_PROXY",
@@ -941,7 +1175,9 @@
     "metadata_path": "content/parsers/third_party/community/KUBERNETES_AUTH_PROXY/cbn/metadata.json",
     "vendor": "KUBERNETES",
     "product": "KUBERNETES_AUTH_PROXY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3ac42fd1ad714e762d1fbf25449060742e935837",
+    "latest_commit_time": 1779772630
   },
   {
     "log_type": "KYRIBA",
@@ -949,7 +1185,9 @@
     "metadata_path": "content/parsers/third_party/community/KYRIBA/cbn/metadata.json",
     "vendor": "KYRIBA",
     "product": "KYRIBA TREASURY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "630a070864c3acfcbf4551721a1a342a9a157ddf",
+    "latest_commit_time": 1781173286
   },
   {
     "log_type": "LENEL_ONGUARD",
@@ -957,7 +1195,9 @@
     "metadata_path": "content/parsers/third_party/community/LENEL_ONGUARD/cbn/metadata.json",
     "vendor": "Lenel",
     "product": "OnGuard",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "461d6ae8587c98389246d14ad03831ffe5f82790",
+    "latest_commit_time": 1779706545
   },
   {
     "log_type": "LINKSHADOW_NDR",
@@ -965,7 +1205,9 @@
     "metadata_path": "content/parsers/third_party/community/LINKSHADOW_NDR/cbn/metadata.json",
     "vendor": "LinkShadow",
     "product": "LinkShadow",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "78a95b87bdbf9eac68ad858db6d2ff15f2579863",
+    "latest_commit_time": 1779780602
   },
   {
     "log_type": "LOGONBOX",
@@ -973,7 +1215,9 @@
     "metadata_path": "content/parsers/third_party/community/LOGONBOX/cbn/metadata.json",
     "vendor": "LOGONBOX",
     "product": "LOGONBOX",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "630a070864c3acfcbf4551721a1a342a9a157ddf",
+    "latest_commit_time": 1781173286
   },
   {
     "log_type": "LUCID",
@@ -981,7 +1225,9 @@
     "metadata_path": "content/parsers/third_party/community/LUCID/cbn/metadata.json",
     "vendor": "LUCID",
     "product": "LUCID",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "630a070864c3acfcbf4551721a1a342a9a157ddf",
+    "latest_commit_time": 1781173286
   },
   {
     "log_type": "MACOS_ENDPOINT_SECURITY",
@@ -989,7 +1235,9 @@
     "metadata_path": "content/parsers/third_party/community/MACOS_ENDPOINT_SECURITY/cbn/metadata.json",
     "vendor": "APPLE",
     "product": "MACOS_ENDPOINT_SECURITY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "2457cbe7b0e125a3d8be5800848703612cf92520",
+    "latest_commit_time": 1779772750
   },
   {
     "log_type": "MAILMARSHAL",
@@ -997,7 +1245,9 @@
     "metadata_path": "content/parsers/third_party/community/MAILMARSHAL/cbn/metadata.json",
     "vendor": "MAILMARSHAL",
     "product": "MAILMARSHAL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "630a070864c3acfcbf4551721a1a342a9a157ddf",
+    "latest_commit_time": 1781173286
   },
   {
     "log_type": "MALWAREBYTES_EDR",
@@ -1005,7 +1255,9 @@
     "metadata_path": "content/parsers/third_party/community/MALWAREBYTES_EDR/cbn/metadata.json",
     "vendor": "Malwarebytes",
     "product": "Malwarebytes EDR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "MANAGE_ENGINE_AD360",
@@ -1013,7 +1265,9 @@
     "metadata_path": "content/parsers/third_party/community/MANAGE_ENGINE_AD360/cbn/metadata.json",
     "vendor": "MANAGE_ENGINE",
     "product": "MANAGE_ENGINE_AD360",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3ac42fd1ad714e762d1fbf25449060742e935837",
+    "latest_commit_time": 1779772630
   },
   {
     "log_type": "MANAGE_ENGINE_PAM360",
@@ -1021,7 +1275,9 @@
     "metadata_path": "content/parsers/third_party/community/MANAGE_ENGINE_PAM360/cbn/metadata.json",
     "vendor": "MANAGEENGINE",
     "product": "MANAGE_ENGINE_PAM360",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "141cb353a0dfb8dc02a2080228762a9632f64b9f",
+    "latest_commit_time": 1782718534
   },
   {
     "log_type": "MANAGE_ENGINE_REPORTER_PLUS",
@@ -1029,7 +1285,9 @@
     "metadata_path": "content/parsers/third_party/community/MANAGE_ENGINE_REPORTER_PLUS/cbn/metadata.json",
     "vendor": "MANAGE ENGINE",
     "product": "MANAGE ENGINE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "630a070864c3acfcbf4551721a1a342a9a157ddf",
+    "latest_commit_time": 1781173286
   },
   {
     "log_type": "MANDIANT_DTM_ALERTS",
@@ -1037,7 +1295,9 @@
     "metadata_path": "content/parsers/third_party/community/MANDIANT_DTM_ALERTS/cbn/metadata.json",
     "vendor": "MANDIANT",
     "product": "MANDIANT_DTM_ALERTS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f66e9c6fb9c718892d8802249ee92efab3f54e9e",
+    "latest_commit_time": 1782478493
   },
   {
     "log_type": "MICROFOCUS_IMANAGER",
@@ -1045,7 +1305,9 @@
     "metadata_path": "content/parsers/third_party/community/MICROFOCUS_IMANAGER/cbn/metadata.json",
     "vendor": "NetIQ",
     "product": "MICROFOCUS_IMANAGER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "3ac42fd1ad714e762d1fbf25449060742e935837",
+    "latest_commit_time": 1779772630
   },
   {
     "log_type": "MICROSOFT_ATA",
@@ -1053,7 +1315,9 @@
     "metadata_path": "content/parsers/third_party/community/MICROSOFT_ATA/cbn/metadata.json",
     "vendor": "MICROSOFT",
     "product": "ATA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "MICROSOFT_IAS",
@@ -1061,7 +1325,9 @@
     "metadata_path": "content/parsers/third_party/community/MICROSOFT_IAS/cbn/metadata.json",
     "vendor": "MICROSOFT",
     "product": "MICROSOFT_IAS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "MICROSOFT_SCEP",
@@ -1069,7 +1335,9 @@
     "metadata_path": "content/parsers/third_party/community/MICROSOFT_SCEP/cbn/metadata.json",
     "vendor": "MICROSOFT",
     "product": "MICROSOFT SYSTEM CENTER ENDPOINT PROTECTION",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "06e0a945b8f013076d3548220af66e6bcdd8c0c2",
+    "latest_commit_time": 1781172693
   },
   {
     "log_type": "MICROSTRATEGY",
@@ -1077,7 +1345,9 @@
     "metadata_path": "content/parsers/third_party/community/MICROSTRATEGY/cbn/metadata.json",
     "vendor": "MICROSTRATEGY",
     "product": "MICROSTRATEGY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NAGIOS",
@@ -1085,7 +1355,9 @@
     "metadata_path": "content/parsers/third_party/community/NAGIOS/cbn/metadata.json",
     "vendor": "NAGIOS",
     "product": "NAGIOS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "c5474cec966ae47fc50d681f3db4926e4e3905a3",
+    "latest_commit_time": 1779707100
   },
   {
     "log_type": "NEO4J",
@@ -1093,7 +1365,9 @@
     "metadata_path": "content/parsers/third_party/community/NEO4J/cbn/metadata.json",
     "vendor": "NEO4J",
     "product": "NEO4J",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NETAPP_BLUEXP",
@@ -1101,7 +1375,9 @@
     "metadata_path": "content/parsers/third_party/community/NETAPP_BLUEXP/cbn/metadata.json",
     "vendor": "NETAPP",
     "product": "NETAPP_BLUEXP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NETDOCUMENTS",
@@ -1109,7 +1385,9 @@
     "metadata_path": "content/parsers/third_party/community/NETDOCUMENTS/cbn/metadata.json",
     "vendor": "NETDOCUMENTS",
     "product": "NETDOCUMENTS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "06e0a945b8f013076d3548220af66e6bcdd8c0c2",
+    "latest_commit_time": 1781172693
   },
   {
     "log_type": "NETSCOUT_OCI",
@@ -1117,7 +1395,9 @@
     "metadata_path": "content/parsers/third_party/community/NETSCOUT_OCI/cbn/metadata.json",
     "vendor": "NETSCOUT",
     "product": "OMNIS_CYBER_INTELLIGENCE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NETSKOPE_CLIENT",
@@ -1125,7 +1405,9 @@
     "metadata_path": "content/parsers/third_party/community/NETSKOPE_CLIENT/cbn/metadata.json",
     "vendor": "NETSKOPE",
     "product": "NETSKOPE_CLIENT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NETWRIX_STEALTHAUDIT",
@@ -1133,7 +1415,9 @@
     "metadata_path": "content/parsers/third_party/community/NETWRIX_STEALTHAUDIT/cbn/metadata.json",
     "vendor": "NETWRIX",
     "product": "NETWRIX_STEALTHAUDIT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NET_SUITE",
@@ -1141,7 +1425,9 @@
     "metadata_path": "content/parsers/third_party/community/NET_SUITE/cbn/metadata.json",
     "vendor": "NET_SUITE",
     "product": "NET_SUITE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NOKIA_ROUTER",
@@ -1149,7 +1435,9 @@
     "metadata_path": "content/parsers/third_party/community/NOKIA_ROUTER/cbn/metadata.json",
     "vendor": "NOKIA_ROUTER",
     "product": "Base",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "cfffcf21de5b8ed9329540914684bac5477104a6",
+    "latest_commit_time": 1778850386
   },
   {
     "log_type": "NTOPNG",
@@ -1157,7 +1445,9 @@
     "metadata_path": "content/parsers/third_party/community/NTOPNG/cbn/metadata.json",
     "vendor": "NTOPNG",
     "product": "NTOPNG",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8be385797ec1812720c79c1dd3e1f5e014414234",
+    "latest_commit_time": 1781167963
   },
   {
     "log_type": "NUCLEUS_VULNERABILITY",
@@ -1165,7 +1455,9 @@
     "metadata_path": "content/parsers/third_party/community/NUCLEUS_VULNERABILITY/cbn/metadata.json",
     "vendor": "NUCLEUS",
     "product": "NUCLEUS UNIFIED VULNERIBILITY MANAGEMENT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "06e0a945b8f013076d3548220af66e6bcdd8c0c2",
+    "latest_commit_time": 1781172693
   },
   {
     "log_type": "NXLOG_MANAGER",
@@ -1173,7 +1465,9 @@
     "metadata_path": "content/parsers/third_party/community/NXLOG_MANAGER/cbn/metadata.json",
     "vendor": "NXLOG",
     "product": "NXLOG_MANAGER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "06e0a945b8f013076d3548220af66e6bcdd8c0c2",
+    "latest_commit_time": 1781172693
   },
   {
     "log_type": "NYANSA_EVENTS",
@@ -1181,7 +1475,9 @@
     "metadata_path": "content/parsers/third_party/community/NYANSA_EVENTS/cbn/metadata.json",
     "vendor": "NYANSA_EVENTS",
     "product": "NYANSA_EVENTS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "06e0a945b8f013076d3548220af66e6bcdd8c0c2",
+    "latest_commit_time": 1781172693
   },
   {
     "log_type": "OKTA_ACCESS_GATEWAY",
@@ -1189,7 +1485,9 @@
     "metadata_path": "content/parsers/third_party/community/OKTA_ACCESS_GATEWAY/cbn/metadata.json",
     "vendor": "CLF",
     "product": "OKTA_ACCESS_GATEWAY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "cfffcf21de5b8ed9329540914684bac5477104a6",
+    "latest_commit_time": 1778850386
   },
   {
     "log_type": "ONAPSIS",
@@ -1197,7 +1495,9 @@
     "metadata_path": "content/parsers/third_party/community/ONAPSIS/cbn/metadata.json",
     "vendor": "ONAPSIS",
     "product": "ONAPSIS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "ONFIDO",
@@ -1205,7 +1505,9 @@
     "metadata_path": "content/parsers/third_party/community/ONFIDO/cbn/metadata.json",
     "vendor": "ONFIDO",
     "product": "ONFIDO",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "147d430368c4825ea136ee02a75f7fb5d1b6d4f0",
+    "latest_commit_time": 1781173252
   },
   {
     "log_type": "OORT",
@@ -1213,7 +1515,9 @@
     "metadata_path": "content/parsers/third_party/community/OORT/cbn/metadata.json",
     "vendor": "Cisco",
     "product": "Identity Intelligence",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "8da64d35340a867ea06762d1eb21d2720517ca2b",
+    "latest_commit_time": 1779772860
   },
   {
     "log_type": "OPA",
@@ -1221,7 +1525,9 @@
     "metadata_path": "content/parsers/third_party/community/OPA/cbn/metadata.json",
     "vendor": "OPEN POLICY AGENT",
     "product": "OPEN POLICY AGENT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "147d430368c4825ea136ee02a75f7fb5d1b6d4f0",
+    "latest_commit_time": 1781173252
   },
   {
     "log_type": "OPENAI_AUDITLOG",
@@ -1229,7 +1535,9 @@
     "metadata_path": "content/parsers/third_party/community/OPENAI_AUDITLOG/cbn/metadata.json",
     "vendor": "OPENAI_AUDITLOG",
     "product": "OPENAI_AUDITLOG",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "OPENCANARY",
@@ -1237,7 +1545,9 @@
     "metadata_path": "content/parsers/third_party/community/OPENCANARY/cbn/metadata.json",
     "vendor": "OPENCANARY",
     "product": "OPENCANARY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "OPENDJ",
@@ -1245,7 +1555,9 @@
     "metadata_path": "content/parsers/third_party/community/OPENDJ/cbn/metadata.json",
     "vendor": "ForgeRock",
     "product": "ForgeRock OpenDJ",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "OPENPATH",
@@ -1253,7 +1565,9 @@
     "metadata_path": "content/parsers/third_party/community/OPENPATH/cbn/metadata.json",
     "vendor": "AVIGILON",
     "product": "AVIGILON",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "ORACLE_FUSION",
@@ -1261,7 +1575,9 @@
     "metadata_path": "content/parsers/third_party/community/ORACLE_FUSION/cbn/metadata.json",
     "vendor": "Oracle",
     "product": "Oracle_Fusion",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "ORACLE_NETSUITE",
@@ -1269,7 +1585,9 @@
     "metadata_path": "content/parsers/third_party/community/ORACLE_NETSUITE/cbn/metadata.json",
     "vendor": "ORACLE",
     "product": "ORACLE_NETSUITE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "ORACLE_OUD",
@@ -1277,7 +1595,9 @@
     "metadata_path": "content/parsers/third_party/community/ORACLE_OUD/cbn/metadata.json",
     "vendor": "Oracle",
     "product": "Oracle OUD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "PALANTIR",
@@ -1285,7 +1605,9 @@
     "metadata_path": "content/parsers/third_party/community/PALANTIR/cbn/metadata.json",
     "vendor": "PALANTIR",
     "product": "PALANTIR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "cfffcf21de5b8ed9329540914684bac5477104a6",
+    "latest_commit_time": 1778850386
   },
   {
     "log_type": "PAN_EDR",
@@ -1293,7 +1615,9 @@
     "metadata_path": "content/parsers/third_party/community/PAN_EDR/cbn/metadata.json",
     "vendor": "Palo Alto Networks",
     "product": "Cortex XDR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "PASSWORDSTATE",
@@ -1301,7 +1625,9 @@
     "metadata_path": "content/parsers/third_party/community/PASSWORDSTATE/cbn/metadata.json",
     "vendor": "PASSWORDSTATE",
     "product": "PASSWORDSTATE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "PEPLINK_FW",
@@ -1309,7 +1635,9 @@
     "metadata_path": "content/parsers/third_party/community/PEPLINK_FW/cbn/metadata.json",
     "vendor": "PEPLINK_FW",
     "product": "PEPLINK_FW",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "550d44b9ec3f6c88bfa80caaa7c392591a933768",
+    "latest_commit_time": 1779784583
   },
   {
     "log_type": "PROFTPD",
@@ -1317,7 +1645,9 @@
     "metadata_path": "content/parsers/third_party/community/PROFTPD/cbn/metadata.json",
     "vendor": "PROFTPD",
     "product": "PROFTPD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "147d430368c4825ea136ee02a75f7fb5d1b6d4f0",
+    "latest_commit_time": 1781173252
   },
   {
     "log_type": "PROOFPOINT_SENDMAIL_SENTRION",
@@ -1325,7 +1655,9 @@
     "metadata_path": "content/parsers/third_party/community/PROOFPOINT_SENDMAIL_SENTRION/cbn/metadata.json",
     "vendor": "PROOFPOINT",
     "product": "PROOFPOINT_SENDMAIL_SENTRION",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "5c9f573e8ca7758deb149346a8350ce3d08f8108",
+    "latest_commit_time": 1781173266
   },
   {
     "log_type": "PROOFPOINT_SER",
@@ -1333,7 +1665,9 @@
     "metadata_path": "content/parsers/third_party/community/PROOFPOINT_SER/cbn/metadata.json",
     "vendor": "PROOFPOINT",
     "product": "PROOFPOINT SER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "PROOFPOINT_TAP_THREATS",
@@ -1341,7 +1675,9 @@
     "metadata_path": "content/parsers/third_party/community/PROOFPOINT_TAP_THREATS/cbn/metadata.json",
     "vendor": "Proofpoint",
     "product": "TAP Threats",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "49cc51d23e904d9555f271cd0e114b26b22dc5ff",
+    "latest_commit_time": 1779705774
   },
   {
     "log_type": "PROWATCH",
@@ -1349,7 +1685,9 @@
     "metadata_path": "content/parsers/third_party/community/PROWATCH/cbn/metadata.json",
     "vendor": "Honeywell",
     "product": "ProWatch",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "49cc51d23e904d9555f271cd0e114b26b22dc5ff",
+    "latest_commit_time": 1779705774
   },
   {
     "log_type": "QUALYS_ASSET_CONTEXT",
@@ -1357,7 +1695,9 @@
     "metadata_path": "content/parsers/third_party/community/QUALYS_ASSET_CONTEXT/cbn/metadata.json",
     "vendor": "QUALYS",
     "product": "QUALYS_ASSET_CONTEXT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "5c9f573e8ca7758deb149346a8350ce3d08f8108",
+    "latest_commit_time": 1781173266
   },
   {
     "log_type": "QUALYS_CONTINUOUS_MONITORING",
@@ -1365,7 +1705,9 @@
     "metadata_path": "content/parsers/third_party/community/QUALYS_CONTINUOUS_MONITORING/cbn/metadata.json",
     "vendor": "QUALYS",
     "product": "QUALYS_CONTINOUS_MONITORING",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "39c2c2eec0152ff8086018c338c95f485e774b29",
+    "latest_commit_time": 1779785642
   },
   {
     "log_type": "QUALYS_VIRTUAL_SCANNER",
@@ -1373,7 +1715,9 @@
     "metadata_path": "content/parsers/third_party/community/QUALYS_VIRTUAL_SCANNER/cbn/metadata.json",
     "vendor": "QUALYS_VIRTUAL_SCANNER",
     "product": "QUALYS_VIRTUAL_SCANNER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "QUEST_CHANGE_AUDITOR_EMC",
@@ -1381,7 +1725,9 @@
     "metadata_path": "content/parsers/third_party/community/QUEST_CHANGE_AUDITOR_EMC/cbn/metadata.json",
     "vendor": "Quest",
     "product": "Quest Change Auditor EMC",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "QUEST_FILE_AUDIT",
@@ -1389,7 +1735,9 @@
     "metadata_path": "content/parsers/third_party/community/QUEST_FILE_AUDIT/cbn/metadata.json",
     "vendor": "QUEST",
     "product": "QUEST FILE ACCESS AUDIT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "5c9f573e8ca7758deb149346a8350ce3d08f8108",
+    "latest_commit_time": 1781173266
   },
   {
     "log_type": "QUMULO_FS",
@@ -1397,7 +1745,9 @@
     "metadata_path": "content/parsers/third_party/community/QUMULO_FS/cbn/metadata.json",
     "vendor": "QUMULO_FS",
     "product": "QUMULO_FS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "RECORDIA",
@@ -1405,7 +1755,9 @@
     "metadata_path": "content/parsers/third_party/community/RECORDIA/cbn/metadata.json",
     "vendor": "COMUNYCARSE",
     "product": "RECORDIA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "5c9f573e8ca7758deb149346a8350ce3d08f8108",
+    "latest_commit_time": 1781173266
   },
   {
     "log_type": "REDCANARY_EDR",
@@ -1413,7 +1765,9 @@
     "metadata_path": "content/parsers/third_party/community/REDCANARY_EDR/cbn/metadata.json",
     "vendor": "REDCANARY",
     "product": "EDR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "e88dfcd785276abcf7f8ea7dc85bf9cfa5575fd6",
+    "latest_commit_time": 1781170392
   },
   {
     "log_type": "REDHAT_DIRECTORY_SERVER",
@@ -1421,7 +1775,9 @@
     "metadata_path": "content/parsers/third_party/community/REDHAT_DIRECTORY_SERVER/cbn/metadata.json",
     "vendor": "REDHAT",
     "product": "REDHAT_DIRECTORY_SERVER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "49cc51d23e904d9555f271cd0e114b26b22dc5ff",
+    "latest_commit_time": 1779705774
   },
   {
     "log_type": "RH_ISAC_IOC",
@@ -1429,7 +1785,9 @@
     "metadata_path": "content/parsers/third_party/community/RH_ISAC_IOC/cbn/metadata.json",
     "vendor": "RH_ISAC",
     "product": "RH-ISAC",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "RIPPLING_ACTIVITYLOGS",
@@ -1437,7 +1795,9 @@
     "metadata_path": "content/parsers/third_party/community/RIPPLING_ACTIVITYLOGS/cbn/metadata.json",
     "vendor": "RIPPLING",
     "product": "RIPPLING_ACTIVITYLOGS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "SAIWALL_VPN",
@@ -1445,7 +1805,9 @@
     "metadata_path": "content/parsers/third_party/community/SAIWALL_VPN/cbn/metadata.json",
     "vendor": "SAIWALL",
     "product": "SAIWALL_VPN",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "e88dfcd785276abcf7f8ea7dc85bf9cfa5575fd6",
+    "latest_commit_time": 1781170392
   },
   {
     "log_type": "SALESFORCE_COMMERCE_CLOUD",
@@ -1453,7 +1815,9 @@
     "metadata_path": "content/parsers/third_party/community/SALESFORCE_COMMERCE_CLOUD/cbn/metadata.json",
     "vendor": "SALESFORCE",
     "product": "SALESFORCE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "49cc51d23e904d9555f271cd0e114b26b22dc5ff",
+    "latest_commit_time": 1779705774
   },
   {
     "log_type": "SANGFOR_PROXY",
@@ -1461,7 +1825,9 @@
     "metadata_path": "content/parsers/third_party/community/SANGFOR_PROXY/cbn/metadata.json",
     "vendor": "SANGFOR",
     "product": "SANGFOR_PROXY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "e88dfcd785276abcf7f8ea7dc85bf9cfa5575fd6",
+    "latest_commit_time": 1781170392
   },
   {
     "log_type": "SAP_ASE",
@@ -1469,7 +1835,9 @@
     "metadata_path": "content/parsers/third_party/community/SAP_ASE/cbn/metadata.json",
     "vendor": "SAP_ASE",
     "product": "SAP_ASE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "SAP_NETWEAVER",
@@ -1477,7 +1845,9 @@
     "metadata_path": "content/parsers/third_party/community/SAP_NETWEAVER/cbn/metadata.json",
     "vendor": "SAP",
     "product": "SAP Netweaver",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "SAP_SUCCESSFACTORS",
@@ -1485,7 +1855,9 @@
     "metadata_path": "content/parsers/third_party/community/SAP_SUCCESSFACTORS/cbn/metadata.json",
     "vendor": "SAP",
     "product": "SuccessFactors",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "SENTRY",
@@ -1493,7 +1865,9 @@
     "metadata_path": "content/parsers/third_party/community/SENTRY/cbn/metadata.json",
     "vendor": "SENTRY",
     "product": "SENTRY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "e88dfcd785276abcf7f8ea7dc85bf9cfa5575fd6",
+    "latest_commit_time": 1781170392
   },
   {
     "log_type": "SEQRITE_ENDPOINT",
@@ -1501,7 +1875,9 @@
     "metadata_path": "content/parsers/third_party/community/SEQRITE_ENDPOINT/cbn/metadata.json",
     "vendor": "SEQRITE",
     "product": "ENDPOINT SECURITY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "064b0f31981d6b90c96a4ecc6c96ce19c482596d",
+    "latest_commit_time": 1781170359
   },
   {
     "log_type": "SERVICENOW_SECURITY",
@@ -1509,7 +1885,9 @@
     "metadata_path": "content/parsers/third_party/community/SERVICENOW_SECURITY/cbn/metadata.json",
     "vendor": "SERVICENOW",
     "product": "SERVICENOW_SECURITY",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "SHAREPOINT",
@@ -1517,7 +1895,9 @@
     "metadata_path": "content/parsers/third_party/community/SHAREPOINT/cbn/metadata.json",
     "vendor": "SHAREPOINT",
     "product": "SHAREPOINT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "SHRUBBERY_TACACS",
@@ -1525,7 +1905,9 @@
     "metadata_path": "content/parsers/third_party/community/SHRUBBERY_TACACS/cbn/metadata.json",
     "vendor": "SHRUBBERY",
     "product": "SHRUBBERY_TACACS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "064b0f31981d6b90c96a4ecc6c96ce19c482596d",
+    "latest_commit_time": 1781170359
   },
   {
     "log_type": "SIERRA_WIRELESS",
@@ -1533,7 +1915,9 @@
     "metadata_path": "content/parsers/third_party/community/SIERRA_WIRELESS/cbn/metadata.json",
     "vendor": "SIERRA",
     "product": "SIERRA_WIRELESS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "SKYBOX_FIREWALL_ASSURANCE",
@@ -1541,7 +1925,9 @@
     "metadata_path": "content/parsers/third_party/community/SKYBOX_FIREWALL_ASSURANCE/cbn/metadata.json",
     "vendor": "SKYBOX",
     "product": "SKYBOX_FIREWALL_ASSURANCE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "SMARTSHEET",
@@ -1549,7 +1935,9 @@
     "metadata_path": "content/parsers/third_party/community/SMARTSHEET/cbn/metadata.json",
     "vendor": "SMARTSHEET",
     "product": "SMARTSHEET",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "064b0f31981d6b90c96a4ecc6c96ce19c482596d",
+    "latest_commit_time": 1781170359
   },
   {
     "log_type": "SMBD",
@@ -1557,7 +1945,9 @@
     "metadata_path": "content/parsers/third_party/community/SMBD/cbn/metadata.json",
     "vendor": "SMBD",
     "product": "SMBD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "49cc51d23e904d9555f271cd0e114b26b22dc5ff",
+    "latest_commit_time": 1779705774
   },
   {
     "log_type": "SNIPE_IT",
@@ -1565,7 +1955,9 @@
     "metadata_path": "content/parsers/third_party/community/SNIPE_IT/cbn/metadata.json",
     "vendor": "SNIPE-IT",
     "product": "CMDB",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "064b0f31981d6b90c96a4ecc6c96ce19c482596d",
+    "latest_commit_time": 1781170359
   },
   {
     "log_type": "SNORT_IDS",
@@ -1573,7 +1965,9 @@
     "metadata_path": "content/parsers/third_party/community/SNORT_IDS/cbn/metadata.json",
     "vendor": "SNORT",
     "product": "SNORT_IDS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "SOPHOS_DHCP",
@@ -1581,7 +1975,9 @@
     "metadata_path": "content/parsers/third_party/community/SOPHOS_DHCP/cbn/metadata.json",
     "vendor": "SOPHOS",
     "product": "SOPHOS_DHCP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "1a7d49425deaf72b4c4dc7d517b49a9733ad895b",
+    "latest_commit_time": 1781169056
   },
   {
     "log_type": "SOTI_MOBICONTROL",
@@ -1589,7 +1985,9 @@
     "metadata_path": "content/parsers/third_party/community/SOTI_MOBICONTROL/cbn/metadata.json",
     "vendor": "SOTI_MOBICONTROL",
     "product": "SOTI_MOBICONTROL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "4a94969cbe26a9f716861af92dcb7f526efca759",
+    "latest_commit_time": 1779190190
   },
   {
     "log_type": "SPLUNK",
@@ -1597,7 +1995,9 @@
     "metadata_path": "content/parsers/third_party/community/SPLUNK/cbn/metadata.json",
     "vendor": "Splunk",
     "product": "CIM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "SPYCLOUD",
@@ -1605,7 +2005,9 @@
     "metadata_path": "content/parsers/third_party/community/SPYCLOUD/cbn/metadata.json",
     "vendor": "SpyCloud",
     "product": "SPYCLOUD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "STEALTHBITS_AUDIT",
@@ -1613,7 +2015,9 @@
     "metadata_path": "content/parsers/third_party/community/STEALTHBITS_AUDIT/cbn/metadata.json",
     "vendor": "Stealthbits",
     "product": "StealthINTERCEPT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "STEALTHBITS_DEFEND",
@@ -1621,7 +2025,9 @@
     "metadata_path": "content/parsers/third_party/community/STEALTHBITS_DEFEND/cbn/metadata.json",
     "vendor": "STEALTHbits",
     "product": "StealthINTERCEPT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "STEALTHBITS_PAM",
@@ -1629,7 +2035,9 @@
     "metadata_path": "content/parsers/third_party/community/STEALTHBITS_PAM/cbn/metadata.json",
     "vendor": "NETWRIX CORPORATION",
     "product": "NETWRIX PRIVILEGE SECURE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "064b0f31981d6b90c96a4ecc6c96ce19c482596d",
+    "latest_commit_time": 1781170359
   },
   {
     "log_type": "SYMANTEC_SA",
@@ -1637,7 +2045,9 @@
     "metadata_path": "content/parsers/third_party/community/SYMANTEC_SA/cbn/metadata.json",
     "vendor": "SYMANTEC CORPORATION",
     "product": "SYMANTEC_SA",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "1a7d49425deaf72b4c4dc7d517b49a9733ad895b",
+    "latest_commit_time": 1781169056
   },
   {
     "log_type": "SYMANTEC_VIP_AUTHHUB",
@@ -1645,7 +2055,9 @@
     "metadata_path": "content/parsers/third_party/community/SYMANTEC_VIP_AUTHHUB/cbn/metadata.json",
     "vendor": "SYMANTEC",
     "product": "SYMANTEC_VIP_AUTHHUB",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "TACACS_PLUS",
@@ -1653,7 +2065,9 @@
     "metadata_path": "content/parsers/third_party/community/TACACS_PLUS/cbn/metadata.json",
     "vendor": "TACACS Plus",
     "product": "TACACS Plus",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "fd569068ae90691afa1dfe270b9a63ccc902500a",
+    "latest_commit_time": 1781169015
   },
   {
     "log_type": "TALON",
@@ -1661,7 +2075,9 @@
     "metadata_path": "content/parsers/third_party/community/TALON/cbn/metadata.json",
     "vendor": "TALON",
     "product": "Talon",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "TANIUM_INSIGHT",
@@ -1669,7 +2085,9 @@
     "metadata_path": "content/parsers/third_party/community/TANIUM_INSIGHT/cbn/metadata.json",
     "vendor": "Tanium",
     "product": "Tanium Patch",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "TANIUM_INTEGRITY_MONITOR",
@@ -1677,7 +2095,9 @@
     "metadata_path": "content/parsers/third_party/community/TANIUM_INTEGRITY_MONITOR/cbn/metadata.json",
     "vendor": "Tanium Integrity Monitor",
     "product": "Tanium Integrity Monitor",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "TANIUM_PATCH",
@@ -1685,7 +2105,9 @@
     "metadata_path": "content/parsers/third_party/community/TANIUM_PATCH/cbn/metadata.json",
     "vendor": "Tanium",
     "product": "Patch",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "TANIUM_REVEAL",
@@ -1693,7 +2115,9 @@
     "metadata_path": "content/parsers/third_party/community/TANIUM_REVEAL/cbn/metadata.json",
     "vendor": "Tanium",
     "product": "Tanium Reveal",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "f0ad31fb3f79398a54b6f316c8fbfec91481a54f",
+    "latest_commit_time": 1779785622
   },
   {
     "log_type": "TCPWAVE_DDI",
@@ -1701,7 +2125,9 @@
     "metadata_path": "content/parsers/third_party/community/TCPWAVE_DDI/cbn/metadata.json",
     "vendor": "TCPWAVE",
     "product": "TCPWAVE_DDI",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "24031d88966b099c7b1263ac8e7a4c401c7eebb8",
+    "latest_commit_time": 1779707912
   },
   {
     "log_type": "TERADATA_DB",
@@ -1709,7 +2135,9 @@
     "metadata_path": "content/parsers/third_party/community/TERADATA_DB/cbn/metadata.json",
     "vendor": "TERADATA",
     "product": "TERADATA_DB",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "1a7d49425deaf72b4c4dc7d517b49a9733ad895b",
+    "latest_commit_time": 1781169056
   },
   {
     "log_type": "THALES_MFA",
@@ -1717,7 +2145,9 @@
     "metadata_path": "content/parsers/third_party/community/THALES_MFA/cbn/metadata.json",
     "vendor": "Thales",
     "product": "Safenet",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "THREATLOCKER",
@@ -1725,7 +2155,9 @@
     "metadata_path": "content/parsers/third_party/community/THREATLOCKER/cbn/metadata.json",
     "vendor": "THREATLOCKER",
     "product": "THREATLOCKER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "1a7d49425deaf72b4c4dc7d517b49a9733ad895b",
+    "latest_commit_time": 1781169056
   },
   {
     "log_type": "THREATX_WAF",
@@ -1733,7 +2165,9 @@
     "metadata_path": "content/parsers/third_party/community/THREATX_WAF/cbn/metadata.json",
     "vendor": "THREATX_WAF",
     "product": "THREATX_WAF",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "TINES",
@@ -1741,7 +2175,9 @@
     "metadata_path": "content/parsers/third_party/community/TINES/cbn/metadata.json",
     "vendor": "Tines",
     "product": "Tines",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "TINTRI",
@@ -1749,7 +2185,9 @@
     "metadata_path": "content/parsers/third_party/community/TINTRI/cbn/metadata.json",
     "vendor": "Tintri",
     "product": "Tintri",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "TRENDMICRO_VISION_ONE_CONTAINER_VULNERABILITIES",
@@ -1757,7 +2195,9 @@
     "metadata_path": "content/parsers/third_party/community/TRENDMICRO_VISION_ONE_CONTAINER_VULNERABILITIES/cbn/metadata.json",
     "vendor": "TRENDMICRO",
     "product": "TREND VISION ONE CONTAINER VULNERABILITIES",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "1a7d49425deaf72b4c4dc7d517b49a9733ad895b",
+    "latest_commit_time": 1781169056
   },
   {
     "log_type": "UBERAGENT",
@@ -1765,7 +2205,9 @@
     "metadata_path": "content/parsers/third_party/community/UBERAGENT/cbn/metadata.json",
     "vendor": "UBERAGENT",
     "product": "UBERAGENT",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d8a4fe66ef11fbfd978a952815fd00c55505d252",
+    "latest_commit_time": 1781169037
   },
   {
     "log_type": "UBIKA_WAAP",
@@ -1773,7 +2215,9 @@
     "metadata_path": "content/parsers/third_party/community/UBIKA_WAAP/cbn/metadata.json",
     "vendor": "UBIKA_WAAP",
     "product": "UBIKA_WAAP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "UKG",
@@ -1781,7 +2225,9 @@
     "metadata_path": "content/parsers/third_party/community/UKG/cbn/metadata.json",
     "vendor": "UKG",
     "product": "UKG",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "UPGUARD",
@@ -1789,7 +2235,9 @@
     "metadata_path": "content/parsers/third_party/community/UPGUARD/cbn/metadata.json",
     "vendor": "UPGUARD",
     "product": "UPGUARD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "UPSTREAM_VSOC_ALERTS",
@@ -1797,7 +2245,9 @@
     "metadata_path": "content/parsers/third_party/community/UPSTREAM_VSOC_ALERTS/cbn/metadata.json",
     "vendor": "UPSTREAM",
     "product": "UPSTREAM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d8a4fe66ef11fbfd978a952815fd00c55505d252",
+    "latest_commit_time": 1781169037
   },
   {
     "log_type": "UPTYCS_EDR",
@@ -1805,7 +2255,9 @@
     "metadata_path": "content/parsers/third_party/community/UPTYCS_EDR/cbn/metadata.json",
     "vendor": "UPTYCS",
     "product": "UPTYCS_EDR",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "UPX_ANTIDDOS",
@@ -1813,7 +2265,9 @@
     "metadata_path": "content/parsers/third_party/community/UPX_ANTIDDOS/cbn/metadata.json",
     "vendor": "UPX",
     "product": "UPX ANTIDDOS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d8a4fe66ef11fbfd978a952815fd00c55505d252",
+    "latest_commit_time": 1781169037
   },
   {
     "log_type": "VECTRA_ALERTS",
@@ -1821,7 +2275,9 @@
     "metadata_path": "content/parsers/third_party/community/VECTRA_ALERTS/cbn/metadata.json",
     "vendor": "VECTRA",
     "product": "VECTRA ALERTS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d8a4fe66ef11fbfd978a952815fd00c55505d252",
+    "latest_commit_time": 1781169037
   },
   {
     "log_type": "VENAFI_ZTPKI",
@@ -1829,7 +2285,9 @@
     "metadata_path": "content/parsers/third_party/community/VENAFI_ZTPKI/cbn/metadata.json",
     "vendor": "VENAFI",
     "product": "VENAFI ZTPKI",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "d8a4fe66ef11fbfd978a952815fd00c55505d252",
+    "latest_commit_time": 1781169037
   },
   {
     "log_type": "VERBA_REC",
@@ -1837,7 +2295,9 @@
     "metadata_path": "content/parsers/third_party/community/VERBA_REC/cbn/metadata.json",
     "vendor": "VERBA",
     "product": "VERBA RECORDING SYSTEM",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "72d0715d548ec5ed56cc9c66eac1f70b49caaddd",
+    "latest_commit_time": 1781515611
   },
   {
     "log_type": "VIRTRU_EMAIL_ENCRYPTION",
@@ -1845,7 +2305,9 @@
     "metadata_path": "content/parsers/third_party/community/VIRTRU_EMAIL_ENCRYPTION/cbn/metadata.json",
     "vendor": "VIRTRU",
     "product": "VIRTRU EMAIL ENCRYPTION",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "72d0715d548ec5ed56cc9c66eac1f70b49caaddd",
+    "latest_commit_time": 1781515611
   },
   {
     "log_type": "VITALQIP",
@@ -1853,7 +2315,9 @@
     "metadata_path": "content/parsers/third_party/community/VITALQIP/cbn/metadata.json",
     "vendor": "NOKIA",
     "product": "VITALQIP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "72d0715d548ec5ed56cc9c66eac1f70b49caaddd",
+    "latest_commit_time": 1781515611
   },
   {
     "log_type": "VSFTPD",
@@ -1861,7 +2325,9 @@
     "metadata_path": "content/parsers/third_party/community/VSFTPD/cbn/metadata.json",
     "vendor": "VSFTPD",
     "product": "VSFTPD",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "VYOS",
@@ -1869,7 +2335,9 @@
     "metadata_path": "content/parsers/third_party/community/VYOS/cbn/metadata.json",
     "vendor": "VYOS",
     "product": "VYOS DHCP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "WEBMARSHAL",
@@ -1877,7 +2345,9 @@
     "metadata_path": "content/parsers/third_party/community/WEBMARSHAL/cbn/metadata.json",
     "vendor": "WEBMARSHAL",
     "product": "WEBMARSHAL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "72d0715d548ec5ed56cc9c66eac1f70b49caaddd",
+    "latest_commit_time": 1781515611
   },
   {
     "log_type": "WINDCHILL",
@@ -1885,7 +2355,9 @@
     "metadata_path": "content/parsers/third_party/community/WINDCHILL/cbn/metadata.json",
     "vendor": "WINDCHILL",
     "product": "WINDCHILL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "53e298d087a4dd126166a8e3a6c70eac6bf5fafe",
+    "latest_commit_time": 1779784908
   },
   {
     "log_type": "WINSCP",
@@ -1893,7 +2365,9 @@
     "metadata_path": "content/parsers/third_party/community/WINSCP/cbn/metadata.json",
     "vendor": "WINSCP",
     "product": "WINSCP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "72d0715d548ec5ed56cc9c66eac1f70b49caaddd",
+    "latest_commit_time": 1781515611
   },
   {
     "log_type": "WPENGINE",
@@ -1901,7 +2375,9 @@
     "metadata_path": "content/parsers/third_party/community/WPENGINE/cbn/metadata.json",
     "vendor": "WP ENGINE",
     "product": "WPENGINE",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "72d0715d548ec5ed56cc9c66eac1f70b49caaddd",
+    "latest_commit_time": 1781515611
   },
   {
     "log_type": "XITING_XAMS",
@@ -1909,7 +2385,9 @@
     "metadata_path": "content/parsers/third_party/community/XITING_XAMS/cbn/metadata.json",
     "vendor": "Xiting",
     "product": "XAMS",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   },
   {
     "log_type": "YAMAHA_ROUTER",
@@ -1917,7 +2395,9 @@
     "metadata_path": "content/parsers/third_party/community/YAMAHA_ROUTER/cbn/metadata.json",
     "vendor": "YAMAHA_ROUTER",
     "product": "YAMAHA_ROUTER",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   },
   {
     "log_type": "YUBICO_OTP",
@@ -1925,7 +2405,9 @@
     "metadata_path": "content/parsers/third_party/community/YUBICO_OTP/cbn/metadata.json",
     "vendor": "YUBICO",
     "product": "YUBICO_OTP",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "55c1dc8be66ca1008056cb7995917a7462e18bb1",
+    "latest_commit_time": 1778758602
   },
   {
     "log_type": "ZEROFOX_PLATFORM",
@@ -1933,7 +2415,9 @@
     "metadata_path": "content/parsers/third_party/community/ZEROFOX_PLATFORM/cbn/metadata.json",
     "vendor": "ZeroFox",
     "product": "ZeroFox Platform",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "13db00296f52349a3132acc1f9e9cc3045f27e9f",
+    "latest_commit_time": 1779784777
   },
   {
     "log_type": "ZYWALL",
@@ -1941,6 +2425,8 @@
     "metadata_path": "content/parsers/third_party/community/ZYWALL/cbn/metadata.json",
     "vendor": "ZYWALL",
     "product": "ZYWALL",
-    "source": "COMMUNITY"
+    "source": "COMMUNITY",
+    "latest_commit_id": "b93e8139c89dfedc7a9057c863c3b6008ddcd88e",
+    "latest_commit_time": 1779785246
   }
 ]

--- a/tools/parsers/scripts/generate_index.py
+++ b/tools/parsers/scripts/generate_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import subprocess
 import sys
 
 # Target directory to walk (assumes script is run from repo root)
@@ -11,6 +12,28 @@ output_dir = Path("content/parsers/third_party")
 # Subdirectories for community and partner
 community_dir = target_dir / "community"
 partner_dir = target_dir / "partner"
+
+def get_latest_commit_info(file_path: Path) -> tuple[str, int | None]:
+    """Helper to get the latest Git commit SHA and commit time (epoch) for the file."""
+    try:
+        # %H is commit hash, %ct is committer date (unix timestamp)
+        result = subprocess.run(
+            ["git", "log", "-n", "1", "--pretty=format:%H,%ct", "--", file_path.as_posix()],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        output = result.stdout.strip()
+        if not output:
+            return "", None
+            
+        sha, timestamp_str = output.split(",", 1)
+        return sha, int(timestamp_str)
+    except subprocess.CalledProcessError:
+        return "", None
+    except Exception as e:
+        print(f"WARNING: Failed to get commit info for {file_path}: {e}", file=sys.stderr)
+        return "", None
 
 def generate_index_for_subdir(sub_dir: Path, output_json_name: str, source_type: str):
     entries = []
@@ -44,13 +67,18 @@ def generate_index_for_subdir(sub_dir: Path, output_json_name: str, source_type:
             print(f"WARNING: Missing log type in {metadata_path}", file=sys.stderr)
             continue
             
+        # Get the latest commit ID and time for the config file
+        commit_id, commit_time = get_latest_commit_info(config_path)
+            
         entries.append({
             "log_type": log_type.strip().upper(),
             "config_path": config_path.as_posix(),
             "metadata_path": metadata_path.as_posix(),
             "vendor": meta.get("vendor", ""),
             "product": meta.get("product", ""),
-            "source": source_type
+            "source": source_type,
+            "latest_commit_id": commit_id,
+            "latest_commit_time": commit_time
         })
         
     # Sort entries alphabetically by log type and config path to prevent ordering variance


### PR DESCRIPTION
This PR updates the existing parser indexing mechanism to track the latest commit ID for each parser's configuration file. This is a prerequisite for implementing the `FetchParserCandidates` RPC.
1.  **Python Script Update (`tools/parsers/scripts/generate_index.py`):**
    *   Added `get_latest_commit_id` helper to query the git history for each `.conf` file using `git log`.
    *   Appended `latest_commit_id` field to each entry in `COMMUNITY_INDEX.json` and `PARTNER_INDEX.json`.
2.  **GitHub Actions Workflow Update (`.github/workflows/auto_update_index.yml`):**
    *   Configured the checkout step to use `fetch-depth: 0` (full clone) to ensure the git history is available for resolving commit SHAs.