### PR TITLE
fix(socradar_xti): strip feed API key + map hostname feed_type to domain

### DIFF
--- a/content/response_integrations/third_party/partner/socradar_xti/actions/AddComment.py
+++ b/content/response_integrations/third_party/partner/socradar_xti/actions/AddComment.py
@@ -21,10 +21,15 @@ def main() -> None:
     )
     alarm_id = siemplify.extract_action_param("Alarm ID", is_mandatory=True)
     comment = siemplify.extract_action_param("Comment", is_mandatory=True)
-    user_email = siemplify.extract_action_param("User Email", default_value="")
+    user_email = siemplify.extract_action_param("User Email", is_mandatory=True)
     try:
+        if not user_email or not user_email.strip():
+            raise ValueError(
+                "'User Email' is required: the SOCRadar API rejects comments "
+                "without a company user email."
+            )
         manager = SOCRadarManager(api_root, api_key, company_id, verify_ssl)
-        result = manager.add_comment(alarm_id, comment, user_email)
+        result = manager.add_comment(alarm_id, comment, user_email.strip())
         siemplify.result.add_result_json(result)
         siemplify.end(f"Comment added to alarm {alarm_id}.", True)
     except Exception as e:

--- a/content/response_integrations/third_party/partner/socradar_xti/actions/AddComment.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/actions/AddComment.yaml
@@ -17,6 +17,6 @@ parameters:
 - name: User Email
   type: string
   default_value: ''
-  is_mandatory: false
-  description: Email of the user posting the comment.
+  is_mandatory: true
+  description: Email of the company user posting the comment. Required by the SOCRadar API.
 script_result_name: is_success

--- a/content/response_integrations/third_party/partner/socradar_xti/core/SOCRadarManager.py
+++ b/content/response_integrations/third_party/partner/socradar_xti/core/SOCRadarManager.py
@@ -40,7 +40,7 @@ class SOCRadarManager:
     def __init__(self, api_root: str, api_key: str, company_id: str | int, verify_ssl: bool = True) -> None:
         """Initialize SOCRadarManager with API credentials."""
         self.api_root: str = (api_root or "https://platform.socradar.com/api").rstrip("/")
-        self.api_key: str = api_key
+        self.api_key: str = (api_key or "").strip()
         self.company_id: str = str(company_id)
         self.verify_ssl: bool = verify_ssl
         self.session: requests.Session = requests.Session()
@@ -406,7 +406,9 @@ class SOCRadarManager:
             try:
                 resp = self.session.get(url, params=params, timeout=60)
                 if resp.status_code == 401:
-                    raise SOCRadarManagerError("Unauthorized - check your API key")
+                    raise SOCRadarManagerError(
+                        f"Unauthorized - check your API key. Response body: {resp.text[:200]}"
+                    )
                 if 400 <= resp.status_code < 500:
                     raise SOCRadarManagerError(f"Feed request error {resp.status_code} for {collection_uuid}")
                 resp.raise_for_status()

--- a/content/response_integrations/third_party/partner/socradar_xti/jobs/SyncIOCFeeds.py
+++ b/content/response_integrations/third_party/partner/socradar_xti/jobs/SyncIOCFeeds.py
@@ -2,13 +2,18 @@
 Sync IOC Feeds Job
 ==================
 Scheduled job that fetches IOCs from configured SOCRadar Threat Feed
-collections and writes them to Chronicle SIEM reference lists.
+collections and writes them to Google SecOps SOAR Custom Lists.
 
 Runs daily (or at configured interval). Groups IOCs by type
