### PR TITLE
ci: securely enable pull_request_target with double-checkout

### DIFF
--- a/.github/workflows/update_index.yml
+++ b/.github/workflows/update_index.yml
@@ -4,6 +4,10 @@ on:
     paths:
       - 'content/parsers/third_party/community/**'
       - 'content/parsers/third_party/partner/**'
+  pull_request_target: # Triggers on PRs (including forks) and allows access to secrets
+    paths:
+      - 'content/parsers/third_party/community/**'
+      - 'content/parsers/third_party/partner/**'
   workflow_dispatch:
 
 permissions:
@@ -13,23 +17,44 @@ jobs:
   update-index:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      # 1. Checkout the TRUSTED base repository (main branch)
+      # We check this out to the 'trusted-base' folder to get the secure script.
+      - name: Checkout trusted base repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
-          # Fetch all history so git log can find commit SHAs and timestamps for parser files
+          path: trusted-base
+
+      # 2. Checkout the UNTRUSTED PR repository (the code we want to index)
+      # We check this out to the 'pr-repo' folder.
+      - name: Checkout PR repository
+        uses: actions/checkout@v4
+        with:
+          # Fallback to default token if GH_PAT is missing (e.g. on forks)
+          token: ${{ secrets.GH_PAT || github.token }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          # Fetch all history so git log can find commit SHAs and timestamps
           fetch-depth: 0
+          path: pr-repo
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
+      # 3. Run the script from the trusted directory, but run it inside the PR directory
+      # This ensures we only execute trusted code while scanning the PR files.
       - name: Generate Index
-        run: python3 tools/parsers/scripts/generate_index.py
-
-      - name: Commit and Push changes
         run: |
+          cd pr-repo
+          python3 ../trusted-base/tools/parsers/scripts/generate_index.py
+
+      # 4. Commit and push the changes inside the PR directory
+      - name: Commit and Push changes
+        env:
+          TARGET_REF: ${{ github.event.pull_request.head.ref || github.ref }}
+        run: |
+          cd pr-repo
           git config --global user.name "secops-parsers-helper-bot"
           git config --global user.email "secops-parsers-helper-bot@google.com"
           git add content/parsers/third_party/COMMUNITY_INDEX.json content/parsers/third_party/PARTNER_INDEX.json
@@ -38,5 +63,5 @@ jobs:
             echo "No index files were changed. Skipping commit."
           else
             git commit -m "Automated update of parser indexes [skip ci]"
-            git push origin HEAD:${{ github.ref }}
+            git push origin HEAD:"$TARGET_REF"
           fi


### PR DESCRIPTION
### Description
This PR securely enables the GitHub Actions workflow to run on Pull Requests (including those from forks) and automatically commit the updated index files back to the PR branch.
It implements the following security patterns to satisfy CodeQL and GitHub Advanced Security:
1.  **Double-Checkout Pattern (Security Fix for `pull_request_target`):**
    *   To prevent execution of untrusted code in a privileged context, we separate the executable script from the untrusted PR files.
    *   **Trusted Checkout:** We check out the base repository (`main` branch) to a `trusted-base` directory. The index generation script is executed *only* from this trusted folder.
    *   **Untrusted Checkout:** We check out the PR branch (which may come from a fork) to a `pr-repo` directory. The script is run *inside* this directory to scan the parser files and write the updated indexes, but no code from this directory is executed.
2.  **Shell Injection Prevention:**
    *   Moved the target branch expression `${{ github.event.pull_request.head.ref || github.ref }}` into an environment variable (`TARGET_REF`) in the push step.
    *   Referenced it safely as `"$TARGET_REF"` in the bash script to prevent shell injection from malicious branch names.
3.  **Fork Token Fallback:**
    *   Uses `token: ${{ secrets.GH_PAT || github.token }}` to ensure the workflow can fall back to the local token when run on forks where the secret is unavailable.
### Why?
We need the indexing bot to run on PRs so that maintainers can verify the index is up-to-date before merging. 
Because we want the bot to automatically commit the updated index files back to the contributor's PR branch (even for external contributors using forks), we must use `pull_request_target`. These changes ensure we use this privileged context securely without exposing the repository to code injection vulnerabilities.