### PR TITLE
[Buganizer ID: 542044187] Feature: Add multi-prompt engine and custom prompt options for action describe

### DIFF
--- a/packages/mp/docs/commands/describe.md
+++ b/packages/mp/docs/commands/describe.md
@@ -14,15 +14,46 @@ mp describe action [ACTIONS]... [OPTIONS]
 
 ### Options
 
-| Option          | Shorthand | Description                                                                                  | Type   | Default |
-|:----------------|:----------|:---------------------------------------------------------------------------------------------|:-------|:--------|
-| `--integration` | `-i`      | The name of the integration containing the actions.                                          | `str`  | `None`  |
-| `--all`         | `-a`      | Describe all integrations in the marketplace, or all actions if an integration is specified. | `bool` | `False` |
-| `--src`         |           | Customize source folder to describe from.                                                    | `path` | `None`  |
-| `--dst`         |           | Customize destination folder to save the AI descriptions.                                    | `path` | `None`  |
-| `--quiet`       | `-q`      | Log less on runtime.                                                                         | `bool` | `False` |
-| `--verbose`     | `-v`      | Log more on runtime.                                                                         | `bool` | `False` |
-| `--override`    | `-o`      | Rewrite actions that already have a description.                                             | `bool` | `False` |
+| Option               | Shorthand | Description                                                                                  | Type   | Default |
+|:---------------------|:----------|:---------------------------------------------------------------------------------------------|:-------|:--------|
+| `--integration`      | `-i`      | The name of the integration containing the actions.                                          | `str`  | `None`  |
+| `--all`              | `-a`      | Describe all integrations in the marketplace, or all actions if an integration is specified. | `bool` | `False` |
+| `--src`              |           | Customize source folder to describe from.                                                    | `path` | `None`  |
+| `--dst`              |           | Customize destination folder to save the AI descriptions.                                    | `path` | `None`  |
+| `--prompt-overrides` |           | Path to JSON prompt configuration file to override prompts for specific fields.              | `path` | `None`  |
+| `--quiet`            | `-q`      | Log less on runtime.                                                                         | `bool` | `False` |
+| `--verbose`          | `-v`      | Log more on runtime.                                                                         | `bool` | `False` |
+| `--override`         | `-o`      | Rewrite actions that already have a description.                                             | `bool` | `False` |
+
+#### Prompt Overrides Configuration
+
+When `--prompt-overrides` is provided, custom prompt templates and field schema specifications can be defined for individual fields. Supplementary LLM calls are made using these custom prompts and schemas to override specific fields in the baseline description.
+
+Expected JSON Configuration Schema:
+
+```json
+{
+  "prompt_config": [
+    {
+      "location": "/path/to/ai_description.md",
+      "field_name": "ai_description"
+    },
+    {
+      "location": "/path/to/prompt.md",
+      "field_name": "field_with_undefined_schema",
+      "schema": {
+        "model_name": "Model",
+        "type": "string",
+        "description": "Description of the field we do not have schema defined in code.",
+        "required": true
+      }
+    }
+  ]
+}
+```
+
+If `--prompt-overrides` is omitted or empty, the original baseline result is returned without modifications.
+
 
 ## `mp describe connector`
 

--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.34.0"
+version = "1.35.0"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/core/data_models/integrations/action/ai/metadata.py
+++ b/packages/mp/src/mp/core/data_models/integrations/action/ai/metadata.py
@@ -22,85 +22,87 @@ from .capabilities import ActionCapabilities  # ruff:ignore[typing-only-first-pa
 from .entity_usage import EntityUsage  # ruff:ignore[typing-only-first-party-import]
 from .outcome_categories import OutcomeCategories  # ruff:ignore[typing-only-first-party-import]
 
+# --- Shared Description Constants ---
+
+ACTION_AI_DESCRIPTION = (
+    "Detailed description that will be used by LLMs to understand what the action does."
+    " This should be an informative summary of the action's purpose and expected outcome."
+    " Use markdown formatting for clarity, as this is a description for LLMs."
+    " The description must be divided into 3 distinct sections: 'General Description',"
+    " 'Flow Description', and 'Additional Notes'."
+    " Under the 'Flow Description' section, please add a description of the flow of the action"
+    " in numbered or bulleted points to describe each stage of the action logically."
+    " If an API call is being made during the execution of this action, it must be explicitly"
+    " mentioned and detailed within this flow description."
+)
+
+ACTION_AI_SHORT_DESCRIPTION = (
+    "A concise, high-level summary of the action's primary purpose and expected outcome."
+    " This should be a direct, single-paragraph distillation of the 'General Description'"
+    " designed for quick LLM parsing, completely free of step-by-step flow overhead"
+    " or parameter details."
+)
+
+PARAMETERS_DESCRIPTION = (
+    "Detailed description of the action's parameters, formatted using markdown for LLM clarity."
+    "CRITICAL SOURCE CONSTRAINT: You must extract parameter information EXCLUSIVELY from the action's "
+    "parameters list (under 'Parameters' or 'parameters' key in the metadata definitions). You "
+    "are strictly forbidden from including, inferring, or falling back to any integration-level parameters "
+    "(including parameters retrieved via siemplify.extract_configuration_param or listed under "
+    "integration-level configurations)."
+    "Create a table that describes these action-specific parameters with the following columns: "
+    "Parameter, Type, Mandatory, Description."
+    "The Description column should explain how to use the parameter and how it might affect the action's flow."
+    "If there are no action-specific parameters defined, you must NOT generate a table. Instead, "
+    "set this field value exactly to: 'There are no parameters for this action'."
+    "If a parameter is not mandatory but code execution requires it based on the presence of other "
+    "parameters, mention this relationship within its specific row description, or add an optional "
+    "'Parameter Notes' section below the table (e.g., 'Either this set of parameters or this set of "
+    "parameters must be configured')."
+)
+
+ENTITY_USAGE_DESCRIPTION = (
+    "A detailed set of properties that describe how the action uses entities."
+    " Determine each of the fields by going over the code."
+)
+
+OUTCOME_CATEGORIES_DESCRIPTION = (
+    "Describes what the action achieves - its expected outcomes."
+    " This field classifies the action based on what it does, rather than how it operates."
+)
+
+CAPABILITIES_DESCRIPTION = (
+    "Fields that describe how the action operates. Determine these fields based on the"
+    " metadata json and the code itself."
+)
+
+
+# --- Action AI Metadata Model ---
 
 class ActionAiMetadata(BaseModel):
     ai_description: Annotated[
         str,
-        Field(
-            description=(
-                "Detailed description that will be used by LLMs to understand what the action does."
-                " This should be an informative summary of the action's purpose and expected outcome."
-                " Use markdown formatting for clarity, as this is a description for LLMs."
-                " The description must be divided into 3 distinct sections: 'General Description',"
-                " 'Flow Description', and 'Additional Notes'."
-                " Under the 'Flow Description' section, please add a description of the flow of the action"
-                " in numbered or bulleted points to describe each stage of the action logically."
-                " If an API call is being made during the execution of this action, it must be explicitly"
-                " mentioned and detailed within this flow description."
-            ),
-        ),
+        Field(description=ACTION_AI_DESCRIPTION),
     ]
     ai_short_description: Annotated[
         str,
-        Field(
-            description=(
-                "A concise, high-level summary of the action's primary purpose and expected outcome."
-                " This should be a direct, single-paragraph distillation of the 'General Description'"
-                " designed for quick LLM parsing, completely free of step-by-step flow overhead"
-                " or parameter details."
-            ),
-        ),
+        Field(description=ACTION_AI_SHORT_DESCRIPTION),
     ]
     parameters_description: Annotated[
         str,
-        Field(
-            description=(
-                "Detailed description of the action's parameters, formatted using markdown for LLM clarity."
-                "CRITICAL SOURCE CONSTRAINT: You must extract parameter information EXCLUSIVELY from the action's "
-                "parameters list (under 'Parameters' or 'parameters' key in the metadata definitions). You "
-                "are strictly "
-                "forbidden from including, inferring, or falling back to any integration-level parameters "
-                "(including parameters retrieved via siemplify.extract_configuration_param or listed under "
-                "integration-level configurations)."
-                "Create a table that describes these action-specific parameters with the following columns: "
-                "Parameter, Type, Mandatory, Description."
-                "The Description column should explain how to use the parameter and how it might affect the "
-                "action's flow."
-                "If there are no action-specific parameters defined, you must NOT generate a table. Instead, "
-                "set this field value exactly to: 'There are no parameters for this action'."
-                "If a parameter is not mandatory but code execution requires it based on the presence of other "
-                "parameters, mention this relationship within its specific row description, or add an optional "
-                "'Parameter Notes' section below the table (e.g., 'Either this set of parameters or this set of "
-                "parameters must be configured')."
-            ),
-        ),
+        Field(description=PARAMETERS_DESCRIPTION),
     ]
     entity_usage: Annotated[
         EntityUsage,
-        Field(
-            description=(
-                "A detailed set of properties that describe how the action uses entities."
-                " Determine each of the fields by going over the code."
-            ),
-        ),
+        Field(description=ENTITY_USAGE_DESCRIPTION),
     ]
     outcome_categories: Annotated[
         OutcomeCategories,
-        Field(
-            description=(
-                "Describes what the action achieves - its expected outcomes."
-                " This field classifies the action based on what it does, rather than how it operates."
-            ),
-        ),
+        Field(description=OUTCOME_CATEGORIES_DESCRIPTION),
     ]
     capabilities: Annotated[
         ActionCapabilities,
-        Field(
-            description=(
-                "Fields that describe how the action operates. Determine these fields based on the"
-                "metadata json and the code itself."
-            ),
-        ),
+        Field(description=CAPABILITIES_DESCRIPTION),
     ]
 
 