-(ip, domain, hash, url) and updates one reference list per type.
+(ip, domain, hash, url) and writes one Custom List category per type.
+
+Note: the SOAR SDK (SiemplifyJob) exposes Custom Lists, not SIEM reference
+lists, so each IOC is stored as a Custom List entry (category = list name,
+identifier = IOC value) scoped to the configured environment.
 """
 from __future__ import annotations
 
+from soar_sdk.SiemplifyDataModel import CustomList
 from soar_sdk.SiemplifyJob import SiemplifyJob
 from soar_sdk.SiemplifyUtils import output_handler
 
@@ -17,13 +22,19 @@ from ..core.SOCRadarManager import SOCRadarManager
 INTEGRATION_NAME = "SOCRadar"
 JOB_NAME = "SOCRadar - Sync IOC Feeds"
 
-# Reference list name prefix — creates lists like:
+# Custom List category prefix — creates categories like:
 # SOCRadar_IOC_ip, SOCRadar_IOC_domain, SOCRadar_IOC_hash, SOCRadar_IOC_url
 REFERENCE_LIST_PREFIX = "SOCRadar_IOC"
 
+# Max Custom List entries sent per API call (bounds request size for large feeds).
+CUSTOM_LIST_BATCH_SIZE = 1000
+
+# Default SOAR environment for Custom List entries when none is configured.
+DEFAULT_ENVIRONMENT = "Default Environment"
+
 IOC_TYPES = ["ip", "domain", "hash", "url"]
 
-# Map SOCRadar feed_type values to reference-list bucket names.
+# Map SOCRadar feed_type values to custom-list bucket names.
 # NOTE: the feed returns domain IOCs as "hostname" (OpenAPI docs are wrong).
 FEED_TYPE_MAP = {
     "hostname": "domain", "domain": "domain",
@@ -67,6 +78,8 @@ def main() -> None:
             max_iocs = 5000
         list_prefix = siemplify.extract_job_param("Reference List Prefix",
                                                    default_value=REFERENCE_LIST_PREFIX)
+        environment = siemplify.extract_job_param("Environment",
+                                                  default_value=DEFAULT_ENVIRONMENT)
 
         uuids = _parse_uuids(uuids_raw)
         uuids = list(dict.fromkeys(uuids))  # Deduplicate, preserve order
@@ -107,24 +120,44 @@ def main() -> None:
                 siemplify.LOGGER.error(f"Failed to process UUID {uuid}: {e}")
                 feed_stats["error"] += 1
 
-        # Update Chronicle SIEM reference lists
+        # Write IOCs to SOAR Custom Lists (one category per IOC type).
+        lists_written = 0
+        lists_failed = 0
+        lists_with_values = 0
         for ioc_type in IOC_TYPES:
             values = sorted(iocs_by_type[ioc_type])
             if not values:
                 siemplify.LOGGER.info(f"No {ioc_type} IOCs to sync, skipping")
                 continue
 
+            lists_with_values += 1
             list_name = f"{list_prefix}_{ioc_type}"
             try:
-                siemplify.add_values_to_custom_list(list_name, values)
-                siemplify.LOGGER.info(f"Updated reference list '{list_name}' with {len(values)} entries")
+                for start in range(0, len(values), CUSTOM_LIST_BATCH_SIZE):
+                    batch = values[start:start + CUSTOM_LIST_BATCH_SIZE]
+                    custom_list_items = [
+                        CustomList(value, list_name, environment) for value in batch
+                    ]
+                    siemplify.add_entities_to_custom_list(custom_list_items)
+                lists_written += 1
+                siemplify.LOGGER.info(
+                    f"Updated custom list '{list_name}' with {len(values)} entries"
+                )
             except Exception as e:
-                siemplify.LOGGER.error(f"Failed to update reference list '{list_name}': {e}")
+                lists_failed += 1
+                siemplify.LOGGER.error(f"Failed to update custom list '{list_name}': {e}")
 
         siemplify.LOGGER.info(
             f"Sync complete. Feeds: {feed_stats['success']} OK / {feed_stats['error']} failed. "
+            f"Lists: {lists_written} written / {lists_failed} failed. "
             f"Total IOCs processed: {feed_stats['total_iocs']}"
         )
+
+        # A run that fetched IOCs but wrote none is a failure, not a success.
+        if lists_with_values and lists_written == 0:
+            raise RuntimeError(
+                f"All {lists_failed} custom list update(s) failed; no IOCs were written to SOAR."
+            )
 
     except Exception as e:
         siemplify.LOGGER.error(f"Job failed: {e}")

--- a/content/response_integrations/third_party/partner/socradar_xti/jobs/SyncIOCFeeds.py
+++ b/content/response_integrations/third_party/partner/socradar_xti/jobs/SyncIOCFeeds.py
@@ -23,6 +23,15 @@ REFERENCE_LIST_PREFIX = "SOCRadar_IOC"
 
 IOC_TYPES = ["ip", "domain", "hash", "url"]
 
+# Map SOCRadar feed_type values to reference-list bucket names.
+# NOTE: the feed returns domain IOCs as "hostname" (OpenAPI docs are wrong).
+FEED_TYPE_MAP = {
+    "hostname": "domain", "domain": "domain",
+    "ip": "ip", "ipv4": "ip", "ipv6": "ip",
+    "url": "url",
+    "hash": "hash", "md5": "hash", "sha1": "hash", "sha256": "hash",
+}
+
 
 def _parse_uuids(raw: str | None) -> list[str]:
     """Parse comma/newline/semicolon separated UUIDs."""
@@ -84,9 +93,9 @@ def main() -> None:
                 for ioc in feed_data[:max_iocs]:
                     if not isinstance(ioc, dict):
                         continue
-                    ioc_type = str(ioc.get("feed_type") or "").lower()
+                    ioc_type = FEED_TYPE_MAP.get(str(ioc.get("feed_type") or "").lower().strip())
                     ioc_value = str(ioc.get("feed") or "").strip()
-                    if ioc_type in iocs_by_type and ioc_value:
+                    if ioc_type and ioc_value:
                         iocs_by_type[ioc_type].add(ioc_value)
                         count += 1
 

--- a/content/response_integrations/third_party/partner/socradar_xti/jobs/SyncIOCFeeds.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/jobs/SyncIOCFeeds.yaml
@@ -13,7 +13,12 @@ parameters:
     -   name: Reference List Prefix
         default_value: SOCRadar_IOC
         type: string
-        description: "Prefix for Chronicle SIEM reference list names. Creates: {prefix}_ip, {prefix}_domain, {prefix}_hash, {prefix}_url."
+        description: "Prefix for the SOAR Custom List categories. Creates: {prefix}_ip, {prefix}_domain, {prefix}_hash, {prefix}_url."
+        is_mandatory: false
+    -   name: Environment
+        default_value: Default Environment
+        type: string
+        description: SOAR environment that the Custom List entries are written to.
         is_mandatory: false
     -   name: API Root
         default_value: https://platform.socradar.com/api
@@ -37,7 +42,7 @@ parameters:
         is_mandatory: false
 description: >
   Scheduled job that fetches IOCs from configured SOCRadar Threat Feed collections
-  and writes them to Chronicle SIEM reference lists. Creates one list per IOC type
+  and writes them to SOAR Custom Lists. Creates one Custom List category per IOC type
   (ip, domain, hash, url). Run daily to keep threat intelligence feeds current.
 integration: SOCRadar
 creator: SOCRadar

--- a/content/response_integrations/third_party/partner/socradar_xti/pyproject.toml
+++ b/content/response_integrations/third_party/partner/socradar_xti/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SOCRadar"
-version = "3.0"
+version = "4.0"
 description = "Bidirectional integration between SOCRadar Extended Threat Intelligence (XTI) and Google SecOps SOAR. Ingests SOCRadar alarms as cases, provides IOC enrichment, threat feed collection, rapid reputation lookups, and full alarm lifecycle management. Support: integration@socradar.io"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
@@ -29,12 +29,17 @@
   publish_time: '2026-07-17'
   ticket_number: ''
 - description: >
-    Fixed the Sync IOC Feeds job silently dropping domain IOCs — the threat feed
+    Sync IOC Feeds job: fixed IOC writes failing entirely (the job called a
+    non-existent SiemplifyJob method) — IOCs are now written to SOAR Custom Lists
+    via add_entities_to_custom_list, with per-list error handling, an honest
+    "lists written / failed" summary, and the run now fails when no list could be
+    written. Also fixed the job silently dropping domain IOCs — the threat feed
     returns them with feed_type "hostname" (not "domain"), so a normalization map
-    now routes hostname/ip/hash variants to the correct reference lists. Also
-    trimmed the threat-feed API key, since the query-parameter auth used by the
-    feed endpoint is not trimmed server-side and a stray whitespace/newline caused
-    a 401. The 401 error now includes the server response body for easier diagnosis.
+    now routes hostname/ip/hash variants to the correct list. Trimmed the
+    threat-feed API key (the feed endpoint's query-parameter auth is not trimmed
+    server-side, so a stray whitespace/newline caused a 401) and included the
+    server response body in the 401 error. Add Comment: User Email is now required,
+    matching the SOCRadar API which rejects comments without a company user email.
   version: 4.0
   item_name: SOCRadar
   item_type: Integration

--- a/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/socradar_xti/release_notes.yaml
@@ -28,3 +28,15 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: >
+    Fixed the Sync IOC Feeds job silently dropping domain IOCs — the threat feed
+    returns them with feed_type "hostname" (not "domain"), so a normalization map
+    now routes hostname/ip/hash variants to the correct reference lists. Also
+    trimmed the threat-feed API key, since the query-parameter auth used by the
+    feed endpoint is not trimmed server-side and a stray whitespace/newline caused
+    a 401. The 401 error now includes the server response body for easier diagnosis.
+  version: 4.0
+  item_name: SOCRadar
+  item_type: Integration
+  publish_time: '2026-07-25'
+  ticket_number: ''

--- a/content/response_integrations/third_party/partner/socradar_xti/uv.lock
+++ b/content/response_integrations/third_party/partner/socradar_xti/uv.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "socradar"
-version = "3.0"
+version = "4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary
Two bug fixes for the SOCRadar XTI **Sync IOC Feeds** job and its threat-feed client:

- **Domain IOCs were silently dropped.** The threat feed returns domain indicators with `feed_type="hostname"` (the OpenAPI docs incorrectly say `"domain"`), so they never matched the exact `IOC_TYPES` list and the `SOCRadar_IOC_domain` reference list always stayed empty. A new `FEED_TYPE_MAP` normalizes `hostname`→`domain` plus the `ipv4`/`ipv6`/`md5`/`sha1`/`sha256` variants to their correct buckets.
- **Feed API key not trimmed → 401.** The feed endpoint authenticates via a `?key=` query parameter. Unlike the `API-Key` header endpoints (which the server trims), query values are not trimmed server-side, so a stray leading/trailing space or newline in the key caused a `401`. The key is now trimmed once via `.strip()` in `__init__`, and the `401` error now includes the server response body for easier diagnosis.
- **Sync IOC Feeds wrote zero IOCs**: it called SiemplifyJob.add_values_to_custom_list,
  which does not exist in the target SDK, so every list write failed while the run
  still reported success. It now writes to SOAR Custom Lists via
  add_entities_to_custom_list (new Environment job param), reports lists written/failed
  honestly, and fails the run if none could be written. (Found during live regression
  testing; the feed fix above is inert without it.)
- **Add Comment**: User Email was declared optional but the SOCRadar API rejects comments
  without it — now marked required and validated in the script.

## Version
- Bumped integration version `3.0 → 4.0` (major, per marketplace policy).
- Added a `release_notes.yaml` entry (version `4.0`, ordered last).
- Updated `uv.lock` to match.

## Test plan
- [x] `python -m py_compile` passes on both changed modules.
- [x] Existing manager unit test (`feed_type="ip"`) is unaffected — `ip` still maps to the `ip` bucket.
- [x] Verify on a SOAR tenant: a feed collection containing all four types populates `SOCRadar_IOC_ip`/`_domain`/`_hash`/`_url`, and the log reads `Feeds: 1 OK / 0 failed`.
- [x] Verify the feed call still succeeds when the API key is entered with leading/trailing whitespace.