### PR TITLE
ci: fix parser index workflow to trigger on PRs and support forks

### DIFF
--- a/.github/workflows/update_index.yml
+++ b/.github/workflows/update_index.yml
@@ -4,6 +4,10 @@ on:
     paths:
       - 'content/parsers/third_party/community/**'
       - 'content/parsers/third_party/partner/**'
+  pull_request_target: # Triggers on PRs (including from forks) and allows access to secrets
+    paths:
+      - 'content/parsers/third_party/community/**'
+      - 'content/parsers/third_party/partner/**'
   workflow_dispatch:
 
 permissions:
@@ -16,8 +20,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
-          # Fetch all history so git log can find commit SHAs and timestamps for parser files
+          # Fallback to default token if GH_PAT is missing (e.g. on forks)
+          token: ${{ secrets.GH_PAT || github.token }}
+          # Checkout the fork's repository if it's a PR, otherwise default to base repository
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Checkout the PR branch if it's a PR, otherwise default to the pushed branch
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          # Fetch all history so git log can find commit SHAs and timestamps
           fetch-depth: 0
 
       - name: Setup Python
@@ -38,5 +47,6 @@ jobs:
             echo "No index files were changed. Skipping commit."
           else
             git commit -m "Automated update of parser indexes [skip ci]"
-            git push origin HEAD:${{ github.ref }}
+            # Push back to the correct branch on the correct remote
+            git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref }}
           fi

--- a/.github/workflows/update_index.yml
+++ b/.github/workflows/update_index.yml
@@ -4,7 +4,7 @@ on:
     paths:
       - 'content/parsers/third_party/community/**'
       - 'content/parsers/third_party/partner/**'
-  pull_request_target: # Triggers on PRs (including from forks) and allows access to secrets
+  pull_request_target: # Triggers on PRs (including forks) and allows access to secrets
     paths:
       - 'content/parsers/third_party/community/**'
       - 'content/parsers/third_party/partner/**'
@@ -38,6 +38,9 @@ jobs:
         run: python3 tools/parsers/scripts/generate_index.py
 
       - name: Commit and Push changes
+        # SECURITY FIX: Pass the target branch as an env variable to prevent shell injection
+        env:
+          TARGET_REF: ${{ github.event.pull_request.head.ref || github.ref }}
         run: |
           git config --global user.name "secops-parsers-helper-bot"
           git config --global user.email "secops-parsers-helper-bot@google.com"
@@ -47,6 +50,6 @@ jobs:
             echo "No index files were changed. Skipping commit."
           else
             git commit -m "Automated update of parser indexes [skip ci]"
-            # Push back to the correct branch on the correct remote
-            git push origin HEAD:${{ github.event.pull_request.head.ref || github.ref }}
+            # SECURITY FIX: Reference the env variable with double quotes
+            git push origin HEAD:"$TARGET_REF"
           fi


### PR DESCRIPTION
### Description 
This PR updates the GitHub Actions workflow `auto_update_index.yml` to trigger on Pull Requests and support automatic index updates for external contributions coming from forks.
Key changes:
1.  **Added `pull_request_target` trigger:** Allows the workflow to execute when a PR is opened or updated, enabling it to run as a PR check.
2.  **Fork Compatibility in Checkout:** 
    *   Updated the `actions/checkout` step to dynamically checkout the correct fork repository (`github.event.pull_request.head.repo.full_name`) and branch (`github.event.pull_request.head.ref`) when triggered by a PR.
    *   Implemented a fallback token: `token: ${{ secrets.GH_PAT || github.token }}`. This ensures the workflow doesn't crash on forks where `secrets.GH_PAT` is not defined, falling back to the local write-accessible token.
3.  **Targeted Push:** Updated the final `git push` step to push back specifically to the HEAD of the PR branch.


### Why are these changes necessary?
1.  **PR Execution:** The previous workflow only triggered on `push` events. This meant the auto-update only ran for internal developers pushing branches directly to the main repo, but did not trigger at all when external contributors opened a PR from a fork.
2.  **Fork Write Permissions:** Standard `pull_request` events are restricted to read-only access for forks to prevent security issues. By using `pull_request_target`, we grant the runner the permission to write back the generated index files to the contributor's PR branch, ensuring the index is always up-to-date before merge.
3.  **Local Testing Safety:** The token fallback allows developers to test the workflow on their own forks without needing the main repo's `GH_PAT` secret.