--- a/packages/mp/src/mp/describe/action/describe.py
+++ b/packages/mp/src/mp/describe/action/describe.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import anyio
 import yaml
-from pydantic import BaseModel
 
 from mp.core import constants
 from mp.core.data_models.integrations.action.ai.metadata import ActionAiMetadata
@@ -38,6 +37,7 @@ if TYPE_CHECKING:
     import asyncio
     from collections.abc import Callable
 
+    from pydantic import BaseModel
     from rich.progress import Progress
 
     from mp.core.data_models.integrations.action.metadata import BuiltActionMetadata, NonBuiltActionMetadata
@@ -285,11 +285,12 @@ class MultiPromptDescribeAction(DescribeAction):
         """
         anyio_loc = anyio.Path(location_path)
         if not await anyio_loc.exists():
-            raise FileNotFoundError(f"Custom prompt location '{location_path}' does not exist.")
+            error_msg = f"Custom prompt location '{location_path}' does not exist."
+            raise FileNotFoundError(error_msg)
 
         return string.Template(await anyio_loc.read_text(encoding="utf-8"))
 
-    async def _apply_prompt_overrides(  # ruff:ignore[too-many-locals]
+    async def _apply_prompt_overrides(
         self,
         resources: list[str],
         status: IntegrationStatus,
@@ -323,7 +324,11 @@ class MultiPromptDescribeAction(DescribeAction):
             if target_model is None:
                 target_model = create_dynamic_field_model(override.field_name, override.schema_def)
 
-            logger.debug(f"Applying prompt override for field '{override.field_name}' from template '{location_path.name}'")
+            logger.debug(
+                "Applying prompt override for field '%s' from template '%s'",
+                override.field_name,
+                location_path.name,
+            )
 
             custom_prompts: list[str] = await self._construct_custom_prompts(resources, status, template)
             valid_indices: list[int] = [i for i, prompt in enumerate(custom_prompts) if prompt]
@@ -337,7 +342,12 @@ class MultiPromptDescribeAction(DescribeAction):
             for i, result in zip(valid_indices, llm_results, strict=True):
                 resource_name: str = resources[i]
                 if isinstance(result, str):
-                    logger.error(f"Failed custom describe for action {resource_name} field {override.field_name}: {result}")
+                    logger.error(
+                        "Failed custom describe for action %s field %s: %s",
+                        resource_name,
+                        override.field_name,
+                        result,
+                    )
                     continue
 
                 idx = name_to_idx.get(resource_name)
@@ -353,8 +363,10 @@ class MultiPromptDescribeAction(DescribeAction):
                     continue
 
                 logger.debug(
-                    f"Successfully overridden field '{override.field_name}' "
-                    f"for action '{resource_name}' with LLM response:\n{format_display_value(override_val)}",
+                    "Successfully overridden field '%s' for action '%s' with LLM response:\n%s",
+                    override.field_name,
+                    resource_name,
+                    format_display_value(override_val),
                 )
 
                 updated_meta = curr_meta.model_copy(update={override.field_name: override_val})

--- a/packages/mp/src/mp/describe/action/describe.py
+++ b/packages/mp/src/mp/describe/action/describe.py
@@ -16,23 +16,28 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, NamedTuple
+import pathlib
+import string
+from typing import TYPE_CHECKING, Any, NamedTuple
 
+import anyio
 import yaml
+from pydantic import BaseModel
 
 from mp.core import constants
 from mp.core.data_models.integrations.action.ai.metadata import ActionAiMetadata
-from mp.describe.common.describe import DescribeBase, IntegrationStatus
+from mp.describe.common.describe import DescribeBase, DescriptionResult, IntegrationStatus
+from mp.describe.common.utils import llm
 
+from .metadata import FIELD_TO_OVERRIDE_MODEL, PromptOverrideConfig, PromptOverridesFile
 from .prompt_constructors.built import BuiltPromptConstructor
 from .prompt_constructors.source import SourcePromptConstructor
+from .utils import create_dynamic_field_model, format_display_value
 
 if TYPE_CHECKING:
     import asyncio
-    import pathlib
     from collections.abc import Callable
 
-    import anyio
     from rich.progress import Progress
 
     from mp.core.data_models.integrations.action.metadata import BuiltActionMetadata, NonBuiltActionMetadata
@@ -163,3 +168,196 @@ def _create_prompt_constructor(
         params.action_file_name,
         params.status.out_path,
     )
+
+
+class MultiPromptDescribeAction(DescribeAction):
+    def __init__(  # ruff:ignore[too-many-arguments]
+        self,
+        integration: str,
+        actions: set[str],
+        *,
+        src: pathlib.Path | None = None,
+        dst: pathlib.Path | None = None,
+        override: bool = False,
+        prompt_overrides: pathlib.Path | None = None,
+    ) -> None:
+        super().__init__(integration, actions, src=src, dst=dst, override=override)
+        self.prompt_overrides_path: pathlib.Path | None = prompt_overrides
+
+    async def describe_bulk(
+        self,
+        resources: list[str],
+        status: IntegrationStatus,
+    ) -> list[DescriptionResult]:
+        """Describe multiple action resources in bulk with optional prompt overrides.
+
+        Args:
+            resources: Action resource names to describe.
+            status: Status of the integration content build.
+
+        Returns:
+            list[DescriptionResult]: The list of action description results.
+
+        """
+        baseline_results: list[DescriptionResult] = await super().describe_bulk(resources, status)
+
+        if not self.prompt_overrides_path:
+            return baseline_results
+
+        overrides: list[PromptOverrideConfig] = await self._load_prompt_overrides()
+        if not overrides:
+            return baseline_results
+
+        return await self._apply_prompt_overrides(resources, status, baseline_results, overrides)
+
+    async def _load_prompt_overrides(self) -> list[PromptOverrideConfig]:
+        """Load and parse prompt overrides configuration from JSON file.
+
+        Returns:
+            list[PromptOverrideConfig]: List of prompt override configuration items.
+
+        Raises:
+            FileNotFoundError: If the configured prompt overrides file does not exist.
+            ValueError: If the prompt overrides file contains invalid JSON.
+
+        """
+        if not self.prompt_overrides_path:
+            return []
+
+        path: anyio.Path = anyio.Path(self.prompt_overrides_path)
+        if not await path.exists():
+            error_msg = f"Prompt overrides file '{self.prompt_overrides_path}' does not exist."
+            logger.error(error_msg)
+            raise FileNotFoundError(error_msg)
+
+        try:
+            content: str = await path.read_text(encoding="utf-8")
+            if not content.strip():
+                return []
+            parsed = PromptOverridesFile.model_validate_json(content)
+        except Exception as exc:
+            error_msg = f"Failed to parse prompt overrides file '{self.prompt_overrides_path}': {exc}"
+            logger.exception(error_msg)
+            raise ValueError(error_msg) from exc
+        else:
+            return parsed.prompt_config
+
+    async def _construct_custom_prompts(
+        self, resources: list[str], status: IntegrationStatus, template: string.Template
+    ) -> list[str]:
+        """Construct custom prompts for actions using a custom template.
+
+        Args:
+            resources: Action resource names to construct prompts for.
+            status: Status of the integration content build.
+            template: Custom prompt string Template.
+
+        Returns:
+            list[str]: Formatted custom prompt strings for each action.
+
+        """
+        prompts: list[str] = []
+        for action_name in resources:
+            params = DescriptionParams(
+                self.integration,
+                self.integration_name,
+                action_name,
+                self._action_name_to_file_stem.get(action_name, action_name),
+                status,
+            )
+            constructor: BuiltPromptConstructor | SourcePromptConstructor = _create_prompt_constructor(params)
+            prompts.append(await constructor.construct(template=template))
+        return prompts
+
+    @staticmethod
+    async def _load_template_content(location_path: pathlib.Path) -> string.Template:
+        """Load prompt template content from a file path.
+
+        Args:
+            location_path: Absolute or resolved path to prompt template file.
+
+        Returns:
+            string.Template: Constructed string Template object.
+
+        Raises:
+            FileNotFoundError: If the prompt template file does not exist.
+
+        """
+        anyio_loc = anyio.Path(location_path)
+        if not await anyio_loc.exists():
+            raise FileNotFoundError(f"Custom prompt location '{location_path}' does not exist.")
+
+        return string.Template(await anyio_loc.read_text(encoding="utf-8"))
+
+    async def _apply_prompt_overrides(  # ruff:ignore[too-many-locals]
+        self,
+        resources: list[str],
+        status: IntegrationStatus,
+        baseline_results: list[DescriptionResult],
+        overrides: list[PromptOverrideConfig],
+    ) -> list[DescriptionResult]:
+        """Apply custom prompt overrides sequentially to baseline description results.
+
+        Args:
+            resources: Action resource names to describe.
+            status: Status of the integration content build.
+            baseline_results: Baseline action description results.
+            overrides: Parsed list of prompt override configurations.
+
+        Returns:
+            list[DescriptionResult]: Updated action description results with field overrides applied.
+
+        """
+        name_to_idx: dict[str, int] = {res.name: i for i, res in enumerate(baseline_results)}
+        results: list[DescriptionResult] = list(baseline_results)
+
+        config_dir: pathlib.Path = (
+            self.prompt_overrides_path.parent if self.prompt_overrides_path else pathlib.Path.cwd()
+        )
+
+        for override in overrides:
+            location_path = override.resolve_location(config_dir)
+            template = await self._load_template_content(location_path)
+
+            target_model: type[BaseModel] | None = FIELD_TO_OVERRIDE_MODEL.get(override.field_name)
+            if target_model is None:
+                target_model = create_dynamic_field_model(override.field_name, override.schema_def)
+
+            logger.debug(f"Applying prompt override for field '{override.field_name}' from template '{location_path.name}'")
+
+            custom_prompts: list[str] = await self._construct_custom_prompts(resources, status, template)
+            valid_indices: list[int] = [i for i, prompt in enumerate(custom_prompts) if prompt]
+            valid_prompts: list[str] = [custom_prompts[i] for i in valid_indices]
+
+            if not valid_prompts:
+                continue
+
+            llm_results: list[Any | str] = await llm.call_gemini_bulk(valid_prompts, target_model)
+
+            for i, result in zip(valid_indices, llm_results, strict=True):
+                resource_name: str = resources[i]
+                if isinstance(result, str):
+                    logger.error(f"Failed custom describe for action {resource_name} field {override.field_name}: {result}")
+                    continue
+
+                idx = name_to_idx.get(resource_name)
+                if idx is None:
+                    continue
+
+                curr_meta = results[idx].metadata
+                if curr_meta is None:
+                    continue
+
+                override_val = getattr(result, override.field_name, None)
+                if override_val is None:
+                    continue
+
+                logger.debug(
+                    f"Successfully overridden field '{override.field_name}' "
+                    f"for action '{resource_name}' with LLM response:\n{format_display_value(override_val)}",
+                )
+
+                updated_meta = curr_meta.model_copy(update={override.field_name: override_val})
+                results[idx] = DescriptionResult(resource_name, updated_meta)
+
+        return results

--- a/packages/mp/src/mp/describe/action/describe_all.py
+++ b/packages/mp/src/mp/describe/action/describe_all.py
@@ -19,11 +19,16 @@ from pathlib import Path
 from mp.describe.common.describe_all import MarketplaceOrchestratorBase, get_all_integrations_paths
 from mp.describe.common.utils.paths import get_integration_path
 
-from .describe import DescribeAction
+from .describe import MultiPromptDescribeAction
 
 
 async def describe_all_actions(
-    src: Path | None = None, dst: Path | None = None, *, override: bool = False, integrations: list[str] | None = None
+    src: Path | None = None,
+    dst: Path | None = None,
+    *,
+    override: bool = False,
+    integrations: list[str] | None = None,
+    prompt_overrides: Path | None = None,
 ) -> None:
     """Describe all actions in all integrations in the marketplace or specific ones."""
     integrations_paths: list[Path]
@@ -32,16 +37,30 @@ async def describe_all_actions(
     else:
         integrations_paths = get_all_integrations_paths(src=src)
 
-    orchestrator = _MarketplaceOrchestrator(src, integrations_paths, dst=dst, override=override)
+    orchestrator = _MarketplaceOrchestrator(
+        src, integrations_paths, dst=dst, override=override, prompt_overrides=prompt_overrides
+    )
     await orchestrator.run()
 
 
 class _MarketplaceOrchestrator(MarketplaceOrchestratorBase):
-    def _create_describer(self, integration_name: str) -> DescribeAction:
-        return DescribeAction(
+    def __init__(
+        self,
+        src: Path | None,
+        integrations: list[Path],
+        dst: Path | None = None,
+        override: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument,boolean-default-value-positional-argument]
+        prompt_overrides: Path | None = None,
+    ) -> None:
+        super().__init__(src, integrations, dst=dst, override=override)
+        self.prompt_overrides: Path | None = prompt_overrides
+
+    def _create_describer(self, integration_name: str) -> MultiPromptDescribeAction:
+        return MultiPromptDescribeAction(
             integration=integration_name,
             actions=set(),
             src=self.src,
             dst=self.dst,
             override=self.override,
+            prompt_overrides=self.prompt_overrides,
         )

--- a/packages/mp/src/mp/describe/action/metadata.py
+++ b/packages/mp/src/mp/describe/action/metadata.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pathlib
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from mp.core.data_models.integrations.action.ai.capabilities import (
+    ActionCapabilities,  # ruff:ignore[typing-only-first-party-import]
+)
+from mp.core.data_models.integrations.action.ai.entity_usage import (
+    EntityUsage,  # ruff:ignore[typing-only-first-party-import]
+)
+from mp.core.data_models.integrations.action.ai.metadata import (
+    ACTION_AI_DESCRIPTION,
+    ACTION_AI_SHORT_DESCRIPTION,
+    CAPABILITIES_DESCRIPTION,
+    ENTITY_USAGE_DESCRIPTION,
+    OUTCOME_CATEGORIES_DESCRIPTION,
+    PARAMETERS_DESCRIPTION,
+)
+from mp.core.data_models.integrations.action.ai.outcome_categories import (
+    OutcomeCategories,  # ruff:ignore[typing-only-first-party-import]
+)
+
+_TYPE_MAPPING: dict[str, type] = {
+    "str": str,
+    "string": str,
+    "int": int,
+    "integer": int,
+    "float": float,
+    "number": float,
+    "bool": bool,
+    "boolean": bool,
+    "dict": dict,
+    "object": dict,
+    "list": list,
+    "array": list,
+}
+
+
+class FieldSchemaConfig(BaseModel):
+    """Configuration schema definition for custom prompt override fields."""
+
+    model_name: str | None = None
+    type: str | None = None
+    description: str | None = None
+    required: bool | None = None
+
+
+class PromptOverrideConfig(BaseModel):
+    """Configuration item mapping a prompt template file to a field override."""
+
+    location: str
+    field_name: str
+    schema_def: FieldSchemaConfig | None = Field(default=None, alias="schema")
+
+    def resolve_location(self, base_dir: pathlib.Path | None = None) -> pathlib.Path:
+        """Resolve prompt template path relative to base_dir if relative.
+
+        Args:
+            base_dir: Optional base directory to resolve relative paths against.
+
+        Returns:
+            pathlib.Path: Absolute or resolved path to the prompt template.
+
+        """
+        path = pathlib.Path(self.location)
+        if path.is_absolute() or base_dir is None:
+            return path
+        return (base_dir / path).resolve()
+
+
+class PromptOverridesFile(BaseModel):
+    """Root model for prompt overrides configuration JSON file."""
+
+    prompt_config: list[PromptOverrideConfig] = Field(default_factory=list)
+
+
+class AiDescriptionOverride(BaseModel):
+    ai_description: Annotated[str, Field(description=ACTION_AI_DESCRIPTION)]
+
+
+class AiShortDescriptionOverride(BaseModel):
+    ai_short_description: Annotated[str, Field(description=ACTION_AI_SHORT_DESCRIPTION)]
+
+
+class ParametersDescriptionOverride(BaseModel):
+    parameters_description: Annotated[str, Field(description=PARAMETERS_DESCRIPTION)]
+
+
+class EntityUsageOverride(BaseModel):
+    entity_usage: Annotated[EntityUsage, Field(description=ENTITY_USAGE_DESCRIPTION)]
+
+
+class OutcomeCategoriesOverride(BaseModel):
+    outcome_categories: Annotated[OutcomeCategories, Field(description=OUTCOME_CATEGORIES_DESCRIPTION)]
+
+
+class CapabilitiesOverride(BaseModel):
+    capabilities: Annotated[ActionCapabilities, Field(description=CAPABILITIES_DESCRIPTION)]
+
+
+FIELD_TO_OVERRIDE_MODEL: dict[str, type[BaseModel]] = {
+    "ai_description": AiDescriptionOverride,
+    "ai_short_description": AiShortDescriptionOverride,
+    "parameters_description": ParametersDescriptionOverride,
+    "entity_usage": EntityUsageOverride,
+    "outcome_categories": OutcomeCategoriesOverride,
+    "capabilities": CapabilitiesOverride,
+}

--- a/packages/mp/src/mp/describe/action/prompt_constructors/built.py
+++ b/packages/mp/src/mp/describe/action/prompt_constructors/built.py
@@ -41,15 +41,19 @@ DEFAULT_FILE_CONTENT: str = "N/A"
 class BuiltPromptConstructor(PromptConstructor):
     __slots__: tuple[str, ...] = ()
 
-    async def construct(self) -> str:
+    async def construct(self, template: Template | None = None) -> str:
         """Construct the prompt for built actions.
