### PR TITLE
Fix IP Lookup action failure for unknown IPs and add tests (b/540683240)

### DIFF
--- a/content/response_integrations/third_party/partner/grey_noise/actions/ip_lookup.py
+++ b/content/response_integrations/third_party/partner/grey_noise/actions/ip_lookup.py
@@ -101,7 +101,7 @@ def process_community_tier(
                     json_results,
                 )
             else:
-                failed_entities.append(entity)
+                not_found_entities.append(entity)
 
         except RequestFailure as e:
             failed_entities.append(entity)
@@ -159,7 +159,7 @@ def process_enterprise_tier(
                     json_results,
                 )
             else:
-                failed_entities.append(entity)
+                not_found_entities.append(entity)
                 siemplify.LOGGER.info(f"No response for IP: {ip_address}")
 
     except RequestFailure as e:

--- a/content/response_integrations/third_party/partner/grey_noise/release_notes.yaml
+++ b/content/response_integrations/third_party/partner/grey_noise/release_notes.yaml
@@ -68,3 +68,9 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: "Fixed an issue in the IP Lookup action where benign or unknown IPs returning empty responses from GreyNoise were incorrectly marked as failed instead of not found."
+  version: 10.0
+  item_name: GreyNoiseIntegration
+  item_type: Integration
+  publish_time: '2026-08-05'
+  ticket_number: '540683240'

--- a/content/response_integrations/third_party/partner/grey_noise/tests/test_actions/test_ip_lookup.py
+++ b/content/response_integrations/third_party/partner/grey_noise/tests/test_actions/test_ip_lookup.py
@@ -103,6 +103,25 @@ class TestIPLookupAction:
     @set_metadata(
         integration_config_file_path=CONFIG_PATH,
         entities=[
+            {"identifier": "192.168.1.100", "entity_type": "ADDRESS", "additional_properties": {}}
+        ],
+    )
+    def test_ip_lookup_community_empty_response(
+        self,
+        action_output: MockActionOutput,
+        greynoise_sdk: GreyNoiseSDK,
+    ) -> None:
+        """Test community tier IP lookup with an empty/None response (benign/unknown IP)."""
+        greynoise_sdk.set_community_ip_response({})
+
+        ip_lookup.main()
+
+        assert action_output.results.execution_state == ExecutionState.COMPLETED
+        assert "Not found in GreyNoise dataset: 1 IP(s): 192.168.1.100" in action_output.results.output_message
+
+    @set_metadata(
+        integration_config_file_path=CONFIG_PATH,
+        entities=[
             {"identifier": "192.168.1.100", "entity_type": "ADDRESS", "additional_properties": {}},
             {"identifier": "10.0.0.50", "entity_type": "ADDRESS", "additional_properties": {}},
         ],


### PR DESCRIPTION
## Title (Please follow the convention below)

`[Buganizer ID: b/540683240] Fix: IP Lookup action failure for unknown IPs`

[Bug ID] : (http://b/540683240)
---
## Description

**What problem does this PR solve?**
Fixes a bug where benign or unknown IP addresses returning empty responses from the GreyNoise API would cause a system error during the action execution. These IPs were incorrectly being added to `failed_entities` instead of `not_found_entities`.

**How does this PR solve the problem?**
- Updated the `process_community_tier` and `process_enterprise_tier` functions in `ip_lookup.py` to gracefully handle empty API responses and correctly append these IPs to `not_found_entities`.
- Added comprehensive unit tests in `test_ip_lookup.py` to validate empty/unknown response scenarios.
- Updated `release_notes.yaml` to document the fix and bump the version.

**Any other relevant information (e.g., design choices, tradeoffs, known issues):**
N/A - This change strictly improves error handling parity for unknown indicators.

---

## Checklist:

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.

---

## Screenshots (If Applicable)

N/A

---

## Further Comments / Questions

None