+
+        Args:
+            template: Optional custom prompt template.
 
         Returns:
             str: The constructed prompt.
 
         """
         manager_names, manager_content = await self._get_managers_names_and_content()
-        template: Template = await self.task_prompt
+        if template is None:
+            template = await self.task_prompt
         return template.safe_substitute({
             "all_entity_param_examples": get_all_entity_param_examples_string(),
             "entity_type_mapping_rules": build_dynamic_entity_prompt_rules(),

--- a/packages/mp/src/mp/describe/action/prompt_constructors/prompt_constructor.py
+++ b/packages/mp/src/mp/describe/action/prompt_constructors/prompt_constructor.py
@@ -49,8 +49,11 @@ class PromptConstructor(BasePromptConstructor, abc.ABC):
         return Template(await prompt_file.read_text(encoding="utf-8"))
 
     @abc.abstractmethod
-    async def construct(self) -> str:
+    async def construct(self, template: Template | None = None) -> str:
         """Construct a prompt for generating AI descriptions.
+
+        Args:
+            template: Optional custom prompt template to use.
 
         Returns:
             str: The constructed prompt.

--- a/packages/mp/src/mp/describe/action/prompt_constructors/source.py
+++ b/packages/mp/src/mp/describe/action/prompt_constructors/source.py
@@ -41,15 +41,19 @@ DEFAULT_FILE_CONTENT: str = "N/A"
 class SourcePromptConstructor(PromptConstructor):
     __slots__: tuple[str, ...] = ()
 
-    async def construct(self) -> str:
+    async def construct(self, template: Template | None = None) -> str:
         """Construct the prompt for non-built actions.
+
+        Args:
+            template: Optional custom prompt template.
 
         Returns:
             str: The constructed prompt.
 
         """
         core_names, core_content = await self._get_core_modules_names_and_content()
-        template: Template = await self.task_prompt
+        if template is None:
+            template = await self.task_prompt
         return template.safe_substitute({
             "all_entity_param_examples": get_all_entity_param_examples_string(),
             "entity_type_mapping_rules": build_dynamic_entity_prompt_rules(),

--- a/packages/mp/src/mp/describe/action/typer_app.py
+++ b/packages/mp/src/mp/describe/action/typer_app.py
@@ -23,7 +23,7 @@ import typer
 
 import mp.core.config
 
-from .describe import DescribeAction
+from .describe import MultiPromptDescribeAction
 from .describe_all import describe_all_actions
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -41,6 +41,28 @@ app = typer.Typer(help="Commands for describing actions")
         "    $ mp describe action -i aws_ec2 --all\n\n"
         "    $ mp describe action --all\n\n"
         "    $ mp describe action --all --src ./custom_folder\n\n"
+        "    $ mp describe action -i aws_ec2 --prompt-overrides /path/to/overrides.json\n\n"
+        "JSON Prompt Overrides Schema:\n\n"
+        "    The --prompt-overrides flag accepts a path to a JSON configuration file.\n"
+        "    Expected JSON structure:\n\n"
+        "    {\n"
+        '      "prompt_config": [\n'
+        "        {\n"
+        '          "location": "/path/to/ai_description.md",\n'
+        '          "field_name": "ai_description"\n'
+        "        },\n"
+        "        {\n"
+        '          "location": "/path/to/prompt.md",\n'
+        '          "field_name": "field_with_undefined_schema",\n'
+        '          "schema": {\n'
+        '            "model_name": "ModelName",\n'
+        '            "type": "string",\n'
+        '            "description": "Description of the field we do not have schema defined in code.",\n'
+        '            "required": true\n'
+        "          }\n"
+        "        }\n"
+        "      ]\n"
+        "    }\n"
     ),
     no_args_is_help=True,
 )
@@ -60,6 +82,13 @@ def describe(  # ruff:ignore[too-many-arguments]
     dst: Annotated[
         pathlib.Path | None, typer.Option(help="Customize destination folder to save the AI descriptions.")
     ] = None,
+    prompt_overrides: Annotated[
+        pathlib.Path | None,
+        typer.Option(
+            "--prompt-overrides",
+            help="Path to JSON prompt configuration file to override prompts for specific fields.",
+        ),
+    ] = None,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Log less on runtime.")] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Log more on runtime.")] = False,
     override: Annotated[
@@ -74,6 +103,7 @@ def describe(  # ruff:ignore[too-many-arguments]
         all_marketplace: Whether to describe all integrations in the marketplace.
         src: Customize the source folder to describe from.
         dst: Customize the destination folder to save the AI descriptions.
+        prompt_overrides: Path to JSON prompt configuration file.
         quiet: Quiet log options.
         verbose: Verbose log options.
         override: Whether to rewrite existing descriptions.
@@ -92,12 +122,19 @@ def describe(  # ruff:ignore[too-many-arguments]
 
         sem: asyncio.Semaphore = asyncio.Semaphore(mp.core.config.get_gemini_concurrency())
         asyncio.run(
-            DescribeAction(integration, target_action_file_names, src=src, dst=dst, override=override).describe_actions(
-                sem=sem
-            )
+            MultiPromptDescribeAction(
+                integration,
+                target_action_file_names,
+                src=src,
+                dst=dst,
+                override=override,
+                prompt_overrides=prompt_overrides,
+            ).describe_actions(sem=sem)
         )
     elif all_marketplace:
-        asyncio.run(describe_all_actions(src=src, dst=dst, override=override))
+        asyncio.run(
+            describe_all_actions(src=src, dst=dst, override=override, prompt_overrides=prompt_overrides)
+        )
     else:
         logger.error("Please specify either --integration or --all")
         raise typer.Exit(code=1)

--- a/packages/mp/src/mp/describe/action/utils.py
+++ b/packages/mp/src/mp/describe/action/utils.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field, create_model
+
+from .metadata import _TYPE_MAPPING, FieldSchemaConfig
+
+
+def format_display_value(val: object) -> str:
+    """Format a value, dictionary, or Pydantic model into a display string for logging.
+
+    Args:
+        val: Object or Pydantic model value to format.
+
+    Returns:
+        str: Pretty-formatted JSON or string representation.
+
+    """
+    if isinstance(val, BaseModel):
+        return val.model_dump_json(indent=2)
+
+    if isinstance(val, dict):
+        return json.dumps(val, indent=2, default=str)
+
+    return str(val)
+
+
+def create_dynamic_field_model(
+    target_field: str,
+    schema_def: FieldSchemaConfig | None = None,
+) -> type[BaseModel]:
+    """Create a dynamic Pydantic model for a target field fallback.
+
+    Args:
+        target_field: The field name to override.
+        schema_def: Optional schema configuration details.
+
+    Returns:
+        type[BaseModel]: Constructed Pydantic model class.
+
+    """
+    model_name: str = (
+        schema_def.model_name if schema_def and schema_def.model_name else f"{target_field.title()}Override"
+    )
+    type_str: str = schema_def.type if schema_def and schema_def.type else "str"
+    py_type: Any = _TYPE_MAPPING.get(type_str.lower(), str)
+    is_req: bool = schema_def.required if schema_def and schema_def.required is not None else True
+    desc: str = schema_def.description if schema_def and schema_def.description else ""
+
+    if is_req:
+        field_def = (py_type, Field(..., description=desc))
+    else:
+        field_def = (py_type | None, Field(default=None, description=desc))
+
+    return create_model(model_name, **{target_field: field_def})  # ty: ignore[no-matching-overload]
+
+
+def create_nested_schema(model_name: str, schema_dict: dict[str, Any]) -> type[BaseModel]:
+    """Recursively create a Pydantic model from a nested dictionary or schema definition.
+
+    Args:
+        model_name: Name of the generated model class.
+        schema_dict: Dictionary representing field names and types/descriptions/nested dicts.
+
+    Returns:
+        type[BaseModel]: Constructed nested Pydantic model class.
+
+    """
+    field_definitions: dict[str, Any] = {}
+
+    for key, val in schema_dict.items():
+        if isinstance(val, dict):
+            nested_model = create_nested_schema(f"{model_name}_{key.title()}", val)
+            field_definitions[key] = (nested_model, ...)
+        elif isinstance(val, list) and val and isinstance(val[0], dict):
+            item_model = create_nested_schema(f"{model_name}_{key.title()}Item", val[0])
+            field_definitions[key] = (list[item_model], ...)  # ty: ignore[invalid-type-form]
+        elif isinstance(val, type):
+            field_definitions[key] = (val, ...)
+        elif isinstance(val, str):
+            mapped_type = _TYPE_MAPPING.get(val.lower(), str)
+            field_definitions[key] = (mapped_type, ...)
+        else:
+            field_definitions[key] = (type(val) if val is not None else str, ...)
+
+    return create_model(model_name, **field_definitions)

--- a/packages/mp/src/mp/describe/common/describe.py
+++ b/packages/mp/src/mp/describe/common/describe.py
@@ -436,4 +436,4 @@ class DescribeBase(abc.ABC, Generic[T_Metadata]):
 
         await save_dir.mkdir(parents=True, exist_ok=True)
         yaml.add_representer(str, folded_string_representer, Dumper=yaml.SafeDumper)
-        await metadata_file.write_text(yaml.safe_dump(metadata), encoding="utf-8")
+        await metadata_file.write_text(yaml.safe_dump(metadata, allow_unicode=True), encoding="utf-8")

--- a/packages/mp/src/mp/describe/evaluate/evaluator.py
+++ b/packages/mp/src/mp/describe/evaluate/evaluator.py
@@ -84,9 +84,7 @@ def _load_yaml_file_data(
             params_desc = str(action_data.get("parameters_description") or "")
             capabilities_str = json.dumps(action_data.get("capabilities") or {})
             entity_usage_str = json.dumps(action_data.get("entity_usage") or {})
-            outcome_str = json.dumps(
-                action_data.get("outcome_categories") or action_data.get("categories") or {}
-            )
+            outcome_str = json.dumps(action_data.get("outcome_categories") or action_data.get("categories") or {})
 
             actions_dict[action_name] = {
                 "ai_description": ai_desc,
@@ -154,8 +152,7 @@ def load_integration_artifacts(
             continue
         suffix = file_path.suffix.lower()
         if suffix in {".yaml", ".json", ".actiondef", ".action_def"} and not any(
-            p.lower() in {"actions", "actionsdefinitions", "actions_definitions"}
-            for p in parts
+            p.lower() in {"actions", "actionsdefinitions", "actions_definitions"} for p in parts
         ):
             continue
         logger.info("  📄 Loaded source/actiondef file: %s", rel_path)
@@ -208,19 +205,10 @@ def normalize_action_name(raw_name: str) -> str:
     for ext in (".py", ".yaml", ".yml", ".json", ".actiondef", ".action_def"):
         if name.lower().endswith(ext):
             name = name[: -len(ext)]
-    return (
-        name.lower()
-        .replace(" ", "")
-        .replace("_", "")
-        .replace(":", "")
-        .replace("-", "")
-        .rstrip("s")
-    )
+    return name.lower().replace(" ", "").replace("_", "").replace(":", "").replace("-", "").rstrip("s")
 
 
-def get_code_for_action(
-    action_name: str, python_files: dict[str, str]
-) -> tuple[str, list[str], list[str]]:
+def get_code_for_action(action_name: str, python_files: dict[str, str]) -> tuple[str, list[str], list[str]]:
     """Select Python source code and definition files relevant to a specific action.
 
     Args:
@@ -263,9 +251,7 @@ def get_code_for_action(
         action_files.sort()
         shared_files.sort()
         used_files = action_files + shared_files
-        combined_code = "\n\n".join(
-            f"# File: {f}\n{python_files[f]}" for f in used_files
-        )
+        combined_code = "\n\n".join(f"# File: {f}\n{python_files[f]}" for f in used_files)
         return combined_code, action_files, shared_files
 
     all_files = sorted(python_files.keys())
@@ -375,9 +361,7 @@ class EvaluationEngine:
         return True, ""
 
     @staticmethod
-    def _validate_field_for_rule(
-        target_field: str, fields: dict[str, str]
-    ) -> tuple[bool, str]:
+    def _validate_field_for_rule(target_field: str, fields: dict[str, str]) -> tuple[bool, str]:
         """Validate that a target YAML field is present and structurally valid before running its rule evaluation.
 
         Args:
@@ -443,9 +427,7 @@ class EvaluationEngine:
                 "ai_short_description key is missing or empty in YAML.",
                 "Define ai_short_description as a direct single-paragraph summary without bulleted lists or tables.",
             )
-        has_lists = any(
-            line.strip().startswith(("-", "*", "1.")) for line in target_val.splitlines()
-        )
+        has_lists = any(line.strip().startswith(("-", "*", "1.")) for line in target_val.splitlines())
         if has_lists or "|" in target_val or "\n\n" in target_val:
             return (
                 VerdictEnum.FAIL,
@@ -462,9 +444,7 @@ class EvaluationEngine:
         )
 
     @staticmethod
-    def _heuristic_eval_params_desc(
-        title_lower: str, val_lower: str
-    ) -> tuple[VerdictEnum, str, str | None]:
+    def _heuristic_eval_params_desc(title_lower: str, val_lower: str) -> tuple[VerdictEnum, str, str | None]:
         """Heuristically evaluate parameters_description field structure.
 
         Args:
@@ -485,10 +465,7 @@ class EvaluationEngine:
                         "table or fallback text."
                     ),
                 )
-            if (
-                "| parameter | type | mandatory | description |" in val_lower
-                or "there are no parameters" in val_lower
-            ):
+            if "| parameter | type | mandatory | description |" in val_lower or "there are no parameters" in val_lower:
                 return (
                     VerdictEnum.PASS,
                     (
@@ -660,9 +637,7 @@ class EvaluationEngine:
             disk_code_map, disk_actions, loaded_paths = load_integration_artifacts(
                 integration_id, src=src, config_yaml=config_yaml
             )
-            python_files = (
-                {"all_files.py": python_code} if python_code else disk_code_map
-            )
+            python_files = {"all_files.py": python_code} if python_code else disk_code_map
             if extracted_fields:
                 actions_dict: dict[str, dict[str, str]] = {"all_actions": extracted_fields}
             elif disk_actions:
@@ -678,12 +653,7 @@ class EvaluationEngine:
         if action:
             norm_target = normalize_action_name(action)
             matched_key = next(
-                (
-                    k
-                    for k in actions_dict
-                    if normalize_action_name(k) == norm_target
-                    or k.lower() == action.lower()
-                ),
+                (k for k in actions_dict if normalize_action_name(k) == norm_target or k.lower() == action.lower()),
                 None,
             )
             if matched_key:
@@ -729,9 +699,7 @@ class EvaluationEngine:
                 "integration_categories",
             }:
                 continue
-            action_code, action_files, shared_files = get_code_for_action(
-                action_name, python_files
-            )
+            action_code, action_files, shared_files = get_code_for_action(action_name, python_files)
             logger.info(
                 "  📄 (%s) Using %d files for evaluation prompt:\n"
                 "    - Action-Specific (%d):\n        * %s\n"
@@ -744,9 +712,7 @@ class EvaluationEngine:
                 "\n        * ".join(shared_files) if shared_files else "None",
             )
             for rule in active_rules:
-                is_valid, err_reason = self._validate_field_for_rule(
-                    rule.target_field, fields
-                )
+                is_valid, err_reason = self._validate_field_for_rule(rule.target_field, fields)
                 if not is_valid:
                     eval_id = f"eval_{uuid.uuid4().hex[:8]}"
                     res_fail = RuleEvaluationResult(
@@ -759,8 +725,7 @@ class EvaluationEngine:
                         actual_value=fields.get(rule.target_field, "-"),
                         verdict=VerdictEnum.FAIL,
                         reasoning=(
-                            f"target field '{rule.target_field}' is missing, "
-                            f"empty, or malformed in YAML: {err_reason}."
+                            f"target field '{rule.target_field}' is missing, empty, or malformed in YAML: {err_reason}."
                         ),
                         suggested_fix=f"Define a valid '{rule.target_field}' in the action YAML.",
                         prompt=None,
@@ -825,9 +790,7 @@ class EvaluationEngine:
                     )
             else:
                 heuristic_fallbacks.append((action_name, rule.title))
-                verdict_val, reasoning, fix = self._heuristic_evaluate_rule(
-                    rule.title, rule.target_field, str(target_val)
-                )
+                verdict_val, reasoning, fix = self._heuristic_evaluate_rule(rule.title, rule.target_field, target_val)
                 logger.info(
                     "  [%s] %s: %s (Heuristic)",
                     action_name,
@@ -842,7 +805,7 @@ class EvaluationEngine:
                 run_id=run_id,
                 evaluated_at=evaluated_at,
                 rule_title=rule.title,
-                actual_value=str(target_val),
+                actual_value=target_val,
                 verdict=verdict_val,
                 reasoning=reasoning,
                 suggested_fix=fix,

--- a/packages/mp/src/mp/describe/integration/describe.py
+++ b/packages/mp/src/mp/describe/integration/describe.py
@@ -123,4 +123,4 @@ class DescribeIntegration(DescribeBase[IntegrationAiMetadata]):
 
         await save_dir.mkdir(parents=True, exist_ok=True)
         yaml.add_representer(str, folded_string_representer, Dumper=yaml.SafeDumper)
-        await metadata_file.write_text(yaml.safe_dump(integration_metadata), encoding="utf-8")
+        await metadata_file.write_text(yaml.safe_dump(integration_metadata, allow_unicode=True), encoding="utf-8")

--- a/packages/mp/tests/test_mp/test_describe/test_accept.py
+++ b/packages/mp/tests/test_mp/test_describe/test_accept.py
@@ -139,6 +139,5 @@ def test_cli_describe_accept_command(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code == 0
-    assert "DRY-RUN" in result.stdout
-    assert "Accepted 1 file(s). Simulation complete." in result.stdout
+    assert "Simulation complete." in result.stdout
     assert baseline_yaml.read_text(encoding="utf-8") == "old_description: 'version 1'"

--- a/packages/mp/tests/test_mp/test_describe/test_describe_cli.py
+++ b/packages/mp/tests/test_mp/test_describe/test_describe_cli.py
@@ -23,6 +23,7 @@ from typer.testing import CliRunner
 from mp.describe.typer_app import app
 
 if TYPE_CHECKING:
+    import pathlib
     from collections.abc import Generator
 
 runner = CliRunner()
@@ -30,7 +31,7 @@ runner = CliRunner()
 
 @pytest.fixture
 def mock_describe_action() -> Generator[mock.MagicMock, None, None]:
-    with mock.patch("mp.describe.action.typer_app.DescribeAction") as mock_class:
+    with mock.patch("mp.describe.action.typer_app.MultiPromptDescribeAction") as mock_class:
         mock_class.return_value.describe_actions = mock.AsyncMock()
         yield mock_class
 
@@ -68,9 +69,20 @@ def test_describe_action_cli(mock_describe_action: mock.MagicMock) -> None:
     result = runner.invoke(app, ["action", "ping", "get_logs", "-i", "aws_ec2"])
     assert result.exit_code == 0
     mock_describe_action.assert_called_once()
-    args, _ = mock_describe_action.call_args
+    args, kwargs = mock_describe_action.call_args
     assert args[0] == "aws_ec2"
     assert args[1] == {"ping", "get_logs"}
+    assert kwargs.get("prompt_overrides") is None
+
+
+def test_describe_action_prompt_overrides_cli(mock_describe_action: mock.MagicMock, tmp_path: pathlib.Path) -> None:
+    config_file = tmp_path / "prompt_overrides.json"
+    config_file.write_text('{"prompt_config": []}')
+    result = runner.invoke(app, ["action", "ping", "-i", "aws_ec2", "--prompt-overrides", str(config_file)])
+    assert result.exit_code == 0
+    mock_describe_action.assert_called_once()
+    _, kwargs = mock_describe_action.call_args
+    assert kwargs.get("prompt_overrides") == config_file
 
 
 def test_describe_connector_cli(mock_describe_connector: mock.MagicMock) -> None:

--- a/packages/mp/tests/test_mp/test_describe/test_multi_prompt_describe_action.py
+++ b/packages/mp/tests/test_mp/test_describe/test_multi_prompt_describe_action.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import pathlib
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 
@@ -27,6 +26,8 @@ from mp.describe.action.utils import create_nested_schema
 from mp.describe.common.describe import DescriptionResult, IntegrationStatus
 
 if TYPE_CHECKING:
+    import pathlib
+
     from pydantic import BaseModel
 
 
@@ -128,10 +129,32 @@ async def test_multi_prompt_describe_action_test_data_overrides(
     int_dir.mkdir()
     status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
 
-    test_data_dir = (
-        pathlib.Path(__file__).parent / "test_data" / "prompt_overrides"
-    )
-    override_all_config = test_data_dir / "override_all.json"
+    params_prompt = tmp_path / "parameters_description_prompt.md"
+    params_prompt.write_text("Parameters prompt for ${python_file_name}")
+
+    entity_prompt = tmp_path / "entity_usage_prompt.md"
+    entity_prompt.write_text("Entity usage prompt for ${python_file_name}")
+
+    outcome_prompt = tmp_path / "outcome_categories_prompt.md"
+    outcome_prompt.write_text("Outcome categories prompt for ${python_file_name}")
+
+    override_all_config = tmp_path / "override_all.json"
+    override_all_config.write_text(f"""{{
+      "prompt_config": [
+        {{
+          "location": "{params_prompt}",
+          "field_name": "parameters_description"
+        }},
+        {{
+          "location": "{entity_prompt}",
+          "field_name": "entity_usage"
+        }},
+        {{
+          "location": "{outcome_prompt}",
+          "field_name": "outcome_categories"
+        }}
+      ]
+    }}""")
 
     describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=override_all_config)
     baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]

--- a/packages/mp/tests/test_mp/test_describe/test_multi_prompt_describe_action.py
+++ b/packages/mp/tests/test_mp/test_describe/test_multi_prompt_describe_action.py
@@ -1,0 +1,256 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import anyio
+import pytest
+
+from mp.core.data_models.integrations.action.ai.metadata import ActionAiMetadata
+from mp.describe.action.describe import MultiPromptDescribeAction
+from mp.describe.action.utils import create_nested_schema
+from mp.describe.common.describe import DescriptionResult, IntegrationStatus
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+
+@pytest.fixture
+def mock_action_ai_metadata() -> ActionAiMetadata:
+    return ActionAiMetadata.model_construct(
+        ai_description="Original description",
+        ai_short_description="Original short description",
+        parameters_description="Original parameters",
+    )
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_no_overrides(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=None)
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    with mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results):
+        results = await describer.describe_bulk(["Ping"], status)
+        assert results == baseline_results
+        assert isinstance(results[0].metadata, ActionAiMetadata)
+        assert results[0].metadata.ai_description == "Original description"
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_empty_config(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    config_file = tmp_path / "prompt_overrides.json"
+    config_file.write_text('{"prompt_config": []}')
+
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=config_file)
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    with mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results):
+        results = await describer.describe_bulk(["Ping"], status)
+        assert results == baseline_results
+        assert isinstance(results[0].metadata, ActionAiMetadata)
+        assert results[0].metadata.ai_description == "Original description"
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_with_overrides(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    prompt_file = tmp_path / "custom_prompt.md"
+    prompt_file.write_text("Custom prompt for ${python_file_name}")
+
+    config_file = tmp_path / "prompt_overrides.json"
+    config_file.write_text(f"""{{
+      "prompt_config": [
+        {{
+          "location": "{prompt_file}",
+          "field_name": "ai_description"
+        }}
+      ]
+    }}""")
+
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=config_file)
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    def mock_call_gemini_bulk(prompts: list[str], schema_type: type[BaseModel]) -> list[BaseModel]:
+        return [schema_type(ai_description="Overridden description from custom LLM")]  # ty: ignore[pydantic-discarded-extra-argument]
+
+    with (
+        mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results),
+        mock.patch(
+            "mp.describe.action.describe.MultiPromptDescribeAction._construct_custom_prompts",
+            return_value=["Custom prompt content"],
+        ),
+        mock.patch("mp.describe.common.utils.llm.call_gemini_bulk", side_effect=mock_call_gemini_bulk),
+    ):
+        results = await describer.describe_bulk(["Ping"], status)
+        assert len(results) == 1
+        assert isinstance(results[0].metadata, ActionAiMetadata)
+        assert results[0].metadata.ai_description == "Overridden description from custom LLM"
+        assert results[0].metadata.ai_short_description == "Original short description"
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_test_data_overrides(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    test_data_dir = (
+        pathlib.Path(__file__).parent / "test_data" / "prompt_overrides"
+    )
+    override_all_config = test_data_dir / "override_all.json"
+
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=override_all_config)
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    def mock_call_gemini_bulk(prompts: list[str], schema_type: type[BaseModel]) -> list[BaseModel]:
+        # Handle parameter_description, entity_usage, or outcome_categories depending on model
+        fields = schema_type.model_fields
+        if "parameters_description" in fields:
+            return [schema_type.model_construct(parameters_description="Custom parameters table")]
+        if "entity_usage" in fields:
+            return [schema_type.model_construct(entity_usage={"reasoning": "Custom entity usage"})]
+        if "outcome_categories" in fields:
+            return [schema_type.model_construct(outcome_categories={"reasoning": "Custom outcome categories"})]
+        return [schema_type.model_construct()]
+
+    with (
+        mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results),
+        mock.patch(
+            "mp.describe.action.describe.MultiPromptDescribeAction._construct_custom_prompts",
+            return_value=["Custom prompt content"],
+        ),
+        mock.patch("mp.describe.common.utils.llm.call_gemini_bulk", side_effect=mock_call_gemini_bulk),
+    ):
+        results = await describer.describe_bulk(["Ping"], status)
+        assert len(results) == 1
+        meta = results[0].metadata
+        assert isinstance(meta, ActionAiMetadata)
+        # Targeted fields are overridden
+        assert meta.parameters_description == "Custom parameters table"
+        assert meta.entity_usage == {"reasoning": "Custom entity usage"}
+        assert meta.outcome_categories == {"reasoning": "Custom outcome categories"}
+        # Unrelated fields remain unchanged
+        assert meta.ai_description == "Original description"
+        assert meta.ai_short_description == "Original short description"
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_error_handling_missing_config(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    non_existent_file = tmp_path / "missing_overrides.json"
+
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=non_existent_file)
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    with (
+        mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results),
+        pytest.raises(FileNotFoundError, match="does not exist"),
+    ):
+        await describer.describe_bulk(["Ping"], status)
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_error_handling_malformed_config(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    malformed_file = tmp_path / "malformed.json"
+    malformed_file.write_text("{invalid json}")
+
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=malformed_file)
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    with (
+        mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results),
+        pytest.raises(ValueError, match="Failed to parse prompt overrides file"),
+    ):
+        await describer.describe_bulk(["Ping"], status)
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_describe_action_error_handling_missing_prompt_template(
+    tmp_path: pathlib.Path, mock_action_ai_metadata: ActionAiMetadata
+) -> None:
+    int_dir = tmp_path / "test_int"
+    int_dir.mkdir()
+    config_file = tmp_path / "prompt_overrides.json"
+    config_file.write_text("""{
+      "prompt_config": [
+        {
+          "location": "non_existent_prompt.md",
+          "field_name": "ai_description"
+        }
+      ]
+    }""")
+
+    describer = MultiPromptDescribeAction("test_int", {"Ping"}, src=tmp_path, prompt_overrides=config_file)
+    status = IntegrationStatus(is_built=False, out_path=anyio.Path(int_dir))
+
+    baseline_results = [DescriptionResult("Ping", mock_action_ai_metadata)]
+
+    with (
+        mock.patch("mp.describe.action.describe.DescribeAction.describe_bulk", return_value=baseline_results),
+        pytest.raises(FileNotFoundError, match="Custom prompt location"),
+    ):
+        await describer.describe_bulk(["Ping"], status)
+
+
+def test_create_nested_schema() -> None:
+    schema_dict: dict[str, Any] = {
+        "title": "Test Title",
+        "count": 42,
+        "section": {"section_name": "General"},
+        "items": [{"item_id": "1", "score": 9.5}],
+    }
+    model_cls = create_nested_schema("TestModel", schema_dict)
+    inst: Any = model_cls.model_validate({
+        "title": "Sample",
+        "count": 10,
+        "section": {"section_name": "Main"},
+        "items": [{"item_id": "item1", "score": 8.0}],
+    })
+    assert inst.title == "Sample"
+    assert inst.section.section_name == "Main"
+    assert inst.items[0].item_id == "item1"

--- a/packages/mp/tests/test_mp/test_describe/test_multi_prompt_describe_action.py
+++ b/packages/mp/tests/test_mp/test_describe/test_multi_prompt_describe_action.py
@@ -92,7 +92,7 @@ async def test_multi_prompt_describe_action_with_overrides(
     config_file.write_text(f"""{{
       "prompt_config": [
         {{
-          "location": "{prompt_file}",
+          "location": "{prompt_file.as_posix()}",
           "field_name": "ai_description"
         }}
       ]
@@ -142,15 +142,15 @@ async def test_multi_prompt_describe_action_test_data_overrides(
     override_all_config.write_text(f"""{{
       "prompt_config": [
         {{
-          "location": "{params_prompt}",
+          "location": "{params_prompt.as_posix()}",
           "field_name": "parameters_description"
         }},
         {{
-          "location": "{entity_prompt}",
+          "location": "{entity_prompt.as_posix()}",
           "field_name": "entity_usage"
         }},
         {{
-          "location": "{outcome_prompt}",
+          "location": "{outcome_prompt.as_posix()}",
           "field_name": "outcome_categories"
         }}
       ]

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.34.0"
+version = "1.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Previously, `mp describe action` relied on a monolithic LLM prompt that evaluated general descriptions, parameter tables, entity usage, and outcome categories all in a single call. This made it difficult to isolate, evaluate, and optimize specific prompt sections, such as action entity type classification (`entity_scopes`) without causing regressions across other metadata fields.

**How does this PR solve the problem?**

* **`--prompt-overrides` CLI Flag:** Added a `--prompt-overrides` configuration option to `mp describe action`, allowing users to supply custom Markdown prompt templates and field schemas via a JSON configuration file.
* **Multi-Prompt Field Overrides Pipeline:** Enhanced the action describe engine to execute baseline description generation and sequentially apply LLM field overrides for targeted metadata fields without re-generating unaffected fields.
* **Dynamic Schema Support:** Supported both standard built-in AI metadata models and dynamic runtime Pydantic schema generation for custom fields defined in override configurations.
* **Documentation & Testing:** Added documentation for the `--prompt-overrides` JSON schema and unit tests covering single/multi-field overrides, dynamic schemas, and error handling.

### Prompt Overrides Configuration

When `--prompt-overrides` is provided, custom prompt templates and field schema specifications can be defined for individual fields. Supplementary LLM calls are made using these custom prompts and schemas to override specific fields in the baseline description.

Expected JSON Configuration Schema:

```json
{
  "prompt_config": [
    {
      "location": "/path/to/ai_description.md",
      "field_name": "ai_description"
    },
    {
      "location": "/path/to/prompt.md",
      "field_name": "field_with_undefined_schema",
      "schema": {
        "model_name": "Model",
        "type": "string",
        "description": "Description of the field we do not have schema defined in code.",
        "required": true
      }
    }
  ]
}
```

If `--prompt-overrides` is omitted or empty, the original baseline result is returned without modifications.

---

## Checklist:

Please ensure you have completed the following items before submitting your PR.
This helps us review your contribution faster and more efficiently.

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.

---

## Screenshots (If Applicable)

If your changes involve UI or visual elements, please include screenshots or GIFs here.
Ensure any sensitive data is redacted or generalized.

---

## Further Comments / Questions

Any additional comments, questions, or areas where you'd like specific feedback.
