### PR TITLE
Add third-party block: Phishing Investigation

### DIFF
--- a/content/parsers/third_party/COMMUNITY_INDEX.json
+++ b/content/parsers/third_party/COMMUNITY_INDEX.json
@@ -1,5 +1,1035 @@
 [
   {
+    "log_type": "ACCELLION",
+    "config_path": "content/parsers/third_party/community/ACCELLION_GUS/cbn/default_accellion.conf",
+    "metadata_path": "content/parsers/third_party/community/ACCELLION_GUS/cbn/metadata.json",
+    "vendor": "ACCELLION",
+    "product": "ACCELLION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ADVA_FSP",
+    "config_path": "content/parsers/third_party/community/ADVA_FSP_GUS/cbn/default_adva_fsp.conf",
+    "metadata_path": "content/parsers/third_party/community/ADVA_FSP_GUS/cbn/metadata.json",
+    "vendor": "ADVA_FSP",
+    "product": "ADVA_FSP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "AGILOFT",
+    "config_path": "content/parsers/third_party/community/AGILOFT_GUS/cbn/default_agiloft.conf",
+    "metadata_path": "content/parsers/third_party/community/AGILOFT_GUS/cbn/metadata.json",
+    "vendor": "AGILOFT",
+    "product": "AGILOFT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ALVEO_RDM",
+    "config_path": "content/parsers/third_party/community/ALVEO_RDM_GUS/cbn/default_alveo_rdm.conf",
+    "metadata_path": "content/parsers/third_party/community/ALVEO_RDM_GUS/cbn/metadata.json",
+    "vendor": "ALVEO RDM",
+    "product": "ALVEO RDM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ARBOR_SIGHTLINE",
+    "config_path": "content/parsers/third_party/community/ARBOR_SIGHTLINE_GUS/cbn/default_arbor_sightline.conf",
+    "metadata_path": "content/parsers/third_party/community/ARBOR_SIGHTLINE_GUS/cbn/metadata.json",
+    "vendor": "NETSCOUT",
+    "product": "ARBOR_SIGHTLINE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ARCHER_IRM",
+    "config_path": "content/parsers/third_party/community/ARCHER_IRM_GUS/cbn/default_archer_irm.conf",
+    "metadata_path": "content/parsers/third_party/community/ARCHER_IRM_GUS/cbn/metadata.json",
+    "vendor": "ARCHER",
+    "product": "ARCHER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ARMIS_VULNERABILITIES",
+    "config_path": "content/parsers/third_party/community/ARMIS_VULNERABILITIES_GUS/cbn/default_armis_vulnerabilities.conf",
+    "metadata_path": "content/parsers/third_party/community/ARMIS_VULNERABILITIES_GUS/cbn/metadata.json",
+    "vendor": "ARMIS",
+    "product": "ARMIS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ARRAYNETWORKS_VPN",
+    "config_path": "content/parsers/third_party/community/ARRAYNETWORKS_VPN_GUS/cbn/default_arraynetworks_vpn.conf",
+    "metadata_path": "content/parsers/third_party/community/ARRAYNETWORKS_VPN_GUS/cbn/metadata.json",
+    "vendor": "ARRAYNETWORKS_VPN",
+    "product": "ARRAYNETWORKS_VPN",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ASSET_PANDA",
+    "config_path": "content/parsers/third_party/community/ASSET_PANDA_GUS/cbn/default_asset_panda.conf",
+    "metadata_path": "content/parsers/third_party/community/ASSET_PANDA_GUS/cbn/metadata.json",
+    "vendor": "ASSET_PANDA",
+    "product": "ASSET_PANDA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "ASSET_STATIC_IP",
+    "config_path": "content/parsers/third_party/community/ASSET_STATIC_IP_GUS/cbn/default_asset_static_ip.conf",
+    "metadata_path": "content/parsers/third_party/community/ASSET_STATIC_IP_GUS/cbn/metadata.json",
+    "vendor": "ASSET_STATIC_IP",
+    "product": "ASSET_STATIC_IP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c707941601dff0edb8b5146623ffe3f4fe8546de",
+    "latest_commit_time": 1786030230
+  },
+  {
+    "log_type": "AVATIER",
+    "config_path": "content/parsers/third_party/community/AVATIER_GUS/cbn/default_avatier.conf",
+    "metadata_path": "content/parsers/third_party/community/AVATIER_GUS/cbn/metadata.json",
+    "vendor": "AVATIER",
+    "product": "AVATIER IDENTITY MANAGEMENT SUITE (AIMS)",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AVIGILON_ACCESS_LOGS",
+    "config_path": "content/parsers/third_party/community/AVIGILON_ACCESS_LOGS_GUS/cbn/default_avigilon_access_logs.conf",
+    "metadata_path": "content/parsers/third_party/community/AVIGILON_ACCESS_LOGS_GUS/cbn/metadata.json",
+    "vendor": "AVIGILON_ACCESS_LOGS",
+    "product": "AVIGILON_ACCESS_LOGS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWARE_AUDIT",
+    "config_path": "content/parsers/third_party/community/AWARE_AUDIT_GUS/cbn/default_aware_audit.conf",
+    "metadata_path": "content/parsers/third_party/community/AWARE_AUDIT_GUS/cbn/metadata.json",
+    "vendor": "AWARE_AUDIT",
+    "product": "AWARE_AUDIT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWARE_SIGNALS",
+    "config_path": "content/parsers/third_party/community/AWARE_SIGNALS_GUS/cbn/default_aware_signals.conf",
+    "metadata_path": "content/parsers/third_party/community/AWARE_SIGNALS_GUS/cbn/metadata.json",
+    "vendor": "AWARE SIGNALS",
+    "product": "AWARE SIGNALS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_ECS_METRICS",
+    "config_path": "content/parsers/third_party/community/AWS_ECS_METRICS_GUS/cbn/default_aws_ecs_metrics.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_ECS_METRICS_GUS/cbn/metadata.json",
+    "vendor": "AWS_ECS_METRICS",
+    "product": "AWS_ECS_METRICS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_INSPECTOR",
+    "config_path": "content/parsers/third_party/community/AWS_INSPECTOR_GUS/cbn/default_aws_inspector.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_INSPECTOR_GUS/cbn/metadata.json",
+    "vendor": "AWS INSPECTOR",
+    "product": "AWS INSPECTOR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_KMS",
+    "config_path": "content/parsers/third_party/community/AWS_KMS_GUS/cbn/default_aws_kms.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_KMS_GUS/cbn/metadata.json",
+    "vendor": "AMAZON",
+    "product": "AWS Key Management Service",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_LAMBDA_FUNCTION",
+    "config_path": "content/parsers/third_party/community/AWS_LAMBDA_FUNCTION_GUS/cbn/default_aws_lambda_function.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_LAMBDA_FUNCTION_GUS/cbn/metadata.json",
+    "vendor": "AWS_LAMBDA_FUNCTION",
+    "product": "AWS_LAMBDA_FUNCTION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_REDSHIFT",
+    "config_path": "content/parsers/third_party/community/AWS_REDSHIFT_GUS/cbn/default_aws_redshift.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_REDSHIFT_GUS/cbn/metadata.json",
+    "vendor": "AWS_REDSHIFT",
+    "product": "AWS_REDSHIFT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_VPC_FLOW_CSV",
+    "config_path": "content/parsers/third_party/community/AWS_VPC_FLOW_CSV_GUS/cbn/default_aws_vpc_flow_csv.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_VPC_FLOW_CSV_GUS/cbn/metadata.json",
+    "vendor": "AMAZON",
+    "product": "AWS VPC Flow CSV",
+    "source": "COMMUNITY",
+    "latest_commit_id": "679fbe7e37197bbf2a84855b3bb4350096855d53",
+    "latest_commit_time": 1786029603
+  },
+  {
+    "log_type": "AWS_VPC_TRANSIT_GATEWAY",
+    "config_path": "content/parsers/third_party/community/AWS_VPC_TRANSIT_GATEWAY_GUS/cbn/default_aws_vpc_transit_gateway.conf",
+    "metadata_path": "content/parsers/third_party/community/AWS_VPC_TRANSIT_GATEWAY_GUS/cbn/metadata.json",
+    "vendor": "AWS",
+    "product": "AWS_VPC_TRANSIT_GATEWAY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "AZURE_COSMOS_DB",
+    "config_path": "content/parsers/third_party/community/AZURE_COSMOS_DB_GUS/cbn/default_azure_cosmos_db.conf",
+    "metadata_path": "content/parsers/third_party/community/AZURE_COSMOS_DB_GUS/cbn/metadata.json",
+    "vendor": "MICROSOFT",
+    "product": "AZURE_COSMOS_DB",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BARRACUDA_CLOUDGEN_FIREWALL",
+    "config_path": "content/parsers/third_party/community/BARRACUDA_CLOUDGEN_FIREWALL_GUS/cbn/default_barracuda_cloudgen_firewall.conf",
+    "metadata_path": "content/parsers/third_party/community/BARRACUDA_CLOUDGEN_FIREWALL_GUS/cbn/metadata.json",
+    "vendor": "BARRACUDA CLOUDGEN FIREWALL",
+    "product": "BARRACUDA CLOUDGEN FIREWALL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BLUECAT_EDGE",
+    "config_path": "content/parsers/third_party/community/BLUECAT_EDGE_GUS/cbn/default_bluecat_edge.conf",
+    "metadata_path": "content/parsers/third_party/community/BLUECAT_EDGE_GUS/cbn/metadata.json",
+    "vendor": "BLUECAT_EDGE",
+    "product": "BLUECAT_EDGE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BMC_AMI_DEFENDER",
+    "config_path": "content/parsers/third_party/community/BMC_AMI_DEFENDER_GUS/cbn/default_bmc_ami_defender.conf",
+    "metadata_path": "content/parsers/third_party/community/BMC_AMI_DEFENDER_GUS/cbn/metadata.json",
+    "vendor": "BMC AMI",
+    "product": "BMC AMI DEFENDER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BMC_CLIENT_MANAGEMENT",
+    "config_path": "content/parsers/third_party/community/BMC_CLIENT_MANAGEMENT_GUS/cbn/default_bmc_client_management.conf",
+    "metadata_path": "content/parsers/third_party/community/BMC_CLIENT_MANAGEMENT_GUS/cbn/metadata.json",
+    "vendor": "BMC_CLIENT_MANAGEMENT",
+    "product": "BMC_CLIENT_MANAGEMENT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BMC_HELIX_DISCOVERY",
+    "config_path": "content/parsers/third_party/community/BMC_HELIX_DISCOVERY_GUS/cbn/default_bmc_helix_discovery.conf",
+    "metadata_path": "content/parsers/third_party/community/BMC_HELIX_DISCOVERY_GUS/cbn/metadata.json",
+    "vendor": "BMC_HELIX_DISCOVERY",
+    "product": "BMC_HELIX_DISCOVERY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BROADCOM_CA_PAM",
+    "config_path": "content/parsers/third_party/community/BROADCOM_CA_PAM_GUS/cbn/default_broadcom_ca_pam.conf",
+    "metadata_path": "content/parsers/third_party/community/BROADCOM_CA_PAM_GUS/cbn/metadata.json",
+    "vendor": "BROADCOM_CA_PAM",
+    "product": "BROADCOM_CA_PAM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "BRO_TSV",
+    "config_path": "content/parsers/third_party/community/BRO_TSV_GUS/cbn/default_bro_tsv.conf",
+    "metadata_path": "content/parsers/third_party/community/BRO_TSV_GUS/cbn/metadata.json",
+    "vendor": "BRO_TSV",
+    "product": "BRO_TSV",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "CAMBIUM_NETWORKS",
+    "config_path": "content/parsers/third_party/community/CAMBIUM_NETWORKS_GUS/cbn/default_cambium_networks.conf",
+    "metadata_path": "content/parsers/third_party/community/CAMBIUM_NETWORKS_GUS/cbn/metadata.json",
+    "vendor": "CAMBIUM_NETWORKS",
+    "product": "CAMBIUM NETWORKS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CASSANDRA",
+    "config_path": "content/parsers/third_party/community/CASSANDRA_GUS/cbn/default_cassandra.conf",
+    "metadata_path": "content/parsers/third_party/community/CASSANDRA_GUS/cbn/metadata.json",
+    "vendor": "CASSANDRA",
+    "product": "CASSANDRA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CA_ACCESS_CONTROL",
+    "config_path": "content/parsers/third_party/community/CA_ACCESS_CONTROL_GUS/cbn/default_ca_access_control.conf",
+    "metadata_path": "content/parsers/third_party/community/CA_ACCESS_CONTROL_GUS/cbn/metadata.json",
+    "vendor": "CA TECHNOLOGIES",
+    "product": "CA_ACCESS_CONTROL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6d6ec94f3bc4c5229d7cf0d3c073d4a59675a27d",
+    "latest_commit_time": 1786029632
+  },
+  {
+    "log_type": "CA_ACF2",
+    "config_path": "content/parsers/third_party/community/CA_ACF2_GUS/cbn/default_ca_acf2.conf",
+    "metadata_path": "content/parsers/third_party/community/CA_ACF2_GUS/cbn/metadata.json",
+    "vendor": "CA",
+    "product": "ACF2",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CA_LDAP",
+    "config_path": "content/parsers/third_party/community/CA_LDAP_GUS/cbn/default_ca_ldap.conf",
+    "metadata_path": "content/parsers/third_party/community/CA_LDAP_GUS/cbn/metadata.json",
+    "vendor": "CA_LDAP",
+    "product": "CA_LDAP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CA_SSO_WEB",
+    "config_path": "content/parsers/third_party/community/CA_SSO_WEB_GUS/cbn/default_ca_sso_web.conf",
+    "metadata_path": "content/parsers/third_party/community/CA_SSO_WEB_GUS/cbn/metadata.json",
+    "vendor": "SITEMINDER",
+    "product": "WEB ACCESS MANAGEMENT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CENSYS",
+    "config_path": "content/parsers/third_party/community/CENSYS_GUS/cbn/default_censys.conf",
+    "metadata_path": "content/parsers/third_party/community/CENSYS_GUS/cbn/metadata.json",
+    "vendor": "CENSYS",
+    "product": "CENSYS_ASM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CENTRIFY_SSO",
+    "config_path": "content/parsers/third_party/community/CENTRIFY_SSO_GUS/cbn/default_centrify_sso.conf",
+    "metadata_path": "content/parsers/third_party/community/CENTRIFY_SSO_GUS/cbn/metadata.json",
+    "vendor": "CENTRIFY",
+    "product": "SSO",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CEQUENCE_BOT_DEFENSE",
+    "config_path": "content/parsers/third_party/community/CEQUENCE_BOT_DEFENSE_GUS/cbn/default_cequence_bot_defense.conf",
+    "metadata_path": "content/parsers/third_party/community/CEQUENCE_BOT_DEFENSE_GUS/cbn/metadata.json",
+    "vendor": "CEQUENCE_BOT_DEFENSE",
+    "product": "CEQUENCE_BOT_DEFENSE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CIENA_ROUTER",
+    "config_path": "content/parsers/third_party/community/CIENA_ROUTER_GUS/cbn/default_ciena_router.conf",
+    "metadata_path": "content/parsers/third_party/community/CIENA_ROUTER_GUS/cbn/metadata.json",
+    "vendor": "CIENA_ROUTER",
+    "product": "CIENA_ROUTER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CIMCOR",
+    "config_path": "content/parsers/third_party/community/CIMCOR_GUS/cbn/default_cimcor.conf",
+    "metadata_path": "content/parsers/third_party/community/CIMCOR_GUS/cbn/metadata.json",
+    "vendor": "CIMCOR",
+    "product": "CIMCOR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "9aff911868154783128a6e1e974f5a16fe7936c9",
+    "latest_commit_time": 1786030185
+  },
+  {
+    "log_type": "CIRCLECI",
+    "config_path": "content/parsers/third_party/community/CIRCLECI_GUS/cbn/default_circleci.conf",
+    "metadata_path": "content/parsers/third_party/community/CIRCLECI_GUS/cbn/metadata.json",
+    "vendor": "CIRCLECI",
+    "product": "CIRCLECI",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CISCO_ACE",
+    "config_path": "content/parsers/third_party/community/CISCO_ACE_GUS/cbn/default_cisco_ace.conf",
+    "metadata_path": "content/parsers/third_party/community/CISCO_ACE_GUS/cbn/metadata.json",
+    "vendor": "CISCO_ACE",
+    "product": "CISCO_ACE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CISCO_CALL_MANAGER",
+    "config_path": "content/parsers/third_party/community/CISCO_CALL_MANAGER_GUS/cbn/default_cisco_call_manager.conf",
+    "metadata_path": "content/parsers/third_party/community/CISCO_CALL_MANAGER_GUS/cbn/metadata.json",
+    "vendor": "CISCO",
+    "product": "CISCO_CALL_MANAGER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CISCO_PIX_FIREWALL",
+    "config_path": "content/parsers/third_party/community/CISCO_PIX_FIREWALL_GUS/cbn/default_cisco_pix_firewall.conf",
+    "metadata_path": "content/parsers/third_party/community/CISCO_PIX_FIREWALL_GUS/cbn/metadata.json",
+    "vendor": "CISCO",
+    "product": "CISCO_PIX_FIREWALL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CISCO_STADIUMVISION",
+    "config_path": "content/parsers/third_party/community/CISCO_STADIUMVISION_GUS/cbn/default_cisco_stadiumvision.conf",
+    "metadata_path": "content/parsers/third_party/community/CISCO_STADIUMVISION_GUS/cbn/metadata.json",
+    "vendor": "CISCO_STADIUMVISION",
+    "product": "CISCO_STADIUMVISION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CISCO_UMBRELLA_SWG_DLP",
+    "config_path": "content/parsers/third_party/community/CISCO_UMBRELLA_SWG_DLP_GUS/cbn/default_cisco_umbrella_swg_dlp.conf",
+    "metadata_path": "content/parsers/third_party/community/CISCO_UMBRELLA_SWG_DLP_GUS/cbn/metadata.json",
+    "vendor": "CISCO_UMBRELLA_SWG_DLP",
+    "product": "CISCO_UMBRELLA_SWG_DLP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CIS_ALBERT_ALERT",
+    "config_path": "content/parsers/third_party/community/CIS_ALBERT_ALERT_GUS/cbn/default_cis_albert_alert.conf",
+    "metadata_path": "content/parsers/third_party/community/CIS_ALBERT_ALERT_GUS/cbn/metadata.json",
+    "vendor": "CIS_ALBERT_ALERTS",
+    "product": "CIS_ALBERT_ALERT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CITRIX_ANALYTICS",
+    "config_path": "content/parsers/third_party/community/CITRIX_ANALYTICS_GUS/cbn/default_citrix_analytics.conf",
+    "metadata_path": "content/parsers/third_party/community/CITRIX_ANALYTICS_GUS/cbn/metadata.json",
+    "vendor": "CITRIX_ANALYTICS",
+    "product": "CITRIX_ANALYTICS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CITRIX_MONITOR",
+    "config_path": "content/parsers/third_party/community/CITRIX_MONITOR_GUS/cbn/default_citrix_monitor.conf",
+    "metadata_path": "content/parsers/third_party/community/CITRIX_MONITOR_GUS/cbn/metadata.json",
+    "vendor": "CITRIX_MONITOR",
+    "product": "CITRIX_MONITOR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CITRIX_STOREFRONT",
+    "config_path": "content/parsers/third_party/community/CITRIX_STOREFRONT_GUS/cbn/default_citrix_storefront.conf",
+    "metadata_path": "content/parsers/third_party/community/CITRIX_STOREFRONT_GUS/cbn/metadata.json",
+    "vendor": "CITRIX",
+    "product": "CITRIX_STOREFRONT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "75528b2db3e4a05ee88a5b555f00a25ba3f7ef32",
+    "latest_commit_time": 1786085819
+  },
+  {
+    "log_type": "CLEARSWIFT",
+    "config_path": "content/parsers/third_party/community/CLEARSWIFT_GUS/cbn/default_clearswift.conf",
+    "metadata_path": "content/parsers/third_party/community/CLEARSWIFT_GUS/cbn/metadata.json",
+    "vendor": "CLEARSWIFT",
+    "product": "CLEARSWIFT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CLOUDFLARE_PAGESHIELD",
+    "config_path": "content/parsers/third_party/community/CLOUDFLARE_PAGESHIELD_GUS/cbn/default_cloudflare_pageshield.conf",
+    "metadata_path": "content/parsers/third_party/community/CLOUDFLARE_PAGESHIELD_GUS/cbn/metadata.json",
+    "vendor": "CLOUDFLARE_PAGESHIELD",
+    "product": "CLOUDFLARE_PAGESHIELD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CLOUDIAN_HYPERSTORE",
+    "config_path": "content/parsers/third_party/community/CLOUDIAN_HYPERSTORE_GUS/cbn/default_cloudian_hyperstore.conf",
+    "metadata_path": "content/parsers/third_party/community/CLOUDIAN_HYPERSTORE_GUS/cbn/metadata.json",
+    "vendor": "CLOUDIAN_HYPERSTORE",
+    "product": "CLOUDIAN_HYPERSTORE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CLOUDM",
+    "config_path": "content/parsers/third_party/community/CLOUDM_GUS/cbn/default_cloudm.conf",
+    "metadata_path": "content/parsers/third_party/community/CLOUDM_GUS/cbn/metadata.json",
+    "vendor": "CLOUDM",
+    "product": "CLOUDM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "COMFORTE_SECURDPS",
+    "config_path": "content/parsers/third_party/community/COMFORTE_SECURDPS_GUS/cbn/default_comforte_securdps.conf",
+    "metadata_path": "content/parsers/third_party/community/COMFORTE_SECURDPS_GUS/cbn/metadata.json",
+    "vendor": "COMFORTE_SECURDPS",
+    "product": "COMFORTE_SECURDPS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "COMODO_AV",
+    "config_path": "content/parsers/third_party/community/COMODO_AV_GUS/cbn/default_comodo_av.conf",
+    "metadata_path": "content/parsers/third_party/community/COMODO_AV_GUS/cbn/metadata.json",
+    "vendor": "COMODO_AV",
+    "product": "COMODO_AV",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CSG_CITRIX_RX",
+    "config_path": "content/parsers/third_party/community/CSG_CITRIX_RX_GUS/cbn/default_csg_citrix_rx.conf",
+    "metadata_path": "content/parsers/third_party/community/CSG_CITRIX_RX_GUS/cbn/metadata.json",
+    "vendor": "CSG_CITRIX_RX",
+    "product": "CSG_CITRIX_RX",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CT_GAUS_SEGUROS",
+    "config_path": "content/parsers/third_party/community/CT_GAUS_SEGUROS_GUS/cbn/default_ct_gaus_seguros.conf",
+    "metadata_path": "content/parsers/third_party/community/CT_GAUS_SEGUROS_GUS/cbn/metadata.json",
+    "vendor": "CT_GAUS_SEGUROS",
+    "product": "CT_GAUS_SEGUROS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CYBERGATEKEEPER_NAC",
+    "config_path": "content/parsers/third_party/community/CYBERGATEKEEPER_NAC_GUS/cbn/default_cybergatekeeper_nac.conf",
+    "metadata_path": "content/parsers/third_party/community/CYBERGATEKEEPER_NAC_GUS/cbn/metadata.json",
+    "vendor": "CYBERGATEKEEPER_NAC",
+    "product": "CYBERGATEKEEPER_NAC",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CYBER_2_IDS",
+    "config_path": "content/parsers/third_party/community/CYBER_2_IDS_GUS/cbn/default_cyber_2_ids.conf",
+    "metadata_path": "content/parsers/third_party/community/CYBER_2_IDS_GUS/cbn/metadata.json",
+    "vendor": "CYBER_2_IDS",
+    "product": "CYBER_2_IDS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "41f851cb4b1812f07dc1c097d71eca0fa6235b2b",
+    "latest_commit_time": 1786085850
+  },
+  {
+    "log_type": "CYNET_360_AUTOXDR",
+    "config_path": "content/parsers/third_party/community/CYNET_360_AUTOXDR_GUS/cbn/default_cynet_360_autoxdr.conf",
+    "metadata_path": "content/parsers/third_party/community/CYNET_360_AUTOXDR_GUS/cbn/metadata.json",
+    "vendor": "CYNET_360_AUTOXDR",
+    "product": "CYNET_360_AUTOXDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DATTO_FILE_PROTECTION",
+    "config_path": "content/parsers/third_party/community/DATTO_FILE_PROTECTION_GUS/cbn/default_datto_file_protection.conf",
+    "metadata_path": "content/parsers/third_party/community/DATTO_FILE_PROTECTION_GUS/cbn/metadata.json",
+    "vendor": "DATTO_FILE_PROTECTION",
+    "product": "DATTO_FILE_PROTECTION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DEEP_INSTINCT_EDR",
+    "config_path": "content/parsers/third_party/community/DEEP_INSTINCT_EDR_GUS/cbn/default_deep_instinct_edr.conf",
+    "metadata_path": "content/parsers/third_party/community/DEEP_INSTINCT_EDR_GUS/cbn/metadata.json",
+    "vendor": "DEEP_INSTINCT_EDR",
+    "product": "DEEP_INSTINCT_EDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DELINEA_DISTRIBUTED_ENGINE",
+    "config_path": "content/parsers/third_party/community/DELINEA_DISTRIBUTED_ENGINE_GUS/cbn/default_delinea_distributed_engine.conf",
+    "metadata_path": "content/parsers/third_party/community/DELINEA_DISTRIBUTED_ENGINE_GUS/cbn/metadata.json",
+    "vendor": "DELINEA_DISTRIBUTED_ENGINE",
+    "product": "DELINEA_DISTRIBUTED_ENGINE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DELL_CYBERSENSE",
+    "config_path": "content/parsers/third_party/community/DELL_CYBERSENSE_GUS/cbn/default_dell_cybersense.conf",
+    "metadata_path": "content/parsers/third_party/community/DELL_CYBERSENSE_GUS/cbn/metadata.json",
+    "vendor": "DELL_CYBERSENSE",
+    "product": "DELL_CYBERSENSE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DIGICERT",
+    "config_path": "content/parsers/third_party/community/DIGICERT_GUS/cbn/default_digicert.conf",
+    "metadata_path": "content/parsers/third_party/community/DIGICERT_GUS/cbn/metadata.json",
+    "vendor": "DIGICERT",
+    "product": "DIGICERT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DIGITALGUARDIAN_DLP",
+    "config_path": "content/parsers/third_party/community/DIGITALGUARDIAN_DLP_GUS/cbn/default_digitalguardian_dlp.conf",
+    "metadata_path": "content/parsers/third_party/community/DIGITALGUARDIAN_DLP_GUS/cbn/metadata.json",
+    "vendor": "DIGITALGUARDIAN_DLP",
+    "product": "DIGITALGUARDIAN_DLP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DIGITALGUARDIAN_EDR",
+    "config_path": "content/parsers/third_party/community/DIGITALGUARDIAN_EDR_GUS/cbn/default_digitalguardian_edr.conf",
+    "metadata_path": "content/parsers/third_party/community/DIGITALGUARDIAN_EDR_GUS/cbn/metadata.json",
+    "vendor": "DIGITALGUARDIAN_EDR",
+    "product": "DIGITALGUARDIAN_EDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "DIGITAL_SHADOWS_IOC",
+    "config_path": "content/parsers/third_party/community/DIGITAL_SHADOWS_IOC_GUS/cbn/default_digital_shadows_ioc.conf",
+    "metadata_path": "content/parsers/third_party/community/DIGITAL_SHADOWS_IOC_GUS/cbn/metadata.json",
+    "vendor": "DIGITAL_SHADOWS_IOC",
+    "product": "DIGITAL_SHADOWS_IOC",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DIGITAL_SHADOWS_SEARCHLIGHT",
+    "config_path": "content/parsers/third_party/community/DIGITAL_SHADOWS_SEARCHLIGHT_GUS/cbn/default_digital_shadows_searchlight.conf",
+    "metadata_path": "content/parsers/third_party/community/DIGITAL_SHADOWS_SEARCHLIGHT_GUS/cbn/metadata.json",
+    "vendor": "DIGITAL_SHADOWS_SEARCHLIGHT",
+    "product": "DIGITAL_SHADOWS_SEARCHLIGHT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DIGI_MODEMS",
+    "config_path": "content/parsers/third_party/community/DIGI_MODEMS_GUS/cbn/default_digi_modems.conf",
+    "metadata_path": "content/parsers/third_party/community/DIGI_MODEMS_GUS/cbn/metadata.json",
+    "vendor": "DIGI_MODEMS",
+    "product": "DIGI_MODEMS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2b2598285979e1053db03f098749899c0fc1e97b",
+    "latest_commit_time": 1786086078
+  },
+  {
+    "log_type": "DMP_ENTRE",
+    "config_path": "content/parsers/third_party/community/DMP_ENTRE_GUS/cbn/default_dmp_entre.conf",
+    "metadata_path": "content/parsers/third_party/community/DMP_ENTRE_GUS/cbn/metadata.json",
+    "vendor": "DMP_ENTRE",
+    "product": "DMP_ENTRE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "DOMAINTOOLS_THREATINTEL",
+    "config_path": "content/parsers/third_party/community/DOMAINTOOLS_THREATINTEL_GUS/cbn/default_domaintools_threatintel.conf",
+    "metadata_path": "content/parsers/third_party/community/DOMAINTOOLS_THREATINTEL_GUS/cbn/metadata.json",
+    "vendor": "DOMAINTOOLS_THREATINTEL",
+    "product": "DOMAINTOOLS_THREATINTEL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "DOPE_SWG",
+    "config_path": "content/parsers/third_party/community/DOPE_SWG_GUS/cbn/default_dope_swg.conf",
+    "metadata_path": "content/parsers/third_party/community/DOPE_SWG_GUS/cbn/metadata.json",
+    "vendor": "DOPE_SWG",
+    "product": "DOPE_SWG",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "ELASTIC_DEFEND",
+    "config_path": "content/parsers/third_party/community/ELASTIC_DEFEND_GUS/cbn/default_elastic_defend.conf",
+    "metadata_path": "content/parsers/third_party/community/ELASTIC_DEFEND_GUS/cbn/metadata.json",
+    "vendor": "ELASTIC_DEFEND",
+    "product": "ELASTIC_DEFEND",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "ENTRUST_HSM",
+    "config_path": "content/parsers/third_party/community/ENTRUST_HSM_GUS/cbn/default_entrust_hsm.conf",
+    "metadata_path": "content/parsers/third_party/community/ENTRUST_HSM_GUS/cbn/metadata.json",
+    "vendor": "ENTRUST_HSM",
+    "product": "ENTRUST_HSM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "ERGON_INFORMATIK_AIRLOCK_IAM",
+    "config_path": "content/parsers/third_party/community/ERGON_INFORMATIK_AIRLOCK_IAM_GUS/cbn/default_airlock_iam.conf",
+    "metadata_path": "content/parsers/third_party/community/ERGON_INFORMATIK_AIRLOCK_IAM_GUS/cbn/metadata.json",
+    "vendor": "ERGON_INFORMATIK_AIRLOCK_IAM",
+    "product": "ERGON_INFORMATIK_AIRLOCK_IAM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "ESET_IOC",
+    "config_path": "content/parsers/third_party/community/ESET_IOC_GUS/cbn/default_eset_ioc.conf",
+    "metadata_path": "content/parsers/third_party/community/ESET_IOC_GUS/cbn/metadata.json",
+    "vendor": "ESET_IOC",
+    "product": "ESET_IOC",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "EVISION_FIRCOSOFT",
+    "config_path": "content/parsers/third_party/community/EVISION_FIRCOSOFT_GUS/cbn/default_evision_fircosoft.conf",
+    "metadata_path": "content/parsers/third_party/community/EVISION_FIRCOSOFT_GUS/cbn/metadata.json",
+    "vendor": "EVISION_FIRCOSOFT",
+    "product": "EVISION_FIRCOSOFT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "F5_SHAPE",
+    "config_path": "content/parsers/third_party/community/F5_SHAPE_GUS/cbn/default_f5_shape.conf",
+    "metadata_path": "content/parsers/third_party/community/F5_SHAPE_GUS/cbn/metadata.json",
+    "vendor": "F5_SHAPE",
+    "product": "F5_SHAPE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bd1a25b2d8b70d422244f248cb1ee74bf2faed00",
+    "latest_commit_time": 1786086404
+  },
+  {
+    "log_type": "FILEZILLA_FTP",
+    "config_path": "content/parsers/third_party/community/FILEZILLA_FTP_GUS/cbn/default_filezilla_ftp.conf",
+    "metadata_path": "content/parsers/third_party/community/FILEZILLA_FTP_GUS/cbn/metadata.json",
+    "vendor": "FILEZILLA",
+    "product": "FILEZILLA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FINGERPRINT_JS",
+    "config_path": "content/parsers/third_party/community/FINGERPRINT_JS_GUS/cbn/default_fingerprint_js.conf",
+    "metadata_path": "content/parsers/third_party/community/FINGERPRINT_JS_GUS/cbn/metadata.json",
+    "vendor": "FINGERPRINT_JS",
+    "product": "FINGERPRINT_JS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FIREEYE_HX_AUDIT",
+    "config_path": "content/parsers/third_party/community/FIREEYE_HX_AUDIT_GUS/cbn/default_fireeye_hx_audit.conf",
+    "metadata_path": "content/parsers/third_party/community/FIREEYE_HX_AUDIT_GUS/cbn/metadata.json",
+    "vendor": "FIREEYE_HX_AUDIT",
+    "product": "FIREEYE_HX_AUDIT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FIREEYE_NX_AUDIT",
+    "config_path": "content/parsers/third_party/community/FIREEYE_NX_AUDIT_GUS/cbn/default_fireeye_nx_audit.conf",
+    "metadata_path": "content/parsers/third_party/community/FIREEYE_NX_AUDIT_GUS/cbn/metadata.json",
+    "vendor": "FIREEYE_NX_AUDIT",
+    "product": "FIREEYE_NX_AUDIT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FIVETRAN",
+    "config_path": "content/parsers/third_party/community/FIVETRAN_GUS/cbn/default_fivetran.conf",
+    "metadata_path": "content/parsers/third_party/community/FIVETRAN_GUS/cbn/metadata.json",
+    "vendor": "FIVETRAN",
+    "product": "FIVETRAN",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FORCEPOINT_CASB",
+    "config_path": "content/parsers/third_party/community/FORCEPOINT_CASB_GUS/cbn/default_forcepoint_casb.conf",
+    "metadata_path": "content/parsers/third_party/community/FORCEPOINT_CASB_GUS/cbn/metadata.json",
+    "vendor": "FORCEPOINT_CASB",
+    "product": "FORCEPOINT_CASB",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FORCEPOINT_MAIL_RELAY",
+    "config_path": "content/parsers/third_party/community/FORCEPOINT_MAIL_RELAY_GUS/cbn/default_forcepoint_mail_relay.conf",
+    "metadata_path": "content/parsers/third_party/community/FORCEPOINT_MAIL_RELAY_GUS/cbn/metadata.json",
+    "vendor": "FORCEPOINT_MAIL_RELAY",
+    "product": "FORCEPOINT_MAIL_RELAY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FORGEROCK_IDENTITY_CLOUD",
+    "config_path": "content/parsers/third_party/community/FORGEROCK_IDENTITY_CLOUD_GUS/cbn/default_forgerock_identity_cloud.conf",
+    "metadata_path": "content/parsers/third_party/community/FORGEROCK_IDENTITY_CLOUD_GUS/cbn/metadata.json",
+    "vendor": "FORGEROCK_IDENTITY_CLOUD",
+    "product": "FORGEROCK_IDENTITY_CLOUD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "FORTINET_FORTIDDOS",
+    "config_path": "content/parsers/third_party/community/FORTINET_FORTIDDOS_GUS/cbn/default_fortinet_fortiddos.conf",
+    "metadata_path": "content/parsers/third_party/community/FORTINET_FORTIDDOS_GUS/cbn/metadata.json",
+    "vendor": "FORTINET_FORTIDDOS",
+    "product": "FORTINET_FORTIDDOS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "515fed658730484f3f7842a7ff52f7527ef3555c",
+    "latest_commit_time": 1786101471
+  },
+  {
+    "log_type": "GITGUARDIAN_ENTERPRISE",
+    "config_path": "content/parsers/third_party/community/GITGUARDIAN_ENTERPRISE_GUS/cbn/default_gitguardian_enterprise.conf",
+    "metadata_path": "content/parsers/third_party/community/GITGUARDIAN_ENTERPRISE_GUS/cbn/metadata.json",
+    "vendor": "GITGUARDIAN_ENTERPRISE",
+    "product": "GITGUARDIAN_ENTERPRISE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22f67f36929fe4bb962b2160532019a69b8b901d",
+    "latest_commit_time": 1786086486
+  },
+  {
+    "log_type": "GITHUB_DEPENDABOT",
+    "config_path": "content/parsers/third_party/community/GITHUB_DEPENDABOT_GUS/cbn/default_github_dependabot.conf",
+    "metadata_path": "content/parsers/third_party/community/GITHUB_DEPENDABOT_GUS/cbn/metadata.json",
+    "vendor": "GITHUB_DEPENDABOT",
+    "product": "GITHUB_DEPENDABOT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "GREYNOISE",
+    "config_path": "content/parsers/third_party/community/GREYNOISE_GUS/cbn/default_greynoise.conf",
+    "metadata_path": "content/parsers/third_party/community/GREYNOISE_GUS/cbn/metadata.json",
+    "vendor": "GREYNOISE",
+    "product": "GREYNOISE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HACKERONE",
+    "config_path": "content/parsers/third_party/community/HACKERONE_GUS/cbn/default_hackerone.conf",
+    "metadata_path": "content/parsers/third_party/community/HACKERONE_GUS/cbn/metadata.json",
+    "vendor": "HACKERONE",
+    "product": "HACKERONE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HADOOP",
+    "config_path": "content/parsers/third_party/community/HADOOP_GUS/cbn/default_hadoop.conf",
+    "metadata_path": "content/parsers/third_party/community/HADOOP_GUS/cbn/metadata.json",
+    "vendor": "HADOOP",
+    "product": "HADOOP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HASHICORP_BOUNDARY",
+    "config_path": "content/parsers/third_party/community/HASHICORP_BOUNDARY/cbn/default_hashicorp_boundary.conf",
+    "metadata_path": "content/parsers/third_party/community/HASHICORP_BOUNDARY/cbn/metadata.json",
+    "vendor": "HASHICORP",
+    "product": "HASHICORP_BOUNDARY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "bf01c4bf91a86cccb2b2414954e4a5c326e7b60e",
+    "latest_commit_time": 1786433355
+  },
+  {
+    "log_type": "HCL_BIGFIX",
+    "config_path": "content/parsers/third_party/community/HCL_BIGFIX_GUS/cbn/default_hcl_bigfix.conf",
+    "metadata_path": "content/parsers/third_party/community/HCL_BIGFIX_GUS/cbn/metadata.json",
+    "vendor": "HCL_BIGFIX",
+    "product": "HCL_BIGFIX",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HCNET_ACCOUNT_ADAPTER",
+    "config_path": "content/parsers/third_party/community/HCNET_ACCOUNT_ADAPTER_GUS/cbn/default_hcnet_account_adapter.conf",
+    "metadata_path": "content/parsers/third_party/community/HCNET_ACCOUNT_ADAPTER_GUS/cbn/metadata.json",
+    "vendor": "HCNET_ACCOUNT_ADAPTER",
+    "product": "HCNET_ACCOUNT_ADAPTER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HID_DIGITALPERSONA",
+    "config_path": "content/parsers/third_party/community/HID_DIGITALPERSONA_GUS/cbn/default_hid_digitalpersona.conf",
+    "metadata_path": "content/parsers/third_party/community/HID_DIGITALPERSONA_GUS/cbn/metadata.json",
+    "vendor": "HID_DIGITALPERSONA",
+    "product": "HID_DIGITALPERSONA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HILLSTONE_NGFW",
+    "config_path": "content/parsers/third_party/community/HILLSTONE_NGFW_GUS/cbn/default_hillstone_ngfw.conf",
+    "metadata_path": "content/parsers/third_party/community/HILLSTONE_NGFW_GUS/cbn/metadata.json",
+    "vendor": "HILLSTONE_NGFW",
+    "product": "HILLSTONE_NGFW",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HITACHI_CLOUD_PLATFORM",
+    "config_path": "content/parsers/third_party/community/HITACHI_CLOUD_PLATFORM_GUS/cbn/default_hitachi_cloud_platform.conf",
+    "metadata_path": "content/parsers/third_party/community/HITACHI_CLOUD_PLATFORM_GUS/cbn/metadata.json",
+    "vendor": "HITACHI_CLOUD_PLATFORM",
+    "product": "HITACHI_CLOUD_PLATFORM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HPE_BLADESYSTEM_C7000",
+    "config_path": "content/parsers/third_party/community/HPE_BLADESYSTEM_C7000_GUS/cbn/default_hpe_bladesystem_c7000.conf",
+    "metadata_path": "content/parsers/third_party/community/HPE_BLADESYSTEM_C7000_GUS/cbn/metadata.json",
+    "vendor": "HPE_BLADESYSTEM_C7000",
+    "product": "HPE_BLADESYSTEM_C7000",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b17bcecbd09789146bb02fe04088183922f4a317",
+    "latest_commit_time": 1786087493
+  },
+  {
+    "log_type": "HUAWEI_VRP",
+    "config_path": "content/parsers/third_party/community/HUAWEI_VRP/cbn/default_huawei_vrp.conf",
+    "metadata_path": "content/parsers/third_party/community/HUAWEI_VRP/cbn/metadata.json",
+    "vendor": "HUAWEI",
+    "product": "HUAWEI_VRP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "fbc5e5e18735e6c868660c1cfee110bb999ab9c3",
+    "latest_commit_time": 1786452295
+  },
+  {
+    "log_type": "HYPR_MFA",
+    "config_path": "content/parsers/third_party/community/HYPR_MFA_GUS/cbn/default_hypr_mfa.conf",
+    "metadata_path": "content/parsers/third_party/community/HYPR_MFA_GUS/cbn/metadata.json",
+    "vendor": "HYPR_MFA",
+    "product": "HYPR_MFA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
     "log_type": "IBM_B2B_INTEGRATOR",
     "config_path": "content/parsers/third_party/community/IBM_B2B_INTEGRATOR/cbn/default_ibm_b2b_integrator.conf",
     "metadata_path": "content/parsers/third_party/community/IBM_B2B_INTEGRATOR/cbn/metadata.json",
@@ -8,6 +1038,196 @@
     "source": "COMMUNITY",
     "latest_commit_id": "c734ab262730917de880cc9ef7f80f578722d544",
     "latest_commit_time": 1783312850
+  },
+  {
+    "log_type": "IBM_CICS",
+    "config_path": "content/parsers/third_party/community/IBM_CICS_GUS/cbn/default_ibm_cics.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_CICS_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "CICS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_DS8000",
+    "config_path": "content/parsers/third_party/community/IBM_DS8000_GUS/cbn/default_ibm_ds8000.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_DS8000_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "IBM DS8000",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_LTO",
+    "config_path": "content/parsers/third_party/community/IBM_LTO_GUS/cbn/default_ibm_lto.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_LTO_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "IBM LTO",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_MAAS360",
+    "config_path": "content/parsers/third_party/community/IBM_MAAS360_GUS/cbn/default_ibm_maas360.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_MAAS360_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "IBM MAAS360",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_OPENPAGES",
+    "config_path": "content/parsers/third_party/community/IBM_OPENPAGES_GUS/cbn/default_ibm_openpages.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_OPENPAGES_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "OPENPAGES",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_QRADAR",
+    "config_path": "content/parsers/third_party/community/IBM_QRADAR_GUS/cbn/default_ibm_qradar.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_QRADAR_GUS/cbn/metadata.json",
+    "vendor": "IBM_QRADAR",
+    "product": "IBM QRADAR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_SAFENET",
+    "config_path": "content/parsers/third_party/community/IBM_SAFENET_GUS/cbn/default_ibm_safenet.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_SAFENET_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "IBM_SAFENET",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_SECURITY_VERIFY",
+    "config_path": "content/parsers/third_party/community/IBM_SECURITY_VERIFY_GUS/cbn/default_ibm_security_verify.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_SECURITY_VERIFY_GUS/cbn/metadata.json",
+    "vendor": "IBM_SECURITY_VERIFY",
+    "product": "IBM_SECURITY_VERIFY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "daff1fada83f11e665ef96253ced9f8829fb0602",
+    "latest_commit_time": 1786096085
+  },
+  {
+    "log_type": "IBM_SIM",
+    "config_path": "content/parsers/third_party/community/IBM_SIM_GUS/cbn/default_ibm_sim.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_SIM_GUS/cbn/metadata.json",
+    "vendor": "IBM_SIM",
+    "product": "IBM_SIM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IBM_SOAR",
+    "config_path": "content/parsers/third_party/community/IBM_SOAR_GUS/cbn/default_ibm_soar.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_SOAR_GUS/cbn/metadata.json",
+    "vendor": "IBM SOAR",
+    "product": "IBM SOAR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IBM_SVA",
+    "config_path": "content/parsers/third_party/community/IBM_SVA_GUS/cbn/default_ibm_sva.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_SVA_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "IBM_SVA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IBM_WEBSEAL",
+    "config_path": "content/parsers/third_party/community/IBM_WEBSEAL_GUS/cbn/default_ibm_webseal.conf",
+    "metadata_path": "content/parsers/third_party/community/IBM_WEBSEAL_GUS/cbn/metadata.json",
+    "vendor": "IBM",
+    "product": "WEBSEAL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IMPERVA_ABP",
+    "config_path": "content/parsers/third_party/community/IMPERVA_ABP_GUS/cbn/default_imperva_abp.conf",
+    "metadata_path": "content/parsers/third_party/community/IMPERVA_ABP_GUS/cbn/metadata.json",
+    "vendor": "IMPERVA_ABP",
+    "product": "IMPERVA_ABP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IMPERVA_DRA",
+    "config_path": "content/parsers/third_party/community/IMPERVA_DRA_GUS/cbn/default_imperva_dra.conf",
+    "metadata_path": "content/parsers/third_party/community/IMPERVA_DRA_GUS/cbn/metadata.json",
+    "vendor": "IMPERVA",
+    "product": "IMPERVA_DRA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "INTEL471_WATCHER_ALERTS",
+    "config_path": "content/parsers/third_party/community/INTEL471_WATCHER_ALERTS_GUS/cbn/default_intel471_watcher_alerts.conf",
+    "metadata_path": "content/parsers/third_party/community/INTEL471_WATCHER_ALERTS_GUS/cbn/metadata.json",
+    "vendor": "INTEL471_WATCHER_ALERTS",
+    "product": "INTEL471_WATCHER_ALERTS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "INTEL_EMA",
+    "config_path": "content/parsers/third_party/community/INTEL_EMA_GUS/cbn/default_intel_ema.conf",
+    "metadata_path": "content/parsers/third_party/community/INTEL_EMA_GUS/cbn/metadata.json",
+    "vendor": "INTEL_EMA",
+    "product": "INTEL_EMA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "ION_SPECTRUM",
+    "config_path": "content/parsers/third_party/community/ION_SPECTRUM_GUS/cbn/default_ion_spectrum.conf",
+    "metadata_path": "content/parsers/third_party/community/ION_SPECTRUM_GUS/cbn/metadata.json",
+    "vendor": "ION_SPECTRUM",
+    "product": "ION_SPECTRUM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IPSWITCH_SFTP",
+    "config_path": "content/parsers/third_party/community/IPSWITCH_SFTP_GUS/cbn/default_ipswitch_sftp.conf",
+    "metadata_path": "content/parsers/third_party/community/IPSWITCH_SFTP_GUS/cbn/metadata.json",
+    "vendor": "IPSWITCH",
+    "product": "IPSWITCH_SFTP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c0e2bd03cb43f1369d211181efb2e565213795ca",
+    "latest_commit_time": 1786029814
+  },
+  {
+    "log_type": "IRONSTREAM_ZOS",
+    "config_path": "content/parsers/third_party/community/IRONSTREAM_ZOS_GUS/cbn/default_ironstream_zos.conf",
+    "metadata_path": "content/parsers/third_party/community/IRONSTREAM_ZOS_GUS/cbn/metadata.json",
+    "vendor": "IRONSTREAM_ZOS",
+    "product": "ZOS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
   },
   {
     "log_type": "JBOSS_WEB",
@@ -20,6 +1240,36 @@
     "latest_commit_time": 1786015012
   },
   {
+    "log_type": "JUNIPER_IPS",
+    "config_path": "content/parsers/third_party/community/JUNIPER_IPS_GUS/cbn/default_juniper_ips.conf",
+    "metadata_path": "content/parsers/third_party/community/JUNIPER_IPS_GUS/cbn/metadata.json",
+    "vendor": "JUNIPER",
+    "product": "JUNIPER_IPS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "KEA_DHCP",
+    "config_path": "content/parsers/third_party/community/KEA_DHCP_GUS/cbn/default_kea_dhcp.conf",
+    "metadata_path": "content/parsers/third_party/community/KEA_DHCP_GUS/cbn/metadata.json",
+    "vendor": "KEA",
+    "product": "KEA_DHCP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "KERIOCONTROL",
+    "config_path": "content/parsers/third_party/community/KERIOCONTROL_GUS/cbn/default_keriocontrol.conf",
+    "metadata_path": "content/parsers/third_party/community/KERIOCONTROL_GUS/cbn/metadata.json",
+    "vendor": "KERIOCONTROL",
+    "product": "KERIOCONTROL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
     "log_type": "KEYFACTOR",
     "config_path": "content/parsers/third_party/community/KEYFACTOR/cbn/default_keyfactor.conf",
     "metadata_path": "content/parsers/third_party/community/KEYFACTOR/cbn/metadata.json",
@@ -28,6 +1278,136 @@
     "source": "COMMUNITY",
     "latest_commit_id": "3cad7681cffae37a43b687584f16edc94cd681ed",
     "latest_commit_time": 1782213528
+  },
+  {
+    "log_type": "KISI",
+    "config_path": "content/parsers/third_party/community/KISI_GUS/cbn/default_kisi.conf",
+    "metadata_path": "content/parsers/third_party/community/KISI_GUS/cbn/metadata.json",
+    "vendor": "KISI",
+    "product": "KISI",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "KOLIDE",
+    "config_path": "content/parsers/third_party/community/KOLIDE_GUS/cbn/default_kolide.conf",
+    "metadata_path": "content/parsers/third_party/community/KOLIDE_GUS/cbn/metadata.json",
+    "vendor": "KOLIDE",
+    "product": "KOLIDE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "KUBERNETES_AUTH_PROXY",
+    "config_path": "content/parsers/third_party/community/KUBERNETES_AUTH_PROXY_GUS/cbn/default_kubernetes_auth_proxy.conf",
+    "metadata_path": "content/parsers/third_party/community/KUBERNETES_AUTH_PROXY_GUS/cbn/metadata.json",
+    "vendor": "KUBERNETES",
+    "product": "KUBERNETES_AUTH_PROXY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "KYRIBA",
+    "config_path": "content/parsers/third_party/community/KYRIBA_GUS/cbn/default_kyriba.conf",
+    "metadata_path": "content/parsers/third_party/community/KYRIBA_GUS/cbn/metadata.json",
+    "vendor": "KYRIBA",
+    "product": "KYRIBA TREASURY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "LENEL_ONGUARD",
+    "config_path": "content/parsers/third_party/community/LENEL_ONGUARD_GUS/cbn/default_lenel_onguard.conf",
+    "metadata_path": "content/parsers/third_party/community/LENEL_ONGUARD_GUS/cbn/metadata.json",
+    "vendor": "LENEL",
+    "product": "ONGUARD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "LINKSHADOW_NDR",
+    "config_path": "content/parsers/third_party/community/LINKSHADOW_NDR_GUS/cbn/default_linkshadow_ndr.conf",
+    "metadata_path": "content/parsers/third_party/community/LINKSHADOW_NDR_GUS/cbn/metadata.json",
+    "vendor": "LINKSHADOW",
+    "product": "LINKSHADOW",
+    "source": "COMMUNITY",
+    "latest_commit_id": "42e8e03a9d67005d16899b359741cc9bc65b498f",
+    "latest_commit_time": 1786029876
+  },
+  {
+    "log_type": "LOGONBOX",
+    "config_path": "content/parsers/third_party/community/LOGONBOX_GUS/cbn/default_logonbox.conf",
+    "metadata_path": "content/parsers/third_party/community/LOGONBOX_GUS/cbn/metadata.json",
+    "vendor": "LOGONBOX",
+    "product": "LOGONBOX",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "LUCID",
+    "config_path": "content/parsers/third_party/community/LUCID_GUS/cbn/default_lucid.conf",
+    "metadata_path": "content/parsers/third_party/community/LUCID_GUS/cbn/metadata.json",
+    "vendor": "LUCID",
+    "product": "LUCIDCHART",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MACOS_ENDPOINT_SECURITY",
+    "config_path": "content/parsers/third_party/community/MACOS_ENDPOINT_SECURITY_GUS/cbn/default_macos_endpoint_security.conf",
+    "metadata_path": "content/parsers/third_party/community/MACOS_ENDPOINT_SECURITY_GUS/cbn/metadata.json",
+    "vendor": "APPLE",
+    "product": "MACOS_ENDPOINT_SECURITY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MAILMARSHAL",
+    "config_path": "content/parsers/third_party/community/MAILMARSHAL_GUS/cbn/default_mailmarshal.conf",
+    "metadata_path": "content/parsers/third_party/community/MAILMARSHAL_GUS/cbn/metadata.json",
+    "vendor": "MAILMARSHAL",
+    "product": "MAILMARSHAL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MALWAREBYTES_EDR",
+    "config_path": "content/parsers/third_party/community/MALWAREBYTES_EDR_GUS/cbn/default_malwarebytes_edr.conf",
+    "metadata_path": "content/parsers/third_party/community/MALWAREBYTES_EDR_GUS/cbn/metadata.json",
+    "vendor": "MALWAREBYTES",
+    "product": "MALWAREBYTES_EDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MANAGE_ENGINE_AD360",
+    "config_path": "content/parsers/third_party/community/MANAGE_ENGINE_AD360_GUS/cbn/default_manage_engine_ad360.conf",
+    "metadata_path": "content/parsers/third_party/community/MANAGE_ENGINE_AD360_GUS/cbn/metadata.json",
+    "vendor": "MANAGE_ENGINE_AD360",
+    "product": "MANAGE_ENGINE_AD360",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MANAGE_ENGINE_ENDPT_CNTRL",
+    "config_path": "content/parsers/third_party/community/MANAGE_ENGINE_ENDPT_CNTRL/cbn/default_manage_engine_endpt_cntrl.conf",
+    "metadata_path": "content/parsers/third_party/community/MANAGE_ENGINE_ENDPT_CNTRL/cbn/metadata.json",
+    "vendor": "MANAGEENGINE",
+    "product": "MANAGEENGINE ENDPOINT CENTRAL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "15420568b19867a79ebf3c1c602d83af9f778b54",
+    "latest_commit_time": 1786339409
   },
   {
     "log_type": "MANAGE_ENGINE_PAM360",
@@ -40,6 +1420,256 @@
     "latest_commit_time": 1782718534
   },
   {
+    "log_type": "MANAGE_ENGINE_REPORTER_PLUS",
+    "config_path": "content/parsers/third_party/community/MANAGE_ENGINE_REPORTER_PLUS_GUS/cbn/default_manage_engine_reporter_plus.conf",
+    "metadata_path": "content/parsers/third_party/community/MANAGE_ENGINE_REPORTER_PLUS_GUS/cbn/metadata.json",
+    "vendor": "MANAGE_ENGINE_REPORTER_PLUS",
+    "product": "MANAGE_ENGINE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MCAFEE_MVISION_CASB",
+    "config_path": "content/parsers/third_party/community/MCAFEE_MVISION_CASB_GUS/cbn/default_mcafee_mvision_casb.conf",
+    "metadata_path": "content/parsers/third_party/community/MCAFEE_MVISION_CASB_GUS/cbn/metadata.json",
+    "vendor": "MCAFEE",
+    "product": "MVISION_CLOUD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MCAFEE_WEB_PROTECTION",
+    "config_path": "content/parsers/third_party/community/MCAFEE_WEB_PROTECTION_GUS/cbn/default_mcafee_web_protection.conf",
+    "metadata_path": "content/parsers/third_party/community/MCAFEE_WEB_PROTECTION_GUS/cbn/metadata.json",
+    "vendor": "MCAFEE_WEB_PROTECTION",
+    "product": "MCAFEE_WEB_PROTECTION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "METABASE",
+    "config_path": "content/parsers/third_party/community/METABASE_GUS/cbn/default_metabase.conf",
+    "metadata_path": "content/parsers/third_party/community/METABASE_GUS/cbn/metadata.json",
+    "vendor": "METABASE",
+    "product": "METABASE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "174e07132467a332d532f28e6e0a5b576e7a4869",
+    "latest_commit_time": 1786030017
+  },
+  {
+    "log_type": "MICROFOCUS_IMANAGER",
+    "config_path": "content/parsers/third_party/community/MICROFOCUS_IMANAGER_GUS/cbn/default_microfocus_imanager.conf",
+    "metadata_path": "content/parsers/third_party/community/MICROFOCUS_IMANAGER_GUS/cbn/metadata.json",
+    "vendor": "MICROFOCUS_IMANAGER",
+    "product": "MICROFOCUS_IMANAGER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "MICROSOFT_ATA",
+    "config_path": "content/parsers/third_party/community/MICROSOFT_ATA_GUS/cbn/default_microsoft_ata.conf",
+    "metadata_path": "content/parsers/third_party/community/MICROSOFT_ATA_GUS/cbn/metadata.json",
+    "vendor": "MICROSOFT_ATA",
+    "product": "MICROSOFT_ATA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "MICROSOFT_DEFENDER_ENDPOINT_IOS",
+    "config_path": "content/parsers/third_party/community/MICROSOFT_DEFENDER_ENDPOINT_IOS_GUS/cbn/default_microsoft_defender_endpoint_ios.conf",
+    "metadata_path": "content/parsers/third_party/community/MICROSOFT_DEFENDER_ENDPOINT_IOS_GUS/cbn/metadata.json",
+    "vendor": "MICROSOFT_DEFENDER_ENDPOINT_IOS",
+    "product": "MICROSOFT_DEFENDER_ENDPOINT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "MICROSOFT_IAS",
+    "config_path": "content/parsers/third_party/community/MICROSOFT_IAS_GUS/cbn/default_microsoft_ias.conf",
+    "metadata_path": "content/parsers/third_party/community/MICROSOFT_IAS_GUS/cbn/metadata.json",
+    "vendor": "MICROSOFT_IAS",
+    "product": "MICROSOFT_IAS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "MICROSOFT_SCEP",
+    "config_path": "content/parsers/third_party/community/MICROSOFT_SCEP_GUS/cbn/default_microsoft_scep.conf",
+    "metadata_path": "content/parsers/third_party/community/MICROSOFT_SCEP_GUS/cbn/metadata.json",
+    "vendor": "MICROSOFT",
+    "product": "MICROSOFT SYSTEM CENTER ENDPOINT PROTECTION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "MICROSTRATEGY",
+    "config_path": "content/parsers/third_party/community/MICROSTRATEGY_GUS/cbn/default_microstrategy.conf",
+    "metadata_path": "content/parsers/third_party/community/MICROSTRATEGY_GUS/cbn/metadata.json",
+    "vendor": "MICROSTRATEGY",
+    "product": "MICROSTRATEGY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "NAGIOS",
+    "config_path": "content/parsers/third_party/community/NAGIOS_GUS/cbn/default_nagios.conf",
+    "metadata_path": "content/parsers/third_party/community/NAGIOS_GUS/cbn/metadata.json",
+    "vendor": "NAGIOS",
+    "product": "NAGIOS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "NEO4J",
+    "config_path": "content/parsers/third_party/community/NEO4J_GUS/cbn/default_neo4j.conf",
+    "metadata_path": "content/parsers/third_party/community/NEO4J_GUS/cbn/metadata.json",
+    "vendor": "NEO4J",
+    "product": "NEO4J",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "NETAPP_BLUEXP",
+    "config_path": "content/parsers/third_party/community/NETAPP_BLUEXP_GUS/cbn/default_netapp_bluexp.conf",
+    "metadata_path": "content/parsers/third_party/community/NETAPP_BLUEXP_GUS/cbn/metadata.json",
+    "vendor": "NETAPP_BLUEXP",
+    "product": "NETAPP_BLUEXP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "NETDOCUMENTS",
+    "config_path": "content/parsers/third_party/community/NETDOCUMENTS_GUS/cbn/default_netdocuments.conf",
+    "metadata_path": "content/parsers/third_party/community/NETDOCUMENTS_GUS/cbn/metadata.json",
+    "vendor": "NETDOCUMENTS",
+    "product": "NETDOCUMENTS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NETSCOUT_OCI",
+    "config_path": "content/parsers/third_party/community/NETSCOUT_OCI_GUS/cbn/default_netscout_oci.conf",
+    "metadata_path": "content/parsers/third_party/community/NETSCOUT_OCI_GUS/cbn/metadata.json",
+    "vendor": "NETSCOUT",
+    "product": "NETSCOUT_OCI",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NETSKOPE_CLIENT",
+    "config_path": "content/parsers/third_party/community/NETSKOPE_CLIENT_GUS/cbn/default_netskope_client.conf",
+    "metadata_path": "content/parsers/third_party/community/NETSKOPE_CLIENT_GUS/cbn/metadata.json",
+    "vendor": "NETSCOPE",
+    "product": "NETSKOPE_CLIENT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NETWRIX_STEALTHAUDIT",
+    "config_path": "content/parsers/third_party/community/NETWRIX_STEALTHAUDIT_GUS/cbn/default_netwrix_stealthaudit.conf",
+    "metadata_path": "content/parsers/third_party/community/NETWRIX_STEALTHAUDIT_GUS/cbn/metadata.json",
+    "vendor": "NETWRIX_STEALTHAUDIT",
+    "product": "NETWRIX_STEALTHAUDIT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NET_SUITE",
+    "config_path": "content/parsers/third_party/community/NET_SUITE_GUS/cbn/default_net_suite.conf",
+    "metadata_path": "content/parsers/third_party/community/NET_SUITE_GUS/cbn/metadata.json",
+    "vendor": "NET_SUITE",
+    "product": "NET_SUITE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e127fee9bd89c293b0c1d284a6dc76a18144d99a",
+    "latest_commit_time": 1786097521
+  },
+  {
+    "log_type": "NOKIA_ROUTER",
+    "config_path": "content/parsers/third_party/community/NOKIA_ROUTER_GUS/cbn/default_nokia_router.conf",
+    "metadata_path": "content/parsers/third_party/community/NOKIA_ROUTER_GUS/cbn/metadata.json",
+    "vendor": "NOKIA_ROUTER",
+    "product": "NOKIA_ROUTER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NTOPNG",
+    "config_path": "content/parsers/third_party/community/NTOPNG_GUS/cbn/default_ntopng.conf",
+    "metadata_path": "content/parsers/third_party/community/NTOPNG_GUS/cbn/metadata.json",
+    "vendor": "NTOPNG",
+    "product": "NTOPNG",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NUCLEUS_VULNERABILITY",
+    "config_path": "content/parsers/third_party/community/NUCLEUS_VULNERABILITY_GUS/cbn/default_nucleus_vulnerability.conf",
+    "metadata_path": "content/parsers/third_party/community/NUCLEUS_VULNERABILITY_GUS/cbn/metadata.json",
+    "vendor": "NUCLEUS",
+    "product": "NUCLEUS_VULNERABILITY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NXLOG_MANAGER",
+    "config_path": "content/parsers/third_party/community/NXLOG_MANAGER_GUS/cbn/default_nxlog_manager.conf",
+    "metadata_path": "content/parsers/third_party/community/NXLOG_MANAGER_GUS/cbn/metadata.json",
+    "vendor": "NXLOG",
+    "product": "NXLOG_MANAGER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "NYANSA_EVENTS",
+    "config_path": "content/parsers/third_party/community/NYANSA_EVENTS_GUS/cbn/default_nyansa_events.conf",
+    "metadata_path": "content/parsers/third_party/community/NYANSA_EVENTS_GUS/cbn/metadata.json",
+    "vendor": "NYANSA_EVENTS",
+    "product": "NYANSA_EVENTS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "OKTA_ACCESS_GATEWAY",
+    "config_path": "content/parsers/third_party/community/OKTA_ACCESS_GATEWAY_GUS/cbn/default_okta_access_gateway.conf",
+    "metadata_path": "content/parsers/third_party/community/OKTA_ACCESS_GATEWAY_GUS/cbn/metadata.json",
+    "vendor": "OKTA",
+    "product": "OKTA_ACCESS_GATEWAY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "cafafd4bc754e5c5706c09c1d2a6ebf847691a87",
+    "latest_commit_time": 1786097831
+  },
+  {
+    "log_type": "ONAPSIS",
+    "config_path": "content/parsers/third_party/community/ONAPSIS_GUS/cbn/default_onapsis.conf",
+    "metadata_path": "content/parsers/third_party/community/ONAPSIS_GUS/cbn/metadata.json",
+    "vendor": "ONAPSIS",
+    "product": "ONAPSIS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
     "log_type": "ONFIDO",
     "config_path": "content/parsers/third_party/community/ONFIDO/cbn/default_onfido.conf",
     "metadata_path": "content/parsers/third_party/community/ONFIDO/cbn/metadata.json",
@@ -48,5 +1678,1025 @@
     "source": "COMMUNITY",
     "latest_commit_id": "509af3eac01cb65c492c9374bb2bd1f2b1f62158",
     "latest_commit_time": 1786017459
+  },
+  {
+    "log_type": "ONFIDO",
+    "config_path": "content/parsers/third_party/community/ONFIDO_GUS/cbn/default_onfido.conf",
+    "metadata_path": "content/parsers/third_party/community/ONFIDO_GUS/cbn/metadata.json",
+    "vendor": "ONFIDO",
+    "product": "ONFIDO",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "OORT",
+    "config_path": "content/parsers/third_party/community/OORT_GUS/cbn/default_oort.conf",
+    "metadata_path": "content/parsers/third_party/community/OORT_GUS/cbn/metadata.json",
+    "vendor": "OORT",
+    "product": "OORT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "OPA",
+    "config_path": "content/parsers/third_party/community/OPA_GUS/cbn/default_opa.conf",
+    "metadata_path": "content/parsers/third_party/community/OPA_GUS/cbn/metadata.json",
+    "vendor": "OPEN POLICY AGENT",
+    "product": "OPEN POLICY AGENT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "OPENAI_AUDITLOG",
+    "config_path": "content/parsers/third_party/community/OPENAI_AUDITLOG_GUS/cbn/default_openai_auditlog.conf",
+    "metadata_path": "content/parsers/third_party/community/OPENAI_AUDITLOG_GUS/cbn/metadata.json",
+    "vendor": "OPENAI_AUDITLOG",
+    "product": "OPENAI_AUDITLOG",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "OPENCANARY",
+    "config_path": "content/parsers/third_party/community/OPENCANARY_GUS/cbn/default_opencanary.conf",
+    "metadata_path": "content/parsers/third_party/community/OPENCANARY_GUS/cbn/metadata.json",
+    "vendor": "OPENCANARY",
+    "product": "OPENCANARY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "OPENDJ",
+    "config_path": "content/parsers/third_party/community/OPENDJ_GUS/cbn/default_opendj.conf",
+    "metadata_path": "content/parsers/third_party/community/OPENDJ_GUS/cbn/metadata.json",
+    "vendor": "OPENDJ",
+    "product": "OPENDJ",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "OPENPATH",
+    "config_path": "content/parsers/third_party/community/OPENPATH_GUS/cbn/default_openpath.conf",
+    "metadata_path": "content/parsers/third_party/community/OPENPATH_GUS/cbn/metadata.json",
+    "vendor": "AVIGILON",
+    "product": "AVIGILON",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "ORACLE_FUSION",
+    "config_path": "content/parsers/third_party/community/ORACLE_FUSION_GUS/cbn/default_oracle_fusion.conf",
+    "metadata_path": "content/parsers/third_party/community/ORACLE_FUSION_GUS/cbn/metadata.json",
+    "vendor": "ORACLE_FUSION",
+    "product": "ORACLE_FUSION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "ORACLE_NETSUITE",
+    "config_path": "content/parsers/third_party/community/ORACLE_NETSUITE_GUS/cbn/default_oracle_netsuite.conf",
+    "metadata_path": "content/parsers/third_party/community/ORACLE_NETSUITE_GUS/cbn/metadata.json",
+    "vendor": "ORACLE_NETSUITE",
+    "product": "ORACLE_NETSUITE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "2036ad1ccfb363d336726b54d1ee35b9e5572a11",
+    "latest_commit_time": 1786101040
+  },
+  {
+    "log_type": "ORACLE_OUD",
+    "config_path": "content/parsers/third_party/community/ORACLE_OUD_GUS/cbn/default_oracle_oud.conf",
+    "metadata_path": "content/parsers/third_party/community/ORACLE_OUD_GUS/cbn/metadata.json",
+    "vendor": "ORACLE OUD",
+    "product": "ORACLE OUD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PALANTIR",
+    "config_path": "content/parsers/third_party/community/PALANTIR_GUS/cbn/default_palantir.conf",
+    "metadata_path": "content/parsers/third_party/community/PALANTIR_GUS/cbn/metadata.json",
+    "vendor": "PALANTIR",
+    "product": "PALANTIR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PAN_EDR",
+    "config_path": "content/parsers/third_party/community/PAN_EDR_GUS/cbn/default_pan_edr.conf",
+    "metadata_path": "content/parsers/third_party/community/PAN_EDR_GUS/cbn/metadata.json",
+    "vendor": "PALO ALTO NETWORKS",
+    "product": "PAN_EDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PASSWORDSTATE",
+    "config_path": "content/parsers/third_party/community/PASSWORDSTATE_GUS/cbn/default_passwordstate.conf",
+    "metadata_path": "content/parsers/third_party/community/PASSWORDSTATE_GUS/cbn/metadata.json",
+    "vendor": "PASSWORDSTATE",
+    "product": "PASSWORDSTATE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PEPLINK_FW",
+    "config_path": "content/parsers/third_party/community/PEPLINK_FW_GUS/cbn/default_peplink_fw.conf",
+    "metadata_path": "content/parsers/third_party/community/PEPLINK_FW_GUS/cbn/metadata.json",
+    "vendor": "PEPLINK_FW",
+    "product": "PEPLINK_FW",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PERIMETERX_BOT_PROTECTION",
+    "config_path": "content/parsers/third_party/community/PERIMETERX_BOT_PROTECTION_GUS/cbn/default_perimeterx_bot_protection.conf",
+    "metadata_path": "content/parsers/third_party/community/PERIMETERX_BOT_PROTECTION_GUS/cbn/metadata.json",
+    "vendor": "NGINX",
+    "product": "PERIMETERX_BOT_PROTECTION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PROFTPD",
+    "config_path": "content/parsers/third_party/community/PROFTPD_GUS/cbn/default_proftpd.conf",
+    "metadata_path": "content/parsers/third_party/community/PROFTPD_GUS/cbn/metadata.json",
+    "vendor": "PROFTPD",
+    "product": "PROFTPD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PROOFPOINT_SENDMAIL_SENTRION",
+    "config_path": "content/parsers/third_party/community/PROOFPOINT_SENDMAIL_SENTRION_GUS/cbn/default_proofpoint_sendmail_sentrion.conf",
+    "metadata_path": "content/parsers/third_party/community/PROOFPOINT_SENDMAIL_SENTRION_GUS/cbn/metadata.json",
+    "vendor": "PROOFPOINT_SENDMAIL_SENTRION",
+    "product": "PROOFPOINT_SENDMAIL_SENTRION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PROOFPOINT_SER",
+    "config_path": "content/parsers/third_party/community/PROOFPOINT_SER_GUS/cbn/default_proofpoint_ser.conf",
+    "metadata_path": "content/parsers/third_party/community/PROOFPOINT_SER_GUS/cbn/metadata.json",
+    "vendor": "PROOFPOINT",
+    "product": "PROOFPOINT SER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "PROOFPOINT_TAP_THREATS",
+    "config_path": "content/parsers/third_party/community/PROOFPOINT_TAP_THREATS_GUS/cbn/default_proofpoint_tab_threats.conf",
+    "metadata_path": "content/parsers/third_party/community/PROOFPOINT_TAP_THREATS_GUS/cbn/metadata.json",
+    "vendor": "PROOFPOINT",
+    "product": "PROOFPOINT_TAP_THREATS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3cfaf516f3dedc59081fdbb2575f2916ebcb4c68",
+    "latest_commit_time": 1786101490
+  },
+  {
+    "log_type": "QUALYS_ASSET_CONTEXT",
+    "config_path": "content/parsers/third_party/community/QUALYS_ASSET_CONTEXT_GUS/cbn/default_qualys_asset_context.conf",
+    "metadata_path": "content/parsers/third_party/community/QUALYS_ASSET_CONTEXT_GUS/cbn/metadata.json",
+    "vendor": "QUALYS ASSET CONTEXT",
+    "product": "QUALYS ASSET CONTEXT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "QUALYS_CONTINUOUS_MONITORING",
+    "config_path": "content/parsers/third_party/community/QUALYS_CONTINUOUS_MONITORING_GUS/cbn/default_qualys_continuous_monitoring.conf",
+    "metadata_path": "content/parsers/third_party/community/QUALYS_CONTINUOUS_MONITORING_GUS/cbn/metadata.json",
+    "vendor": "QUALYS_CONTINOUS_MONITORING",
+    "product": "QUALYS_CONTINOUS_MONITORING",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "QUALYS_VIRTUAL_SCANNER",
+    "config_path": "content/parsers/third_party/community/QUALYS_VIRTUAL_SCANNER_GUS/cbn/default_qualys_virtual_scanner.conf",
+    "metadata_path": "content/parsers/third_party/community/QUALYS_VIRTUAL_SCANNER_GUS/cbn/metadata.json",
+    "vendor": "QUALYS_VIRTUAL_SCANNER",
+    "product": "QUALYS_VIRTUAL_SCANNER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "QUEST_CHANGE_AUDITOR_EMC",
+    "config_path": "content/parsers/third_party/community/QUEST_CHANGE_AUDITOR_EMC_GUS/cbn/default_quest_change_auditor_emc.conf",
+    "metadata_path": "content/parsers/third_party/community/QUEST_CHANGE_AUDITOR_EMC_GUS/cbn/metadata.json",
+    "vendor": "QUEST",
+    "product": "QUEST_CHANGE_AUDITOR_EMC",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "QUEST_FILE_AUDIT",
+    "config_path": "content/parsers/third_party/community/QUEST_FILE_AUDIT_GUS/cbn/default_quest_file_audit.conf",
+    "metadata_path": "content/parsers/third_party/community/QUEST_FILE_AUDIT_GUS/cbn/metadata.json",
+    "vendor": "QUEST",
+    "product": "QUEST FILE ACCESS AUDIT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "QUMULO_FS",
+    "config_path": "content/parsers/third_party/community/QUMULO_FS_GUS/cbn/default_qumulo_fs.conf",
+    "metadata_path": "content/parsers/third_party/community/QUMULO_FS_GUS/cbn/metadata.json",
+    "vendor": "QUMULO_FS",
+    "product": "QUMULO_FS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "RECORDIA",
+    "config_path": "content/parsers/third_party/community/RECORDIA_GUS/cbn/default_recordia.conf",
+    "metadata_path": "content/parsers/third_party/community/RECORDIA_GUS/cbn/metadata.json",
+    "vendor": "RECORDIA",
+    "product": "RECORDIA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "REDCANARY_EDR",
+    "config_path": "content/parsers/third_party/community/REDCANARY_EDR_GUS/cbn/default_redcanary_edr.conf",
+    "metadata_path": "content/parsers/third_party/community/REDCANARY_EDR_GUS/cbn/metadata.json",
+    "vendor": "REDCANARY",
+    "product": "REDCANARY_EDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "REDHAT_DIRECTORY_SERVER",
+    "config_path": "content/parsers/third_party/community/REDHAT_DIRECTORY_SERVER_GUS/cbn/default_redhat_directory_server.conf",
+    "metadata_path": "content/parsers/third_party/community/REDHAT_DIRECTORY_SERVER_GUS/cbn/metadata.json",
+    "vendor": "REDHAT",
+    "product": "REDHAT_DIRECTORY_SERVER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "aef37e03cf6de4ac7101fcaf94dabbe5b99ec04c",
+    "latest_commit_time": 1786101792
+  },
+  {
+    "log_type": "RH_ISAC_IOC",
+    "config_path": "content/parsers/third_party/community/RH_ISAC_IOC_GUS/cbn/default_rh_isac_ioc.conf",
+    "metadata_path": "content/parsers/third_party/community/RH_ISAC_IOC_GUS/cbn/metadata.json",
+    "vendor": "RH_ISAC",
+    "product": "RH_ISAC",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "RIPPLING_ACTIVITYLOGS",
+    "config_path": "content/parsers/third_party/community/RIPPLING_ACTIVITYLOGS_GUS/cbn/default_rippling_activitylogs.conf",
+    "metadata_path": "content/parsers/third_party/community/RIPPLING_ACTIVITYLOGS_GUS/cbn/metadata.json",
+    "vendor": "RIPPLING_ACTIVITYLOGS",
+    "product": "RIPPLING_ACTIVITYLOGS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SAIWALL_VPN",
+    "config_path": "content/parsers/third_party/community/SAIWALL_VPN_GUS/cbn/default_saiwall_vpn.conf",
+    "metadata_path": "content/parsers/third_party/community/SAIWALL_VPN_GUS/cbn/metadata.json",
+    "vendor": "SAIWALL_VPN",
+    "product": "SAIWALL_VPN",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SALESFORCE_COMMERCE_CLOUD",
+    "config_path": "content/parsers/third_party/community/SALESFORCE_COMMERCE_CLOUD_GUS/cbn/default_salesforce_commerce_cloud.conf",
+    "metadata_path": "content/parsers/third_party/community/SALESFORCE_COMMERCE_CLOUD_GUS/cbn/metadata.json",
+    "vendor": "SALESFORCE",
+    "product": "SALESFORCE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SANGFOR_PROXY",
+    "config_path": "content/parsers/third_party/community/SANGFOR_PROXY_GUS/cbn/default_sangfor_proxy.conf",
+    "metadata_path": "content/parsers/third_party/community/SANGFOR_PROXY_GUS/cbn/metadata.json",
+    "vendor": "SANGFOR_PROXY",
+    "product": "SANGFOR_PROXY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SAP_ASE",
+    "config_path": "content/parsers/third_party/community/SAP_ASE_GUS/cbn/default_sap_ase.conf",
+    "metadata_path": "content/parsers/third_party/community/SAP_ASE_GUS/cbn/metadata.json",
+    "vendor": "SAP_ASE",
+    "product": "SAP_ASE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SAP_BTP",
+    "config_path": "content/parsers/third_party/community/SAP_BTP_GUS/cbn/default_sap_btp.conf",
+    "metadata_path": "content/parsers/third_party/community/SAP_BTP_GUS/cbn/metadata.json",
+    "vendor": "SAP_BTP",
+    "product": "SAP_BTP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SAP_NETWEAVER",
+    "config_path": "content/parsers/third_party/community/SAP_NETWEAVER_GUS/cbn/default_sap_netweaver.conf",
+    "metadata_path": "content/parsers/third_party/community/SAP_NETWEAVER_GUS/cbn/metadata.json",
+    "vendor": "SAP",
+    "product": "SAP NETWEAVER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SAP_SAST",
+    "config_path": "content/parsers/third_party/community/SAP_SAST_GUS/cbn/default_sap_sast.conf",
+    "metadata_path": "content/parsers/third_party/community/SAP_SAST_GUS/cbn/metadata.json",
+    "vendor": "SAST SOLUTIONS",
+    "product": "SAST GRC SUITE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SAP_SUCCESSFACTORS",
+    "config_path": "content/parsers/third_party/community/SAP_SUCCESSFACTORS_GUS/cbn/default_sap_successfactors.conf",
+    "metadata_path": "content/parsers/third_party/community/SAP_SUCCESSFACTORS_GUS/cbn/metadata.json",
+    "vendor": "SAP",
+    "product": "SAP_SUCCESSFACTORS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "e9a4b6349cc21d5d0e6ecd09339e28659baf5772",
+    "latest_commit_time": 1786101366
+  },
+  {
+    "log_type": "SENTRY",
+    "config_path": "content/parsers/third_party/community/SENTRY_GUS/cbn/default_sentry.conf",
+    "metadata_path": "content/parsers/third_party/community/SENTRY_GUS/cbn/metadata.json",
+    "vendor": "SENTRY",
+    "product": "SENTRY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SEQRITE_ENDPOINT",
+    "config_path": "content/parsers/third_party/community/SEQRITE_ENDPOINT_GUS/cbn/default_seqrite_endpoint.conf",
+    "metadata_path": "content/parsers/third_party/community/SEQRITE_ENDPOINT_GUS/cbn/metadata.json",
+    "vendor": "SEQRITE",
+    "product": "SEQRITE_ENDPOINT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SERVICENOW_SECURITY",
+    "config_path": "content/parsers/third_party/community/SERVICENOW_SECURITY_GUS/cbn/default_servicenow_security.conf",
+    "metadata_path": "content/parsers/third_party/community/SERVICENOW_SECURITY_GUS/cbn/metadata.json",
+    "vendor": "SERVICENOW",
+    "product": "SERVICENOW_SECURITY",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SHAREPOINT",
+    "config_path": "content/parsers/third_party/community/SHAREPOINT_GUS/cbn/default_sharepoint.conf",
+    "metadata_path": "content/parsers/third_party/community/SHAREPOINT_GUS/cbn/metadata.json",
+    "vendor": "SHAREPOINT",
+    "product": "SHAREPOINT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SHRUBBERY_TACACS",
+    "config_path": "content/parsers/third_party/community/SHRUBBERY_TACACS_GUS/cbn/default_shrubbery_tacacs.conf",
+    "metadata_path": "content/parsers/third_party/community/SHRUBBERY_TACACS_GUS/cbn/metadata.json",
+    "vendor": "SHRUBBERY_TACACS",
+    "product": "SHRUBBERY_TACACS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SIERRA_WIRELESS",
+    "config_path": "content/parsers/third_party/community/SIERRA_WIRELESS_GUS/cbn/default_sierra_wireless.conf",
+    "metadata_path": "content/parsers/third_party/community/SIERRA_WIRELESS_GUS/cbn/metadata.json",
+    "vendor": "SIERRA_WIRELESS",
+    "product": "SIERRA_WIRELESS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SITEMINDER_SSO",
+    "config_path": "content/parsers/third_party/community/SITEMINDER_SSO_GUS/cbn/default_siteminder_sso.conf",
+    "metadata_path": "content/parsers/third_party/community/SITEMINDER_SSO_GUS/cbn/metadata.json",
+    "vendor": "SITEMINDER_SSO",
+    "product": "SITEMINDER_SSO",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SKYBOX_FIREWALL_ASSURANCE",
+    "config_path": "content/parsers/third_party/community/SKYBOX_FIREWALL_ASSURANCE_GUS/cbn/default_skybox_firewall_assurance.conf",
+    "metadata_path": "content/parsers/third_party/community/SKYBOX_FIREWALL_ASSURANCE_GUS/cbn/metadata.json",
+    "vendor": "SKYBOX",
+    "product": "SKYBOX_FIREWALL_ASSURANCE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SMARTSHEET",
+    "config_path": "content/parsers/third_party/community/SMARTSHEET_GUS/cbn/default_smartsheet.conf",
+    "metadata_path": "content/parsers/third_party/community/SMARTSHEET_GUS/cbn/metadata.json",
+    "vendor": "SMARTSHEET",
+    "product": "SMARTSHEET",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SMBD",
+    "config_path": "content/parsers/third_party/community/SMBD_GUS/cbn/default_smbd.conf",
+    "metadata_path": "content/parsers/third_party/community/SMBD_GUS/cbn/metadata.json",
+    "vendor": "SMBD",
+    "product": "SMBD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "c56ae2fb1b9cc3abe6dd46313f4d489789163d73",
+    "latest_commit_time": 1786030077
+  },
+  {
+    "log_type": "SNIPE_IT",
+    "config_path": "content/parsers/third_party/community/SNIPE_IT_GUS/cbn/default_snipe_it.conf",
+    "metadata_path": "content/parsers/third_party/community/SNIPE_IT_GUS/cbn/metadata.json",
+    "vendor": "SNIPE_IT",
+    "product": "SNIPE_IT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "SNOOPY_LOGGER",
+    "config_path": "content/parsers/third_party/community/SNOOPY_LOGGER_GUS/cbn/default_snoopy_logger.conf",
+    "metadata_path": "content/parsers/third_party/community/SNOOPY_LOGGER_GUS/cbn/metadata.json",
+    "vendor": "SNOOPY_LOGGER",
+    "product": "SNOOPY_LOGGER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "SNORT_IDS",
+    "config_path": "content/parsers/third_party/community/SNORT_IDS_GUS/cbn/default_snort_ids.conf",
+    "metadata_path": "content/parsers/third_party/community/SNORT_IDS_GUS/cbn/metadata.json",
+    "vendor": "SNORT",
+    "product": "SNORT_IDS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "SOPHOS_DHCP",
+    "config_path": "content/parsers/third_party/community/SOPHOS_DHCP_GUS/cbn/default_sophos_dhcp.conf",
+    "metadata_path": "content/parsers/third_party/community/SOPHOS_DHCP_GUS/cbn/metadata.json",
+    "vendor": "SOPHOS",
+    "product": "SOPHOS_DHCP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "SOTI_MOBICONTROL",
+    "config_path": "content/parsers/third_party/community/SOTI_MOBICONTROL_GUS/cbn/default_soti_mobicontrol.conf",
+    "metadata_path": "content/parsers/third_party/community/SOTI_MOBICONTROL_GUS/cbn/metadata.json",
+    "vendor": "SOTI_MOBICONTROL",
+    "product": "SOTI_MOBICONTROL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "SPLUNK",
+    "config_path": "content/parsers/third_party/community/SPLUNK_GUS/cbn/default_splunk.conf",
+    "metadata_path": "content/parsers/third_party/community/SPLUNK_GUS/cbn/metadata.json",
+    "vendor": "SPLUNK",
+    "product": "SPLUNK",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "SPYCLOUD",
+    "config_path": "content/parsers/third_party/community/SPYCLOUD_GUS/cbn/default_spycloud.conf",
+    "metadata_path": "content/parsers/third_party/community/SPYCLOUD_GUS/cbn/metadata.json",
+    "vendor": "SPYCLOUD",
+    "product": "SPYCLOUD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "STACKHAWK",
+    "config_path": "content/parsers/third_party/community/STACKHAWK_GUS/cbn/default_stackhawk.conf",
+    "metadata_path": "content/parsers/third_party/community/STACKHAWK_GUS/cbn/metadata.json",
+    "vendor": "STACKHAWK",
+    "product": "STACKHAWK",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "STEALTHBITS_AUDIT",
+    "config_path": "content/parsers/third_party/community/STEALTHBITS_AUDIT_GUS/cbn/default_stealthbits_audit.conf",
+    "metadata_path": "content/parsers/third_party/community/STEALTHBITS_AUDIT_GUS/cbn/metadata.json",
+    "vendor": "STEALTHBITS_AUDIT",
+    "product": "STEALTHBITS_AUDIT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "STEALTHBITS_DEFEND",
+    "config_path": "content/parsers/third_party/community/STEALTHBITS_DEFEND_GUS/cbn/default_stealthbits_defend.conf",
+    "metadata_path": "content/parsers/third_party/community/STEALTHBITS_DEFEND_GUS/cbn/metadata.json",
+    "vendor": "STEALTHBITS_DEFEND",
+    "product": "STEALTHBITS_DEFEND",
+    "source": "COMMUNITY",
+    "latest_commit_id": "22b9b47ed41cd9a6e9da94ae2bd411a9a468b8a0",
+    "latest_commit_time": 1786096045
+  },
+  {
+    "log_type": "STEALTHBITS_PAM",
+    "config_path": "content/parsers/third_party/community/STEALTHBITS_PAM_GUS/cbn/default_stealthbits_pam.conf",
+    "metadata_path": "content/parsers/third_party/community/STEALTHBITS_PAM_GUS/cbn/metadata.json",
+    "vendor": "STEALTHBITS_PAM",
+    "product": "STEALTHBITS_PAM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "SURICATA_EVE",
+    "config_path": "content/parsers/third_party/community/SURICATA_EVE/cbn/default_suricata_eve.conf",
+    "metadata_path": "content/parsers/third_party/community/SURICATA_EVE/cbn/metadata.json",
+    "vendor": "SURICATA",
+    "product": "SURICATA_EVE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "3df9711e23ff57421e74f28661a2dcbed4253b8d",
+    "latest_commit_time": 1786452672
+  },
+  {
+    "log_type": "SWIMLANE",
+    "config_path": "content/parsers/third_party/community/SWIMLANE_GUS/cbn/default_swimlane.conf",
+    "metadata_path": "content/parsers/third_party/community/SWIMLANE_GUS/cbn/metadata.json",
+    "vendor": "SWIMLANE",
+    "product": "SWIMLANE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "SYMANTEC_SA",
+    "config_path": "content/parsers/third_party/community/SYMANTEC_SA_GUS/cbn/default_symantec_sa.conf",
+    "metadata_path": "content/parsers/third_party/community/SYMANTEC_SA_GUS/cbn/metadata.json",
+    "vendor": "SYMANTEC_SA",
+    "product": "SYMANTEC_SA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "SYMANTEC_VIP_AUTHHUB",
+    "config_path": "content/parsers/third_party/community/SYMANTEC_VIP_AUTHHUB_GUS/cbn/default_symantec_vip_authhub.conf",
+    "metadata_path": "content/parsers/third_party/community/SYMANTEC_VIP_AUTHHUB_GUS/cbn/metadata.json",
+    "vendor": "SYMANTEC_VIP_AUTHHUB",
+    "product": "SYMANTEC_VIP_AUTHHUB",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "SYMANTEC_WEB_ISOLATION",
+    "config_path": "content/parsers/third_party/community/SYMANTEC_WEB_ISOLATION_GUS/cbn/default_symantec_web_isolation.conf",
+    "metadata_path": "content/parsers/third_party/community/SYMANTEC_WEB_ISOLATION_GUS/cbn/metadata.json",
+    "vendor": "BROADCOM_INC",
+    "product": "SYMANTEC_WEB_ISOLATION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "TACACS_PLUS",
+    "config_path": "content/parsers/third_party/community/TACACS_PLUS_GUS/cbn/default_tacacs_plus.conf",
+    "metadata_path": "content/parsers/third_party/community/TACACS_PLUS_GUS/cbn/metadata.json",
+    "vendor": "TACACS_PLUS",
+    "product": "TACACS_PLUS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "TALON",
+    "config_path": "content/parsers/third_party/community/TALON_GUS/cbn/default_talon.conf",
+    "metadata_path": "content/parsers/third_party/community/TALON_GUS/cbn/metadata.json",
+    "vendor": "TALON",
+    "product": "TALON",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "TANIUM_INSIGHT",
+    "config_path": "content/parsers/third_party/community/TANIUM_INSIGHT_GUS/cbn/default_tanium_insight.conf",
+    "metadata_path": "content/parsers/third_party/community/TANIUM_INSIGHT_GUS/cbn/metadata.json",
+    "vendor": "TANIUM_INSIGHT",
+    "product": "TANIUM_INSIGHT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "TANIUM_INTEGRITY_MONITOR",
+    "config_path": "content/parsers/third_party/community/TANIUM_INTEGRITY_MONITOR_GUS/cbn/default_taniumintegritymonitor.conf",
+    "metadata_path": "content/parsers/third_party/community/TANIUM_INTEGRITY_MONITOR_GUS/cbn/metadata.json",
+    "vendor": "TANIUM_INTEGRITY_MONITOR",
+    "product": "TANIUM_INTEGRITY_MONITOR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "TANIUM_PATCH",
+    "config_path": "content/parsers/third_party/community/TANIUM_PATCH_GUS/cbn/default_tanium_patch.conf",
+    "metadata_path": "content/parsers/third_party/community/TANIUM_PATCH_GUS/cbn/metadata.json",
+    "vendor": "TANIUM",
+    "product": "TANIUM_PATCH",
+    "source": "COMMUNITY",
+    "latest_commit_id": "6a73cab94670f8939f79c91c7dba6feb4b0b0610",
+    "latest_commit_time": 1786095964
+  },
+  {
+    "log_type": "TANIUM_REVEAL",
+    "config_path": "content/parsers/third_party/community/TANIUM_REVEAL_GUS/cbn/default_tanium_reveal.conf",
+    "metadata_path": "content/parsers/third_party/community/TANIUM_REVEAL_GUS/cbn/metadata.json",
+    "vendor": "TANIUM_REVEAL",
+    "product": "TANIUM_REVEAL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "TCPWAVE_DDI",
+    "config_path": "content/parsers/third_party/community/TCPWAVE_DDI_GUS/cbn/default_tcpwave_ddi.conf",
+    "metadata_path": "content/parsers/third_party/community/TCPWAVE_DDI_GUS/cbn/metadata.json",
+    "vendor": "TCPWAVE_DDI",
+    "product": "TCPWAVE_DDI",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "TERADATA_DB",
+    "config_path": "content/parsers/third_party/community/TERADATA_DB_GUS/cbn/default_teradata_db.conf",
+    "metadata_path": "content/parsers/third_party/community/TERADATA_DB_GUS/cbn/metadata.json",
+    "vendor": "TERADATA",
+    "product": "TERADATA_DB",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "THALES_MFA",
+    "config_path": "content/parsers/third_party/community/THALES_MFA_GUS/cbn/default_thales_mfa.conf",
+    "metadata_path": "content/parsers/third_party/community/THALES_MFA_GUS/cbn/metadata.json",
+    "vendor": "THALES_MFA",
+    "product": "THALES_MFA",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "THREATLOCKER",
+    "config_path": "content/parsers/third_party/community/THREATLOCKER_GUS/cbn/default_threatlocker.conf",
+    "metadata_path": "content/parsers/third_party/community/THREATLOCKER_GUS/cbn/metadata.json",
+    "vendor": "THREATLOCKER",
+    "product": "THREATLOCKER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "THREATX_WAF",
+    "config_path": "content/parsers/third_party/community/THREATX_WAF_GUS/cbn/default_threatx_waf.conf",
+    "metadata_path": "content/parsers/third_party/community/THREATX_WAF_GUS/cbn/metadata.json",
+    "vendor": "THREATX_WAF",
+    "product": "THREATX_WAF",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "TINES",
+    "config_path": "content/parsers/third_party/community/TINES_GUS/cbn/default_tines.conf",
+    "metadata_path": "content/parsers/third_party/community/TINES_GUS/cbn/metadata.json",
+    "vendor": "TINES",
+    "product": "TINES",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "TINTRI",
+    "config_path": "content/parsers/third_party/community/TINTRI_GUS/cbn/default_tintri.conf",
+    "metadata_path": "content/parsers/third_party/community/TINTRI_GUS/cbn/metadata.json",
+    "vendor": "TINTRI",
+    "product": "TINTRI",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "TRENDMICRO_VISION_ONE_CONTAINER_VULNERABILITIES",
+    "config_path": "content/parsers/third_party/community/TRENDMICRO_VISION_ONE_CONTAINER_VULNERABILITIES_GUS/cbn/default_trendmicro_vision_one_container_vulnerabilities.conf",
+    "metadata_path": "content/parsers/third_party/community/TRENDMICRO_VISION_ONE_CONTAINER_VULNERABILITIES_GUS/cbn/metadata.json",
+    "vendor": "TREND VISION ONE CONTAINER VULNERABILITIES",
+    "product": "TREND VISION ONE CONTAINER VULNERABILITIES",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "UBERAGENT",
+    "config_path": "content/parsers/third_party/community/UBERAGENT_GUS/cbn/default_uberagent.conf",
+    "metadata_path": "content/parsers/third_party/community/UBERAGENT_GUS/cbn/metadata.json",
+    "vendor": "UBERAGENT",
+    "product": "UBERAGENT",
+    "source": "COMMUNITY",
+    "latest_commit_id": "b47aa951861bb6efef4e74a11d0761b088c4ce62",
+    "latest_commit_time": 1786095008
+  },
+  {
+    "log_type": "UBIKA_WAAP",
+    "config_path": "content/parsers/third_party/community/UBIKA_WAAP_GUS/cbn/default_ubika_waap.conf",
+    "metadata_path": "content/parsers/third_party/community/UBIKA_WAAP_GUS/cbn/metadata.json",
+    "vendor": "UBIKA_WAAP",
+    "product": "UBIKA_WAAP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "UKG",
+    "config_path": "content/parsers/third_party/community/UKG_GUS/cbn/default_ukg.conf",
+    "metadata_path": "content/parsers/third_party/community/UKG_GUS/cbn/metadata.json",
+    "vendor": "UKG",
+    "product": "UKG",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "UNBOUND_DNS",
+    "config_path": "content/parsers/third_party/community/UNBOUND_DNS_GUS/cbn/default_unbound_dns.conf",
+    "metadata_path": "content/parsers/third_party/community/UNBOUND_DNS_GUS/cbn/metadata.json",
+    "vendor": "UNBOUND_DNS",
+    "product": "Unbound DNS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "UPGUARD",
+    "config_path": "content/parsers/third_party/community/UPGUARD_GUS/cbn/default_upguard.conf",
+    "metadata_path": "content/parsers/third_party/community/UPGUARD_GUS/cbn/metadata.json",
+    "vendor": "UPGUARD",
+    "product": "UPGUARD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "UPSTREAM_VSOC_ALERTS",
+    "config_path": "content/parsers/third_party/community/UPSTREAM_VSOC_ALERTS_GUS/cbn/default_upstream_vsoc_alerts.conf",
+    "metadata_path": "content/parsers/third_party/community/UPSTREAM_VSOC_ALERTS_GUS/cbn/metadata.json",
+    "vendor": "UPSTREAM",
+    "product": "UPSTREAM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "UPTYCS_EDR",
+    "config_path": "content/parsers/third_party/community/UPTYCS_EDR_GUS/cbn/default_uptycs_edr.conf",
+    "metadata_path": "content/parsers/third_party/community/UPTYCS_EDR_GUS/cbn/metadata.json",
+    "vendor": "UPTYCS",
+    "product": "UPTYCS_EDR",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "UPX_ANTIDDOS",
+    "config_path": "content/parsers/third_party/community/UPX_ANTIDDOS_GUS/cbn/default_upx_antiddos.conf",
+    "metadata_path": "content/parsers/third_party/community/UPX_ANTIDDOS_GUS/cbn/metadata.json",
+    "vendor": "UPX ANTIDDOS",
+    "product": "UPX ANTIDDOS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "VECTRA_ALERTS",
+    "config_path": "content/parsers/third_party/community/VECTRA_ALERTS_GUS/cbn/default_vectra_alerts.conf",
+    "metadata_path": "content/parsers/third_party/community/VECTRA_ALERTS_GUS/cbn/metadata.json",
+    "vendor": "VECTRA_ALERTS",
+    "product": "VECTRA_ALERTS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "VENAFI_ZTPKI",
+    "config_path": "content/parsers/third_party/community/VENAFI_ZTPKI_GUS/cbn/default_venafi_ztpki.conf",
+    "metadata_path": "content/parsers/third_party/community/VENAFI_ZTPKI_GUS/cbn/metadata.json",
+    "vendor": "VENAFI ZTPKI",
+    "product": "VENAFI ZTPKI",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "VERBA_REC",
+    "config_path": "content/parsers/third_party/community/VERBA_REC_GUS/cbn/default_verba_rec.conf",
+    "metadata_path": "content/parsers/third_party/community/VERBA_REC_GUS/cbn/metadata.json",
+    "vendor": "VERBA_REC",
+    "product": "VERBA_REC",
+    "source": "COMMUNITY",
+    "latest_commit_id": "84df8751ad98735b4e37ce520cd2efa50f632c00",
+    "latest_commit_time": 1786094853
+  },
+  {
+    "log_type": "VIRTRU_EMAIL_ENCRYPTION",
+    "config_path": "content/parsers/third_party/community/VIRTRU_EMAIL_ENCRYPTION_GUS/cbn/default_virtru_email_encryption.conf",
+    "metadata_path": "content/parsers/third_party/community/VIRTRU_EMAIL_ENCRYPTION_GUS/cbn/metadata.json",
+    "vendor": "VIRTRU",
+    "product": "VIRTRU_EMAIL_ENCRYPTION",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "VITALQIP",
+    "config_path": "content/parsers/third_party/community/VITALQIP_GUS/cbn/default_vitalqip.conf",
+    "metadata_path": "content/parsers/third_party/community/VITALQIP_GUS/cbn/metadata.json",
+    "vendor": "NOKIA",
+    "product": "VITALQIP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "VSFTPD",
+    "config_path": "content/parsers/third_party/community/VSFTPD_GUS/cbn/default_vsftpd.conf",
+    "metadata_path": "content/parsers/third_party/community/VSFTPD_GUS/cbn/metadata.json",
+    "vendor": "VSFTPD",
+    "product": "VSFTPD",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "VYOS",
+    "config_path": "content/parsers/third_party/community/VYOS_GUS/cbn/default_vyos.conf",
+    "metadata_path": "content/parsers/third_party/community/VYOS_GUS/cbn/metadata.json",
+    "vendor": "VYOS",
+    "product": "VYOS DHCP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "WEBMARSHAL",
+    "config_path": "content/parsers/third_party/community/WEBMARSHAL_GUS/cbn/default_webmarshal.conf",
+    "metadata_path": "content/parsers/third_party/community/WEBMARSHAL_GUS/cbn/metadata.json",
+    "vendor": "WEBMARSHAL",
+    "product": "WEBMARSHAL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "WINDCHILL",
+    "config_path": "content/parsers/third_party/community/WINDCHILL_GUS/cbn/default_windchill.conf",
+    "metadata_path": "content/parsers/third_party/community/WINDCHILL_GUS/cbn/metadata.json",
+    "vendor": "WINDCHILL",
+    "product": "WINDCHILL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "WINSCP",
+    "config_path": "content/parsers/third_party/community/WINSCP_GUS/cbn/default_winscp.conf",
+    "metadata_path": "content/parsers/third_party/community/WINSCP_GUS/cbn/metadata.json",
+    "vendor": "WINSCP",
+    "product": "WINSCP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "WPENGINE",
+    "config_path": "content/parsers/third_party/community/WPENGINE_GUS/cbn/default_wpengine.conf",
+    "metadata_path": "content/parsers/third_party/community/WPENGINE_GUS/cbn/metadata.json",
+    "vendor": "WPENGINE",
+    "product": "WPENGINE",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "XITING_XAMS",
+    "config_path": "content/parsers/third_party/community/XITING_XAMS_GUS/cbn/default_xiting_xams.conf",
+    "metadata_path": "content/parsers/third_party/community/XITING_XAMS_GUS/cbn/metadata.json",
+    "vendor": "XITING_XAMS",
+    "product": "XITING_XAMS",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "YAMAHA_ROUTER",
+    "config_path": "content/parsers/third_party/community/YAMAHA_ROUTER_GUS/cbn/default_yamaha_router.conf",
+    "metadata_path": "content/parsers/third_party/community/YAMAHA_ROUTER_GUS/cbn/metadata.json",
+    "vendor": "YAMAHA_ROUTER",
+    "product": "YAMAHA_ROUTER",
+    "source": "COMMUNITY",
+    "latest_commit_id": "5e2ea8fbb5aefb9c9bd379eecdf360b2ae3e389a",
+    "latest_commit_time": 1786094775
+  },
+  {
+    "log_type": "YUBICO_OTP",
+    "config_path": "content/parsers/third_party/community/YUBICO_OTP_GUS/cbn/default_yubico_otp.conf",
+    "metadata_path": "content/parsers/third_party/community/YUBICO_OTP_GUS/cbn/metadata.json",
+    "vendor": "YUBICO_OTP",
+    "product": "YUBICO_OTP",
+    "source": "COMMUNITY",
+    "latest_commit_id": "1f47eec065109fd63814e9e58e0bf46607b90685",
+    "latest_commit_time": 1786097497
+  },
+  {
+    "log_type": "ZEROFOX_PLATFORM",
+    "config_path": "content/parsers/third_party/community/ZEROFOX_PLATFORM_GUS/cbn/default_zerofox_platform.conf",
+    "metadata_path": "content/parsers/third_party/community/ZEROFOX_PLATFORM_GUS/cbn/metadata.json",
+    "vendor": "ZEROFOX_PLATFORM",
+    "product": "ZEROFOX_PLATFORM",
+    "source": "COMMUNITY",
+    "latest_commit_id": "1f47eec065109fd63814e9e58e0bf46607b90685",
+    "latest_commit_time": 1786097497
+  },
+  {
+    "log_type": "ZYWALL",
+    "config_path": "content/parsers/third_party/community/ZYWALL_GUS/cbn/default_zywall.conf",
+    "metadata_path": "content/parsers/third_party/community/ZYWALL_GUS/cbn/metadata.json",
+    "vendor": "ZYWALL",
+    "product": "ZYWALL",
+    "source": "COMMUNITY",
+    "latest_commit_id": "1f47eec065109fd63814e9e58e0bf46607b90685",
+    "latest_commit_time": 1786097497
   }
 ]

--- a/content/playbooks/third_party/community/phishing_investigation/definition.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/definition.yaml
@@ -1,0 +1,29 @@
+identifier: 39d8f9cd-d125-4673-9c61-2e00e9727801
+is_enable: true
+version: 0.0
+name: Phishing Investigation
+description: The Playbook ingests and parses .eml/.msg files to extract key email
+    data for Email Header Analysis and Entities & Artifacts Enrichment Blocks. It
+    identifies potentially impacted users and counts those who clicked malicious links.
+    Findings are consolidated and presented through insights, providing a clear, structured
+    view of email threats, user exposure, and risk confidence level.
+debug_alert_identifier: ''
+debug_base_alert_identifier: ''
+is_debug_mode: false
+type: playbook
+template_name: null
+original_workflow_identifier: c1c81f57-e04e-4847-b600-fbe310ec9843
+version_comment: null
+version_creator: null
+creator: 715aa2bc-d5aa-4a95-83fa-6dad9823eba3
+priority: 2
+category: 243
+is_automatic: true
+is_archived: false
+last_editor: null
+default_access_level: edit
+creation_source: user_or_api_initiated
+simulation_clone: false
+permissions: []
+environments:
+- '*'

--- a/content/playbooks/third_party/community/phishing_investigation/display_info.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/display_info.yaml
@@ -1,0 +1,8 @@
+type: playbook
+content_hub_display_name: 'Phishing Investigation'
+author: 'Accenture'
+contact_email: '' # In case support is needed, this email will be used by secops customers to open support queries (required for partner contributed content)
+tags: ['Phishing', 'Enrichment', 'Triage', 'Investigation']
+should_display_in_content_hub: true
+contribution_type: third_party
+acknowledge_debug_data_included: true

--- a/content/playbooks/third_party/community/phishing_investigation/overviews.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/overviews.yaml
@@ -1,0 +1,40 @@
+-   identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+    name: Phishing Enrichment
+    creator: null
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    type: playbook_default
+    alert_rule_type: null
+    roles: []
+    role_names:
+    - Administrator
+    - Tier1
+    - Tier2
+    - Tier3
+    - SocManager
+    - CISO
+    - Content Factory
+    widgets_details:
+    -   title: Email Body
+        size: half_width
+        order: 1
+    -   title: Phishing Investigation Result
+        size: half_width
+        order: 2
+    -   title: Search Outbound Connection
+        size: half_width
+        order: 3
+    -   title: Search for Other Potentially Impacted Users
+        size: half_width
+        order: 4
+    -   title: Enrich IP Address
+        size: half_width
+        order: 5
+    -   title: Enrich URL
+        size: half_width
+        order: 6
+    -   title: Enrich Hash
+        size: half_width
+        order: 7
+    -   title: Enrich Domain
+        size: half_width
+        order: 8

--- a/content/playbooks/third_party/community/phishing_investigation/release_notes.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/release_notes.yaml
@@ -1,0 +1,9 @@
+-   description: Initial release of Phishing Investigation
+    integration_version: 1.0
+    item_name: Phishing Investigation
+    item_type: Playbook
+    publish_time: '2026-08-11'
+    new: true
+    regressive: false
+    deprecated: false
+    removed: false

--- a/content/playbooks/third_party/community/phishing_investigation/steps/attachment_exists_in_case_wall_d28c3.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/attachment_exists_in_case_wall_d28c3.yaml
@@ -1,0 +1,63 @@
+name: Condition
+description: This condition determines if an attachment is available and decides whether
+    to proceed with parsing or stop the flow.
+identifier: d28c3219-d4ca-4492-993f-19c02d849644
+original_step_id: b655472b-6efb-434e-815e-11dd5f34faca
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 65555523-ed14-49e6-a07b-477ffcb7658b
+parent_step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+instance_name: Attachment exists in case wall?
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: Branches
+    value: '[{"LogicalOperator":0,"Conditions":[{"Operator":5,"FieldName":"[Get Case
+        Attachment.ScriptResult]","Type":7,"Value":"0","CustomOperatorName":"Core
+        Functions.Not Equal"}],"Order":1,"IsDefaultBranch":false,"Name":"Yes"},{"LogicalOperator":0,"Conditions":[],"Order":2,"IsDefaultBranch":true,"Name":"Branch"}]'
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ErrorFallbackBranch
+    value: null
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: d28c3219-d4ca-4492-993f-19c02d849644
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: IfFlowCondition
+parallel_actions: []
+integration: Flow
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: condition

--- a/content/playbooks/third_party/community/phishing_investigation/steps/create_sender_domain_entity_77ca9.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/create_sender_domain_entity_77ca9.yaml
@@ -1,0 +1,88 @@
+name: Siemplify_Create Entity
+description: Creates the extracted sender domain as an entity for further enrichment.
+identifier: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+original_step_id: 4bf29341-9c09-496a-b297-e166cd72f0d3
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+parent_step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+instance_name: Create Sender Domain Entity
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Create Entity
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Entities Identifies":"[Parse Sender Domain.ScriptResult]","Delimiter":",","Entity
+        Type":"DOMAIN","Is Internal":false,"Is Suspicious":false}'
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Siemplify_Create Entity
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data:
+    step_id: 4bf29341-9c09-496a-b297-e166cd72f0d3
+    playbook_id: c1c81f57-e04e-4847-b600-fbe310ec9843
+    creation_time: 0
+    modification_time: 0
+    result_value: ''
+    result_json: ''
+    scope_entities_enrichment_data: []
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/does_search_for_other_potentially_affected_users_return_results_4a1b0.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/does_search_for_other_potentially_affected_users_return_results_4a1b0.yaml
@@ -1,0 +1,63 @@
+name: Condition
+description: Validate whether Search for Other Potentially Impacted Users has returned
+    any result.s
+identifier: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+original_step_id: 611d1379-6240-4a9a-af81-17f7aa84b385
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 8b3f68ed-6182-4d37-8870-67f98f287734
+parent_step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+instance_name: Does Search for Other Potentially Affected users return results?
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: Branches
+    value: '[{"LogicalOperator":1,"Conditions":[{"Operator":8,"FieldName":"[Search
+        for Other Potentially Impacted Users.JsonResult| \"events\"]","Type":7,"Value":"","CustomOperatorName":"Core
+        Functions.Not Empty"}],"Order":1,"IsDefaultBranch":false,"Name":"YES"},{"LogicalOperator":0,"Conditions":[],"Order":2,"IsDefaultBranch":true,"Name":"Branch"}]'
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ErrorFallbackBranch
+    value: null
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: IfFlowCondition
+parallel_actions: []
+integration: Flow
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: condition

--- a/content/playbooks/third_party/community/phishing_investigation/steps/does_the_search_outbound_connection_return_results_35704.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/does_the_search_outbound_connection_return_results_35704.yaml
@@ -1,0 +1,62 @@
+name: Condition
+description: Validate whether Search Outbound Connection have any results.
+identifier: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+original_step_id: abeb377a-2174-425f-b59f-dac5c71e3674
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+parent_step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+instance_name: Does the Search Outbound Connection return results?
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters:
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: Branches
+    value: '[{"LogicalOperator":0,"Conditions":[{"Operator":8,"FieldName":"[Search
+        Outbound Connection.JsonResult| \"events\"]","Type":7,"Value":"","CustomOperatorName":"Core
+        Functions.Not Empty"}],"Order":1,"IsDefaultBranch":false,"Name":"Yes"},{"LogicalOperator":0,"Conditions":[],"Order":2,"IsDefaultBranch":true,"Name":"Branch"}]'
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ErrorFallbackBranch
+    value: null
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: IfFlowCondition
+parallel_actions: []
+integration: Flow
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: condition

--- a/content/playbooks/third_party/community/phishing_investigation/steps/email_header_context_09322.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/email_header_context_09322.yaml
@@ -1,0 +1,431 @@
+name: Parallel Actions
+description: ''
+identifier: 093229df-7786-4375-ae89-f1d31c53bf01
+original_step_id: 2ae3c2e7-6c17-4d2b-b8f4-90b16266f920
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 05288ead-9a5a-4450-93e7-6733cde116c2
+parent_step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+instance_name: Email Header Context
+is_automatic: true
+is_skippable: false
+action_provider: ParallelActionsContainer
+start_loop_step_id: null
+parameters: []
+action_name: ParallelActionsContainer
+parallel_actions:
+-   name: Siemplify_Set Scope Context Value
+    description: Runs parallel actions to extract authentication results.
+    identifier: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+    original_step_id: d75e98e5-72cd-4b1d-a4b0-a0bb67306499
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Authentication Result
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"authentication_result","Key Value":"[Parse
+            Email File.JsonResult| \"parsed_emails.result.header.header.authentication-results\"]"}'
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: 4a3cee8d-dad2-4452-b05c-11a05b8971f7
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 093229df-7786-4375-ae89-f1d31c53bf01
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+-   name: Siemplify_Set Scope Context Value
+    description: Runs parallel actions to extract sender.
+    identifier: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+    original_step_id: ac4f7e8a-add0-482e-b443-4591e9157d04
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Email From
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"email_from","Key Value":"[Parse
+            Email File.JsonResult| \"parsed_emails.result.header.from\" | setIfEmpty(\"-\")]"}'
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: a64e2c93-8bbc-40ca-8b3f-36a3a33e74e9
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 093229df-7786-4375-ae89-f1d31c53bf01
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+-   name: Siemplify_Set Scope Context Value
+    description: Runs parallel actions to extract subject.
+    identifier: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+    original_step_id: a1dbdf3d-910c-4ec0-868f-72db00866161
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Email Subject
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"email_subject","Key Value":"[Parse
+            Email File.JsonResult| \"parsed_emails.result.header.subject\"]\n"}'
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: ad94fb6f-ff85-4a42-890f-03b5ea1d12b4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 093229df-7786-4375-ae89-f1d31c53bf01
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data:
+        step_id: a1dbdf3d-910c-4ec0-868f-72db00866161
+        playbook_id: c1c81f57-e04e-4847-b600-fbe310ec9843
+        creation_time: 0
+        modification_time: 0
+        result_value: ''
+        result_json: ''
+        scope_entities_enrichment_data: []
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+-   name: Siemplify_Set Scope Context Value
+    description: Runs parallel actions to extract reply-to.
+    identifier: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+    original_step_id: e0d20efe-fb6d-4a89-aca1-bd8533a2ce12
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Reply-To
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"reply_to","Key Value":"[Parse
+            Email File.JsonResult| \"parsed_emails.result.header.reply_to\" | setIfEmpty(\"-\")]"}'
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: dc183a2a-f2a6-4548-9937-5d01d8c1d6f4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 093229df-7786-4375-ae89-f1d31c53bf01
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+-   name: Siemplify_Set Scope Context Value
+    description: Runs parallel actions to extract return-path.
+    identifier: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+    original_step_id: 1ba20511-65ed-42fd-9c64-7eca1eb338cc
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Return-Path
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"return_path","Key Value":"[Parse
+            Email File.JsonResult| \"parsed_emails.result.header.return_path\" | setIfEmpty(\"-\")]"}'
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: dfd900e9-e10e-4a04-9a8e-d7f8792930f1
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 093229df-7786-4375-ae89-f1d31c53bf01
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+integration: null
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: parallel_actions_container

--- a/content/playbooks/third_party/community/phishing_investigation/steps/for_each_loop_1_end_f7033.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/for_each_loop_1_end_f7033.yaml
@@ -1,0 +1,25 @@
+name: For Each Loop
+description: This returns the results of the loop
+identifier: f703326a-df9d-4f21-b5a2-9260a3d5655b
+original_step_id: 32e3a08d-79fc-4abc-bca9-3db25a9149f0
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+- c1e01089-d6a4-485a-bdd9-711d53bf689f
+parent_step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee;c1e01089-d6a4-485a-bdd9-711d53bf689f
+instance_name: For Each Loop_1_End
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters: []
+action_name: ForEachEndLoop
+parallel_actions: []
+integration: Loop
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: for_each_end_loop

--- a/content/playbooks/third_party/community/phishing_investigation/steps/for_each_loop_1_start_7e4ee.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/for_each_loop_1_start_7e4ee.yaml
@@ -1,0 +1,67 @@
+name: For Each Loop
+description: Use a for-each loop to iterate over an array of entities, events or list
+    items and execute action or series of actions
+identifier: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+original_step_id: 62c38c1c-5f1c-45dc-9d4c-fd0d5c78dadd
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 85aac862-99d1-4f94-b3f2-03b792dd46dd
+parent_step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+instance_name: For Each Loop_1_Start
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters:
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: EndLoopStepIdentifier
+    value: f703326a-df9d-4f21-b5a2-9260a3d5655b
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ListLoopDelimiter
+    value: ;
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ListLoopItems
+    value: '[Select URL.SelectedEntities]
+
+        '
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: LoopType
+    value: '3'
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: null
+action_name: ForEachStartLoop
+parallel_actions: []
+integration: Loop
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: for_each_start_loop

--- a/content/playbooks/third_party/community/phishing_investigation/steps/found_-_potentially_impacted_users_a1fd4.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/found_-_potentially_impacted_users_a1fd4.yaml
@@ -1,0 +1,187 @@
+name: Parallel Actions
+description: ''
+identifier: a1fd466d-0ecd-46f1-9474-63d50c8e6350
+original_step_id: cb2a1b0d-7052-4b09-b6f3-f086a57b66ba
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 4a1b099c-55f9-4f83-9476-7fac8db4203f
+parent_step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+instance_name: Found - Potentially impacted users
+is_automatic: true
+is_skippable: false
+action_provider: ParallelActionsContainer
+start_loop_step_id: null
+parameters: []
+action_name: ParallelActionsContainer
+parallel_actions:
+-   name: Siemplify_Set Scope Context Value
+    description: Sets context on number of recipients for search for Other Potentially
+        Impacted Users Search result
+    identifier: 20a7082c-4f97-40b4-b23d-df745973e9f3
+    original_step_id: 9102153e-d07b-41dc-9ebd-a671cd5fda7c
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Number of Recipients
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"impacted_users_count","Key Value":"[Search
+            for Other Potentially Impacted Users.JsonResult| events.udm.principal.user.userid
+            | distinct() | count()]"}'
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: 20a7082c-4f97-40b4-b23d-df745973e9f3
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: a1fd466d-0ecd-46f1-9474-63d50c8e6350
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+-   name: Siemplify_Set Scope Context Value
+    description: Sets context for Search for Other Potentially Impacted Users result
+    identifier: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+    original_step_id: 97462ddd-312b-4516-9016-ad01451b8066
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Search for Other Potentially Impacted Users - Found
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"impacted_user_search_result","Key
+            Value":"Found"}'
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: a168aff8-cfae-4f77-a7b4-58dd2a6eb17c
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: a1fd466d-0ecd-46f1-9474-63d50c8e6350
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+integration: null
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"4a1b099c-55f9-4f83-9476-7fac8db4203f\": \"1\"\n\
+    }"
+type: parallel_actions_container

--- a/content/playbooks/third_party/community/phishing_investigation/steps/get_case_attachment_65555.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/get_case_attachment_65555.yaml
@@ -1,0 +1,80 @@
+name: FileUtilities_Get Attachment
+description: The action retrieves suspicious email file (e.g., EML/MSG) attached from
+    the case to start the investigation.
+identifier: 65555523-ed14-49e6-a07b-477ffcb7658b
+original_step_id: d85e9799-f5fe-4f63-a63b-6a3ae1b597ee
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids: []
+parent_step_id: ''
+instance_name: Get Case Attachment
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: c3f098ba-381e-49a6-a274-16ec4c220500
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: FileUtilities_Get Attachment
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Attachment Scope":"Case"}'
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 65555523-ed14-49e6-a07b-477ffcb7658b
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: FileUtilities_Get Attachment
+parallel_actions: []
+integration: FileUtilities
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: null
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/no_eml_or_msg_attachment_found_39253.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/no_eml_or_msg_attachment_found_39253.yaml
@@ -1,0 +1,81 @@
+name: Siemplify_Case Comment
+description: Add a comment to the case the current alert has been grouped to
+identifier: 39253191-7083-4bd5-b08c-ffeb891e349e
+original_step_id: 7ace57fd-96bc-4831-a0c6-0ca5866f6253
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- d28c3219-d4ca-4492-993f-19c02d849644
+parent_step_id: d28c3219-d4ca-4492-993f-19c02d849644
+instance_name: No EML or MSG Attachment Found
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Case Comment
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Comment":"There''s no EML or MSG Attached in the Case Wall."}'
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 39253191-7083-4bd5-b08c-ffeb891e349e
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Siemplify_Case Comment
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"d28c3219-d4ca-4492-993f-19c02d849644\": \"2\"\n\
+    }"
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/no_url_present_c6efe.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/no_url_present_c6efe.yaml
@@ -1,0 +1,82 @@
+name: Siemplify_Set Scope Context Value
+description: Sets context for No URL Present to proceed on Search Outbound Connection
+identifier: c6efe758-f372-4428-b712-5a7081eea790
+original_step_id: 7a0f75f8-2d3a-44a0-91c5-e4768386052f
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 7597026c-6a00-4b04-ba01-4784c4d474bf
+parent_step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+instance_name: No URL Present
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Set Scope Context Value
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Context Scope":"Alert","Key Name":"outbound_connection_search_result","Key
+        Value":"No URL present in the suspicious email."}'
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: c6efe758-f372-4428-b712-5a7081eea790
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Siemplify_Set Scope Context Value
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"7597026c-6a00-4b04-ba01-4784c4d474bf\": \"2\"\n\
+    }"
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/not_found_-_potentially_impacted_users_94af7.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/not_found_-_potentially_impacted_users_94af7.yaml
@@ -1,0 +1,192 @@
+name: Parallel Actions
+description: ''
+identifier: 94af7715-5da6-42c1-94f9-6e3e20ce87d7
+original_step_id: 1963b00a-948e-4bab-a34f-8317e59ea20f
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 4a1b099c-55f9-4f83-9476-7fac8db4203f
+parent_step_id: 4a1b099c-55f9-4f83-9476-7fac8db4203f
+instance_name: Not Found - Potentially impacted users
+is_automatic: true
+is_skippable: false
+action_provider: ParallelActionsContainer
+start_loop_step_id: null
+parameters: []
+action_name: ParallelActionsContainer
+parallel_actions:
+-   name: Siemplify_Set Scope Context Value
+    description: Sets context on number of recipients as default for search for Other
+        Potentially Impacted Users Search result
+    identifier: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+    original_step_id: 36cb432f-c345-4008-bd9d-69bd8e37aab9
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Number of Recipients - Default
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"impacted_users_count","Key Value":"-"}'
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: 9f4b1d88-e96a-47db-bf0e-17400d3e4f35
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 94af7715-5da6-42c1-94f9-6e3e20ce87d7
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data:
+        step_id: 36cb432f-c345-4008-bd9d-69bd8e37aab9
+        playbook_id: c1c81f57-e04e-4847-b600-fbe310ec9843
+        creation_time: 0
+        modification_time: 0
+        result_value: ''
+        result_json: ''
+        scope_entities_enrichment_data: []
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+-   name: Siemplify_Set Scope Context Value
+    description: Sets context for Search for Other Potentially Impacted Users result
+    identifier: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+    original_step_id: e04dd688-445a-4d86-bd7f-cd4b5dcbab5d
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    parent_step_ids: []
+    parent_step_id: ''
+    instance_name: Search for Other Potentially Impacted Users - Not Found
+    is_automatic: true
+    is_skippable: false
+    action_provider: Scripts
+    start_loop_step_id: null
+    parameters:
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: AssignedUsers
+        value: null
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DistinctDuplicateEntities
+        value: null
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: DynamicInjectionInstancePlaceholder
+        value: ''
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FallbackIntegrationInstance
+        value: null
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: FetchInstanceByName
+        value: 'false'
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: HasApprovalLink
+        value: null
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: IntegrationInstance
+        value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: MessageToAssignee
+        value: null
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: PendingActionTimeout
+        value: null
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: RetryConfiguration
+        value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptName
+        value: Siemplify_Set Scope Context Value
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: ScriptParametersEntityFields
+        value: '{"Context Scope":"Alert","Key Name":"impacted_user_search_result","Key
+            Value":"Not Found"}'
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: SelectedScopeName
+        value: All entities
+    -   step_id: 05f5d4ef-3d4a-474c-a144-bcea697fd2d4
+        playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+        name: UseEntitiesLoopScope
+        value: null
+    action_name: Siemplify_Set Scope Context Value
+    parallel_actions: []
+    integration: Siemplify
+    parent_container_id: 94af7715-5da6-42c1-94f9-6e3e20ce87d7
+    is_touched_by_ai: false
+    is_debug_mock_data: false
+    step_debug_data: null
+    auto_skip_on_failure: false
+    previous_result_condition: null
+    type: action
+integration: null
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"4a1b099c-55f9-4f83-9476-7fac8db4203f\": \"2\"\n\
+    }"
+type: parallel_actions_container

--- a/content/playbooks/third_party/community/phishing_investigation/steps/parse_email_file_59d84.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/parse_email_file_59d84.yaml
@@ -1,0 +1,84 @@
+name: EmailUtilities_Parse Case Wall Email
+description: Extracts key information from the email such as headers, sender/recipient,
+    and embedded artifacts (URLs, domains, IPs, hashes).
+identifier: 59d84cbe-4445-4566-a806-68af57eec6a7
+original_step_id: 4398d4d0-6830-4187-86cd-d7915cd721bb
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- d28c3219-d4ca-4492-993f-19c02d849644
+parent_step_id: d28c3219-d4ca-4492-993f-19c02d849644
+instance_name: Parse Email File
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: c6222472-485e-4f13-a399-56b390610d50
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: EmailUtilities_Parse Case Wall Email
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Create Entities":true,"Exclude Entities Regex":"","Original EML Only":true,"Create
+        Observed Entities":"All","Save Attachments to Case Wall":false,"Fang Entities":false,"Custom
+        Entity Regexes":"{ }"}'
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: EmailUtilities_Parse Case Wall Email
+parallel_actions: []
+integration: EmailUtilities
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"d28c3219-d4ca-4492-993f-19c02d849644\": \"1\"\n\
+    }"
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/parse_sender_domain_a8f3d.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/parse_sender_domain_a8f3d.yaml
@@ -1,0 +1,87 @@
+name: Functions_String Functions
+description: "Extracts the sender\u2019s domain from the email."
+identifier: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+original_step_id: bb4428fb-636c-40c4-849e-79fff2afa640
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 093229df-7786-4375-ae89-f1d31c53bf01
+parent_step_id: 093229df-7786-4375-ae89-f1d31c53bf01
+instance_name: Parse Sender Domain
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: 8745dc19-6d97-4d6b-a81d-febaa75aab7c
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Functions_String Functions
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Param 2":" ","Param 1":"(?<=@)[\\w.-]+\\.[a-z]{2,}","Input":"[Alert.email_from]","Function":"Regex"}'
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: a8f3d73d-76f3-4267-9264-08ab0a31fdf2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Functions_String Functions
+parallel_actions: []
+integration: Functions
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data:
+    step_id: bb4428fb-636c-40c4-849e-79fff2afa640
+    playbook_id: c1c81f57-e04e-4847-b600-fbe310ec9843
+    creation_time: 0
+    modification_time: 0
+    result_value: ''
+    result_json: ''
+    scope_entities_enrichment_data: []
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/phishing_-_email_header_analysis_c51e4.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/phishing_-_email_header_analysis_c51e4.yaml
@@ -1,0 +1,69 @@
+name: Phishing - Email Header Analysis
+description: This block automates email header parsing for phishing analysis by ingesting
+    and validating raw header data, then extracting key fields like sender, recipient,
+    subject, and routing details. It reconstructs the email path to identify the source
+    IP and servers, evaluates SPF, DKIM, and DMARC results, and outputs structured
+    insights including metadata, authentication status, and flagged indicators.
+identifier: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+original_step_id: 3639c5ed-1bd6-48d4-9187-b6ee5d251929
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+parent_step_id: 77ca927c-9c1f-45cf-8bf6-1abbfd4c20f1
+instance_name: Phishing - Email Header Analysis
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: NestedWorkflowIdentifier
+    value: 3149e117-2ff6-4e75-86ce-7d029d7fca55
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: NestedWorkflowInputs
+    value: '[{"FieldName":"Reply To","Value":"[Alert.reply_to]"},{"FieldName":"Return
+        Path","Value":"[Alert.return_path]"},{"FieldName":"Reply From","Value":"[Alert.reply_from]"},{"FieldName":"Authentication
+        Results","Value":"[Alert.authentication_result]"},{"FieldName":"SPF Dictionary","Value":"{\r\n  \"Pass\"
+        : \"0\",\r\n  \"Fail\" : \"2\",\r\n  \"SoftFail\" : \"1\",\r\n  \"Neutral\"
+        : \"1\",\r\n  \"TempError\" : \"1\",\r\n  \"PermError\" : \"2\",\r\n  \"None\"
+        : \"1\"\r\n}   "},{"FieldName":"DKIM Dictionary","Value":"{\r\n  \"Pass\"
+        : \"0\",\r\n  \"Fail\" : \"1\",\r\n  \"None\" : \"1\"\r\n} "},{"FieldName":"DMARC
+        Dictionary","Value":"{\r\n  \"Pass\" : \"0\",\r\n  \"Fail\" : \"3\",\r\n  \"BestGuessPass\"
+        : \"1\",\r\n  \"TempError\" : \"1\",\r\n  \"PermError\" : \"2\",\r\n  \"None\"
+        : \"2\"\r\n} "}]'
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: NestedAction
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: block

--- a/content/playbooks/third_party/community/phishing_investigation/steps/phishing_-_entities_and_artifacts_enrichment_c7dbe.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/phishing_-_entities_and_artifacts_enrichment_c7dbe.yaml
@@ -1,0 +1,60 @@
+name: Phishing - Entities and Artifacts Enrichment
+description: This block processes and enriches key indicators such as IPs, domains,
+    URLs, and file hashes using Google Threat Intelligence. It retrieves last analysis
+    malicious counts to assess indicator reputation and risk. A scoring matrix is
+    applied across these results to derive an overall confidence level, supporting
+    accurate identification of malicious activity.
+identifier: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+original_step_id: 9f1f6a65-a793-4ca2-88e8-34df87b4fe1a
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+parent_step_id: c51e42c7-7f73-4ee3-b93b-fc7c57698cd3
+instance_name: Phishing - Entities and Artifacts Enrichment
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: NestedWorkflowIdentifier
+    value: f6b69949-9533-4bac-95f5-70f621de3666
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: NestedWorkflowInputs
+    value: '[]'
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: NestedAction
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: block

--- a/content/playbooks/third_party/community/phishing_investigation/steps/phishing_investigation_-_email_body_defang_05288.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/phishing_investigation_-_email_body_defang_05288.yaml
@@ -1,0 +1,61 @@
+name: Defang Email Indicators
+description: The block defangs all potentially malicious indicators found within the
+    email body by neutralizing hyperlinks, obfuscating URL schemes, bracketing dots
+    in IP addresses, domains, and email addresses, and defanging executable file extensions
+    to prevent accidental clicks or execution while preserving the original content
+    for analyst review.
+identifier: 05288ead-9a5a-4450-93e7-6733cde116c2
+original_step_id: bd1fb6f5-5ab9-4afe-8225-1e1de545c8a6
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 59d84cbe-4445-4566-a806-68af57eec6a7
+parent_step_id: 59d84cbe-4445-4566-a806-68af57eec6a7
+instance_name: Phishing Investigation - Email Body Defang
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: NestedWorkflowIdentifier
+    value: 8d451449-0c50-4792-99c4-e0ca84f2cd1d
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: NestedWorkflowInputs
+    value: '[{"FieldName":"Email Body","Value":"[Parse Email File.JsonResult| \"parsed_emails.result.body\"
+        | filter(\"content_type\", \"=\", \"text/html\") | \"content\"]"}]'
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 05288ead-9a5a-4450-93e7-6733cde116c2
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: NestedAction
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: block

--- a/content/playbooks/third_party/community/phishing_investigation/steps/phishing_investigation_result_5a738.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/phishing_investigation_result_5a738.yaml
@@ -1,0 +1,81 @@
+name: Siemplify_Set Scope Context Value
+description: Sets context for Phishing Investigation Result
+identifier: 5a738985-f227-4f1a-b8a3-11a2a7109805
+original_step_id: 645f651a-c215-4591-a6e5-486d6f42f99d
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+parent_step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+instance_name: Phishing Investigation Result
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Set Scope Context Value
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Context Scope":"Alert","Key Name":"phishing_investigation_result","Key
+        Value":"[Prepare Phishing Analysis Result.ScriptResult]"}'
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 5a738985-f227-4f1a-b8a3-11a2a7109805
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Siemplify_Set Scope Context Value
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/potentially_impacted_users_not_found_f8a46.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/potentially_impacted_users_not_found_f8a46.yaml
@@ -1,0 +1,84 @@
+name: Siemplify_Case Comment
+description: Add a comment to the case for the no logs found after search
+identifier: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+original_step_id: c01e5be4-cac9-4eed-9639-90724cf7ed01
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 94af7715-5da6-42c1-94f9-6e3e20ce87d7
+parent_step_id: 94af7715-5da6-42c1-94f9-6e3e20ce87d7
+instance_name: Potentially impacted users not found
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Case Comment
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: "{\"Comment\":\"No logs found within the past 7 days.\\n\\nPossible Issues:\\\
+        n\u2022 No data available for lookup.\\n\u2022 Possible invalid input.\\n\u2022\
+        \ Potential integration error during outbound connection search.\\n\u2022\
+        \ Review and validate the input parameters.\\n\u2022 Consider extending the\
+        \ search duration beyond 7 days.\"}"
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Siemplify_Case Comment
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/prepare_outbound_connection_lookup_result_85aac.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/prepare_outbound_connection_lookup_result_85aac.yaml
@@ -1,0 +1,82 @@
+name: Siemplify_Set Scope Context Value
+description: Sets context for preparation on Outbound Connection Search Result
+identifier: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+original_step_id: 703fbebb-7982-45af-8ec4-3399506e24bf
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 7597026c-6a00-4b04-ba01-4784c4d474bf
+parent_step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+instance_name: Prepare Outbound Connection Lookup Result
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Set Scope Context Value
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Context Scope":"Alert","Key Name":"outbound_connection_search_result","Key
+        Value":"result"}'
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 85aac862-99d1-4f94-b3f2-03b792dd46dd
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: Siemplify_Set Scope Context Value
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"7597026c-6a00-4b04-ba01-4784c4d474bf\": \"1\"\n\
+    }"
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/prepare_phishing_analysis_result_b3b59.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/prepare_phishing_analysis_result_b3b59.yaml
@@ -1,0 +1,213 @@
+name: TemplateEngine_Render Template
+description: Compiles all collected data into a structured investigation report.
+identifier: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+original_step_id: 1b5298b1-ad58-4fe7-a6a0-bcd8ab4415cf
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- f703326a-df9d-4f21-b5a2-9260a3d5655b
+- c6efe758-f372-4428-b712-5a7081eea790
+parent_step_id: f703326a-df9d-4f21-b5a2-9260a3d5655b;c6efe758-f372-4428-b712-5a7081eea790
+instance_name: Prepare Phishing Analysis Result
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: 03edb6fd-5733-4e02-abbb-4d54fc8b1dd1
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: TemplateEngine_Render Template
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: "{\"JSON Object\":\"{}\",\"Jinja\":\"{% macro is_blank(value) -%}{%- if\
+        \ not value or (value | trim) == \\\"\\\" or (value | trim) == \\\"-\\\" or\
+        \ ((value | trim).startswith(\\\"[\\\") and (value | trim).endswith(\\\"]\\\
+        \")) -%}true{%- else -%}false{%- endif -%}{%- endmacro %}{% macro verdict_badge(value)\
+        \ -%}{%- if value == \\\"CONFIRMED MALICIOUS - VERY HIGH CONFIDENCE\\\" -%}<span\
+        \ class=\\\"phishing-report-widget\\\" style=\\\"display:inline-flex;align-items:center;gap:4px;padding:2px\
+        \ 8px 2px 6px;border-radius:3px;border:1px solid #7a1515;background-color:#180404;color:#ff5555;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;\\\
+        \"><span style=\\\"width:5px;height:5px;border-radius:50%;background:#ff5555;box-shadow:0\
+        \ 0 6px #ff5555;flex-shrink:0;display:inline-block;\\\"></span>{{ value }}</span>{%-\
+        \ elif value == \\\"MALICIOUS - HIGH CONFIDENCE\\\" -%}<span class=\\\"phishing-report-widget\\\
+        \" style=\\\"display:inline-flex;align-items:center;gap:4px;padding:2px 8px\
+        \ 2px 6px;border-radius:3px;border:1px solid #5a1010;background-color:#140303;color:#f06060;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;\\\
+        \"><span style=\\\"width:5px;height:5px;border-radius:50%;background:#f06060;box-shadow:0\
+        \ 0 6px #f06060;flex-shrink:0;display:inline-block;\\\"></span>{{ value }}</span>{%-\
+        \ elif value == \\\"LIKELY MALICIOUS - MEDIUM CONFIDENCE\\\" -%}<span class=\\\
+        \"phishing-report-widget\\\" style=\\\"display:inline-flex;align-items:center;gap:4px;padding:2px\
+        \ 8px 2px 6px;border-radius:3px;border:1px solid #703000;background-color:#140800;color:#f08030;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;\\\
+        \"><span style=\\\"width:5px;height:5px;border-radius:50%;background:#f08030;box-shadow:0\
+        \ 0 6px #f08030;flex-shrink:0;display:inline-block;\\\"></span>{{ value }}</span>{%-\
+        \ elif value == \\\"SUSPICIOUS - LOW CONFIDENCE\\\" -%}<span class=\\\"phishing-report-widget\\\
+        \" style=\\\"display:inline-flex;align-items:center;gap:4px;padding:2px 8px\
+        \ 2px 6px;border-radius:3px;border:1px solid #604800;background-color:#110c00;color:#e8b020;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;\\\
+        \"><span style=\\\"width:5px;height:5px;border-radius:50%;background:#e8b020;box-shadow:0\
+        \ 0 4px #e8b020;flex-shrink:0;display:inline-block;\\\"></span>{{ value }}</span>{%-\
+        \ elif value == \\\"LEGITIMATE - NO CONFIDENCE\\\" -%}<span class=\\\"phishing-report-widget\\\
+        \" style=\\\"display:inline-flex;align-items:center;gap:4px;padding:2px 8px\
+        \ 2px 6px;border-radius:3px;border:1px solid #055038;background-color:#011006;color:#28c880;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;\\\
+        \"><span style=\\\"width:5px;height:5px;border-radius:50%;background:#28c880;box-shadow:0\
+        \ 0 6px #28c880;flex-shrink:0;display:inline-block;\\\"></span>{{ value }}</span>{%-\
+        \ else -%}<span class=\\\"phishing-report-widget\\\" style=\\\"display:inline-flex;align-items:center;gap:4px;padding:2px\
+        \ 8px 2px 6px;border-radius:3px;border:1px solid #1a2a38;background-color:#0c1018;color:#506070;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:10px;font-weight:700;letter-spacing:0.08em;text-transform:uppercase;white-space:nowrap;\\\
+        \"><span style=\\\"width:5px;height:5px;border-radius:50%;background:#506070;flex-shrink:0;display:inline-block;\\\
+        \"></span>INCONCLUSIVE</span>{%- endif -%}{%- endmacro %}{% macro data_row(label,\
+        \ value, bg) %}{%- if is_blank(label) | trim == \\\"false\\\" or is_blank(value)\
+        \ | trim == \\\"false\\\" -%}<tr><td style=\\\"padding:4px 14px;border-bottom:1px\
+        \ solid #1e3a5f;border-right:1.5px solid #2e5080;font-family:'Segoe UI',Arial,sans-serif;font-size:11.5px;font-weight:600;color:#d0e8ff;background-color:{{\
+        \ bg }};word-break:break-all;overflow-wrap:anywhere;\\\">{{ label }}</td><td\
+        \ style=\\\"padding:4px 14px;border-bottom:1px solid #1e3a5f;font-family:'Courier\
+        \ New',monospace;font-size:11px;color:#90bce0;background-color:{{ bg }};word-break:break-all;overflow-wrap:anywhere;\\\
+        \">{{ value }}</td></tr>{%- endif %}{%- endmacro %}{% macro verdict_row(label,\
+        \ value) %}{%- if is_blank(value) | trim == \\\"false\\\" -%}<tr><td style=\\\
+        \"padding:4px 14px;border-top:1px solid #2e5080;border-right:1.5px solid #2e5080;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#a8c8f0;background-color:#162d4a;\\\
+        \"><span style=\\\"display:inline-block;width:4px;height:4px;border-radius:50%;background:#4a90d9;box-shadow:0\
+        \ 0 5px #4a90d9;margin-right:7px;vertical-align:middle;\\\"></span>{{ label\
+        \ }}</td><td style=\\\"padding:4px 14px;border-top:1px solid #2e5080;background-color:#162d4a;\\\
+        \">{{ verdict_badge(value) }}</td></tr>{%- endif %}{%- endmacro %}{% macro\
+        \ sec_hdr(icon, title) %}<tr><td colspan=\\\"2\\\" style=\\\"padding:4px 14px;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:1.2px;color:#a8c8f0;background-color:#162d4a;border-top:1px\
+        \ solid #2e5080;border-bottom:1px solid #2e5080;\\\"><span style=\\\"font-size:13px;\\\
+        \">{{ icon }}</span>&nbsp; {{ title }}</td></tr>{%- endmacro %}{% macro col_head(left,\
+        \ right) %}<tr><th style=\\\"padding:4px 14px;text-align:center;width:50%;background-color:#1e3a5f;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.9px;color:#a8c8f0;border-bottom:1.5px\
+        \ solid #4a90d9;border-right:1.5px solid #4a90d9;\\\">{{ left }}</th><th style=\\\
+        \"padding:4px 14px;text-align:center;width:50%;background-color:#1e3a5f;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.9px;color:#a8c8f0;border-bottom:1.5px\
+        \ solid #4a90d9;\\\">{{ right }}</th></tr>{%- endmacro %}<div class=\\\"phishing-report-widget\\\
+        \"><table style=\\\"width:100%;border-collapse:collapse;font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:13px;line-height:1.5;border:1.5px solid #4a90d9;border-radius:8px;overflow:hidden;\\\
+        \"><tr><td colspan=\\\"2\\\" style=\\\"padding:5px 16px;background:linear-gradient(135deg,#0f1e30\
+        \ 0%,#0a1520 100%);border-bottom:2px solid #4a90d9;position:relative;\\\"\
+        ><div style=\\\"position:absolute;left:0;top:0;bottom:0;width:3px;background:linear-gradient(180deg,#3090d8,#1060a8);\\\
+        \"></div><div style=\\\"display:flex;align-items:center;gap:10px;padding-left:8px;\\\
+        \"><div style=\\\"width:30px;height:30px;background:linear-gradient(135deg,rgba(32,128,192,0.2),rgba(16,80,140,0.15));border:1px\
+        \ solid rgba(32,128,192,0.35);border-radius:5px;display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0;\\\
+        \">&#128274;</div><div style=\\\"flex:1;\\\"><div style=\\\"font-family:'Segoe\
+        \ UI',Arial,sans-serif;font-size:13px;font-weight:700;letter-spacing:0.1em;color:#c8dff5;text-transform:uppercase;\\\
+        \">Phishing Investigation</div><div style=\\\"font-family:'Courier New',monospace;font-size:9.5px;color:#4a6880;margin-top:2px;letter-spacing:0.03em;\\\
+        \">SOC Automated Analysis Report</div></div></div></td></tr>{{ sec_hdr(\\\"\
+        \U0001F4E7\\\", \\\"Email Header Analysis\\\") }}{{ col_head(\\\"Field\\\"\
+        , \\\"Finding\\\") }}{{ data_row(\\\"Reply-To\\\", \\\"[Alert.reply_to_result]\\\
+        \", \\\"#0f2035\\\") }}{{ data_row(\\\"Return-Path\\\", \\\"[Alert.return_path_result]\\\
+        \", \\\"#112238\\\") }}{{ data_row(\\\"SPF\\\", \\\"[Alert.spf_result]\\\"\
+        , \\\"#0f2035\\\") }}{{ data_row(\\\"DKIM\\\", \\\"[Alert.dkim_result]\\\"\
+        , \\\"#112238\\\") }}{{ data_row(\\\"DMARC\\\", \\\"[Alert.dmarc_result]\\\
+        \", \\\"#0f2035\\\") }}{{ verdict_row(\\\"Classification\\\", \\\"[Alert.email_header_verdict]\\\
+        \") }}{{ sec_hdr(\\\"\U0001F3AF\\\", \\\"Entities & Artifacts Enrichment\\\
+        \") }}{% set _all_blank = (is_blank(\\\"[Alert.selected_ip]\\\") | trim ==\
+        \ \\\"true\\\" and is_blank(\\\"[Alert.selected_url]\\\") | trim == \\\"true\\\
+        \" and is_blank(\\\"[Alert.selected_domain]\\\") | trim == \\\"true\\\" and\
+        \ is_blank(\\\"[Alert.selected_hash]\\\") | trim == \\\"true\\\") %}{% if\
+        \ _all_blank %}{{ data_row(\\\"Entities\\\", \\\"Not Found\\\", \\\"#0f2035\\\
+        \") }}{% else %}{{ col_head(\\\"Entities\\\", \\\"Vendor Detection Count\\\
+        \") }}{% if is_blank(\\\"[Alert.selected_ip]\\\") | trim == \\\"false\\\"\
+        \ %}{% set _ip_ents = \\\"[Alert.selected_ip]\\\".split(',') %}{% set _ip_res\
+        \ = \\\"[Alert.ip_address_result]\\\".split(',') %}{% for _ent in _ip_ents\
+        \ %}{% set _idx = loop.index0 %}{% if _idx < _ip_res | length %}{% set _res\
+        \ = _ip_res[_idx] | trim %}{% else %}{% set _res = \\\"\u2014\\\" %}{% endif\
+        \ %}{{ data_row(_ent | trim, _res, \\\"#0f2035\\\" if loop.index is odd else\
+        \ \\\"#112238\\\") }}{% endfor %}{% endif %}{% if is_blank(\\\"[Alert.selected_url]\\\
+        \") | trim == \\\"false\\\" %}{% set _url_ents = \\\"[Alert.selected_url]\\\
+        \".split(',') %}{% set _url_res = \\\"[Alert.url_result]\\\".split(',') %}{%\
+        \ for _ent in _url_ents %}{% set _idx = loop.index0 %}{% if _idx < _url_res\
+        \ | length %}{% set _res = _url_res[_idx] | trim %}{% else %}{% set _res =\
+        \ \\\"\u2014\\\" %}{% endif %}{{ data_row(_ent | trim, _res, \\\"#0f2035\\\
+        \" if loop.index is odd else \\\"#112238\\\") }}{% endfor %}{% endif %}{%\
+        \ if is_blank(\\\"[Alert.selected_domain]\\\") | trim == \\\"false\\\" %}{%\
+        \ set _dom_ents = \\\"[Alert.selected_domain]\\\".split(',') %}{% set _dom_res\
+        \ = \\\"[Alert.domain_result]\\\".split(',') %}{% for _ent in _dom_ents %}{%\
+        \ set _idx = loop.index0 %}{% if _idx < _dom_res | length %}{% set _res =\
+        \ _dom_res[_idx] | trim %}{% else %}{% set _res = \\\"\u2014\\\" %}{% endif\
+        \ %}{{ data_row(_ent | trim, _res, \\\"#0f2035\\\" if loop.index is odd else\
+        \ \\\"#112238\\\") }}{% endfor %}{% endif %}{% if is_blank(\\\"[Alert.selected_hash]\\\
+        \") | trim == \\\"false\\\" %}{% set _hash_ents = \\\"[Alert.selected_hash]\\\
+        \".split(',') %}{% set _hash_res = \\\"[Alert.hash_result]\\\".split(',')\
+        \ %}{% for _ent in _hash_ents %}{% set _idx = loop.index0 %}{% if _idx < _hash_res\
+        \ | length %}{% set _res = _hash_res[_idx] | trim %}{% else %}{% set _res\
+        \ = \\\"\u2014\\\" %}{% endif %}{{ data_row(_ent | trim, _res, \\\"#0f2035\\\
+        \" if loop.index is odd else \\\"#112238\\\") }}{% endfor %}{% endif %}{%\
+        \ endif %}{{ verdict_row(\\\"Classification\\\", \\\"[Alert.entities_verdict]\\\
+        \") }}{{ sec_hdr(\\\"\U0001F50D\\\", \\\"Suspicious Email Recipients\\\")\
+        \ }}{% if \\\"[Alert.impacted_user_search_result]\\\" == \\\"Not Found\\\"\
+        \ %}{{ data_row(\\\"Search Result\\\", \\\"[Alert.impacted_user_search_result]\\\
+        \", \\\"#0f2035\\\") }}{% endif %}{% if \\\"[Alert.impacted_user_search_result]\\\
+        \" != \\\"Not Found\\\" %}{{ data_row(\\\"Unique User Count\\\", \\\"[Alert.impacted_users_count]\\\
+        \", \\\"#112238\\\") }}{% endif %}{{ sec_hdr(\\\"\U0001F50D\\\", \\\"Phishing\
+        \ Email Click Records\\\") }}{% set _obs_raw = \\\"[Alert.outbound_connection_search_result]\\\
+        \" %}{% if is_blank(_obs_raw) | trim == \\\"false\\\" %}{% if _obs_raw ==\
+        \ \\\"No URL present in the suspicious email.\\\" %}{{ data_row(\\\"Search\
+        \ Result\\\", \\\"Not Found\\\", \\\"#0f2035\\\") }}{% elif _obs_raw.startswith('result;')\
+        \ %}{{ col_head(\\\"Suspicious URL\\\", \\\"Click Count (Unique User)\\\"\
+        ) }}{% for _entry in _obs_raw.split(';') if _entry.startswith('URL:') %}{%\
+        \ set _parts = _entry.split(',') %}{{ data_row(_parts[0] | replace('URL:',\
+        \ ''), _parts[1] | replace('Count:', ''), \\\"#0f2035\\\" if loop.index is\
+        \ odd else \\\"#112238\\\") }}{% endfor %}{% else %}{{ col_head(\\\"Suspicious\
+        \ URL\\\", \\\"Click Count (Unique Users)\\\") }}{{ data_row(_obs_raw, \\\"\
+        \u2014\\\", \\\"#0f2035\\\") }}{% endif %}{% endif %}</table></div>\",\"Include\
+        \ Case Data\":false,\"Template\":\"{\\\"Content\\\":\\\"\\\",\\\"ContentTemplateName\\\
+        \":\\\"\\\",\\\"HtmlTemplateName\\\":\\\"\\\"}\"}"
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: b3b59a67-ee51-43ec-b8e2-aaaa46c1b239
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: TemplateEngine_Render Template
+parallel_actions: []
+integration: TemplateEngine
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/search_for_other_potentially_impacted_users_8b3f6.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/search_for_other_potentially_impacted_users_8b3f6.yaml
@@ -1,0 +1,84 @@
+name: GoogleChronicle_Execute UDM Query
+description: Uses Google Chronicle to look for additional users who may have interacted
+    with related malicious activity.
+identifier: 8b3f68ed-6182-4d37-8870-67f98f287734
+original_step_id: 3a2444ee-a20d-4542-9279-bfe973aecf00
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+parent_step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+instance_name: Search for Other Potentially Impacted Users
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: null
+parameters:
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: 2da8a612-44aa-4f11-ae86-7ae1534aec7d
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: GoogleChronicle_Execute UDM Query
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Query":"metadata.event_type = \"EMAIL_TRANSACTION\"\nnetwork.email.from
+        = \"[Alert.email_from]\"\nnetwork.email.subject = \"[Alert.email_subject]\"\nprincipal.user.userid
+        != \"\"","Include Raw Log Data":false,"Time Frame":"Last Week","Start Time":"","End
+        Time":"","Max Results To Return":"50"}'
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: null
+action_name: GoogleChronicle_Execute UDM Query
+parallel_actions: []
+integration: GoogleChronicle
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/search_outbound_connection_-_no_result_c1e01.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/search_outbound_connection_-_no_result_c1e01.yaml
@@ -1,0 +1,84 @@
+name: Siemplify_Case Comment
+description: Add a comment to the case for the no logs found after search
+identifier: c1e01089-d6a4-485a-bdd9-711d53bf689f
+original_step_id: aed227ca-11ba-45e1-b9ba-86676ffd8bda
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 8640eaf4-0339-4fdf-8712-f72516b050a0
+parent_step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+instance_name: Search Outbound Connection - No Result
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters:
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: a4e2b09e-9972-4a54-b726-7fc459c31ba5
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Siemplify_Case Comment
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: "{\"Comment\":\"No logs found within the past 7 days for [Loop.Item].\\\
+        n\\nPossible Issues:\\n\u2022 No data available for lookup.\\n\u2022 Possible\
+        \ invalid input.\\n\u2022 Potential integration error during outbound connection\
+        \ search.\\n\u2022 Review and validate the input parameters.\\n\u2022 Consider\
+        \ extending the search duration beyond 7 days.\"}"
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: c1e01089-d6a4-485a-bdd9-711d53bf689f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: Siemplify_Case Comment
+parallel_actions: []
+integration: Siemplify
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/search_outbound_connection_b70e3.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/search_outbound_connection_b70e3.yaml
@@ -1,0 +1,84 @@
+name: GoogleChronicle_Execute UDM Query
+description: Uses Google Chronicle to check if users in the environment accessed or
+    clicked the URL.
+identifier: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+original_step_id: 124fc037-ed11-4b1e-a5a9-cc16f4035f07
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parent_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+instance_name: Search Outbound Connection
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters:
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: 2da8a612-44aa-4f11-ae86-7ae1534aec7d
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: GoogleChronicle_Execute UDM Query
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Query":"metadata.event_type = \"NETWORK_CONNECTION\"\nAND network.direction
+        = \"OUTBOUND\"\nAND network.email.from != \"\"\nAND target.url = \"[Loop.Item]\"","Include
+        Raw Log Data":false,"Time Frame":"Last Week","Start Time":"","End Time":"","Max
+        Results To Return":"50"}'
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: GoogleChronicle_Execute UDM Query
+parallel_actions: []
+integration: GoogleChronicle
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/select_url_e0514.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/select_url_e0514.yaml
@@ -1,0 +1,63 @@
+name: Entity Selection
+description: ' Filters and isolates URL entities from all extracted artifacts for
+    focused analysis.'
+identifier: e05140ed-0f45-4755-a02c-dd8a254d6c52
+original_step_id: 367b5715-6e30-4346-b646-41c4dc314cd3
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- a1fd466d-0ecd-46f1-9474-63d50c8e6350
+- f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+parent_step_id: a1fd466d-0ecd-46f1-9474-63d50c8e6350;f8a46b8d-0451-4811-8d1f-956b4a7d6e59
+instance_name: Select URL
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ConditionOperator
+    value: '0'
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: Conditions
+    value: '[{"FieldName":"Entity.Type","Operator":0,"Value":"DestinationURL","Type":2,"CustomOperatorName":"Core
+        Functions.Equal"}]'
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: EntitySelection
+parallel_actions: []
+integration: Flow
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/set_number_of_user_clicked_malicious_url_-_default_8640e.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/set_number_of_user_clicked_malicious_url_-_default_8640e.yaml
@@ -1,0 +1,82 @@
+name: Tools_Append to Context Value
+description: Sets context on number of clicks as default for search for Search Outbound
+    Connection result
+identifier: 8640eaf4-0339-4fdf-8712-f72516b050a0
+original_step_id: b881abe5-885c-416e-a6de-0909c4499d12
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 35704ff2-448d-493e-a7ff-a72c5d3a8244
+parent_step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+instance_name: Set Number of User Clicked Malicious URL - Default
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters:
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: 'false'
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: 4b41988d-9fb1-4a11-b3e5-18f17c87bc84
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Tools_Append to Context Value
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Scope":"Alert","Key":"outbound_connection_search_result","Value":"URL:[Loop.Item],Count:-","Delimiter":";"}'
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 8640eaf4-0339-4fdf-8712-f72516b050a0
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: Tools_Append to Context Value
+parallel_actions: []
+integration: Tools
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"35704ff2-448d-493e-a7ff-a72c5d3a8244\": \"2\"\n\
+    }"
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/set_number_of_user_clicked_malicious_url_e6d63.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/set_number_of_user_clicked_malicious_url_e6d63.yaml
@@ -1,0 +1,84 @@
+name: Tools_Append to Context Value
+description: Sets context on number of clicks for search for Search Outbound Connection
+    result
+identifier: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+original_step_id: bb167020-fb64-4e12-b40c-040f950aee4b
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- 35704ff2-448d-493e-a7ff-a72c5d3a8244
+parent_step_id: 35704ff2-448d-493e-a7ff-a72c5d3a8244
+instance_name: Set Number of User Clicked Malicious URL
+is_automatic: true
+is_skippable: false
+action_provider: Scripts
+start_loop_step_id: 7e4eec9b-6a2e-4b57-9176-6de51ed20812
+parameters:
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: null
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DynamicInjectionInstancePlaceholder
+    value: ''
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FallbackIntegrationInstance
+    value: null
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: FetchInstanceByName
+    value: 'false'
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: IntegrationInstance
+    value: 4b41988d-9fb1-4a11-b3e5-18f17c87bc84
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: RetryConfiguration
+    value: '{"Enabled":false,"IntervalInSeconds":30,"NumberOfRetries":1}'
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptName
+    value: Tools_Append to Context Value
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ScriptParametersEntityFields
+    value: '{"Scope":"Alert","Key":"outbound_connection_search_result","Value":"URL:[Loop.Item],Count:[Search
+        Outbound Connection.JsonResult| \"events.udm.principal.user.userid\" | distinct()
+        | count()]","Delimiter":";"}'
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: e6d63e8c-156b-4fc5-b98b-1e8f71d5a3ee
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: Tools_Append to Context Value
+parallel_actions: []
+integration: Tools
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: "{\n  \"35704ff2-448d-493e-a7ff-a72c5d3a8244\": \"1\"\n\
+    }"
+type: action

--- a/content/playbooks/third_party/community/phishing_investigation/steps/url_present_75970.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/steps/url_present_75970.yaml
@@ -1,0 +1,62 @@
+name: Condition
+description: Validates whether URL is present in the Case
+identifier: 7597026c-6a00-4b04-ba01-4784c4d474bf
+original_step_id: 05e45414-68a3-428c-a08a-227c204c590b
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+parent_step_ids:
+- e05140ed-0f45-4755-a02c-dd8a254d6c52
+parent_step_id: e05140ed-0f45-4755-a02c-dd8a254d6c52
+instance_name: URL Present?
+is_automatic: true
+is_skippable: false
+action_provider: Flow
+start_loop_step_id: null
+parameters:
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: AssignedUsers
+    value: null
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: Branches
+    value: '[{"LogicalOperator":0,"Conditions":[{"Operator":8,"FieldName":"[Select
+        URL.SelectedEntities]","Type":7,"Value":"","CustomOperatorName":"Core Functions.Not
+        Empty"}],"Order":1,"IsDefaultBranch":false,"Name":"Yes"},{"LogicalOperator":0,"Conditions":[],"Order":2,"IsDefaultBranch":true,"Name":"Branch"}]'
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: DistinctDuplicateEntities
+    value: 'true'
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: ErrorFallbackBranch
+    value: null
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: HasApprovalLink
+    value: null
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: MessageToAssignee
+    value: null
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: PendingActionTimeout
+    value: null
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: SelectedScopeName
+    value: All entities
+-   step_id: 7597026c-6a00-4b04-ba01-4784c4d474bf
+    playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+    name: UseEntitiesLoopScope
+    value: 'true'
+action_name: IfFlowCondition
+parallel_actions: []
+integration: Flow
+parent_container_id: null
+is_touched_by_ai: false
+is_debug_mock_data: false
+step_debug_data: null
+auto_skip_on_failure: false
+previous_result_condition: '{}'
+type: condition

--- a/content/playbooks/third_party/community/phishing_investigation/trigger.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/trigger.yaml
@@ -1,0 +1,13 @@
+identifier: 84e5a0c8-5180-46e4-b93f-b2a639444368
+is_enabled: true
+playbook_id: 39d8f9cd-d125-4673-9c61-2e00e9727801
+type_: case_data
+conditions:
+-   field_name: '1'
+    value: '2'
+    match_type: equal
+    custom_operator_name: null
+logical_operator: and
+environments:
+- '*'
+playbook_name: null

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Email Body.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Email Body.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<style>
+	body {
+		background-color: #EDEFF6;
+		color: #4E4F63;
+		font-family: Source Sans;
+	}
+</style>
+</head>
+
+<body>
+[Alert.email_defang_result]
+</body>
+<script>
+	//This script enables the widget theme to reflect the user's choice in the platform.
+	//Removing this script will result in your HTML widget permanently displayed in the light theme.
+	onmessage = evt => {
+		for (const [key, value] of Object.entries(evt.data)) {
+			document.body.style[key] = value;
+		}
+	}
+</script>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Email Body.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Email Body.yaml
@@ -1,0 +1,22 @@
+title: Email Body
+description: ''
+identifier: cb90d29f-7865-4c82-86af-360d6c22ebe9
+order: 1
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 700
+    safe_rendering: true
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: null
+step_id: null
+block_step_id: null
+present_if_empty: false
+conditions_group:
+    conditions: []
+    logical_operator: and
+integration_name: ''

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Domain.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Domain.html
@@ -1,0 +1,371 @@
+<!-- Custom Widget / Integration Version when it was updated 13.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"/>
+  <link href="https://www.siemplify.co/wp-content/cache/min/1/wp-content/themes/siemplify/assets/fonts/fonts.min.css?ver=1628709624" rel="stylesheet"/>
+  <title>Google Threat Intelligence - Enrich IOCs</title>
+  <style>
+      :root {
+          --widget-bg: #212C44;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: hsl(221, 26%, 46%);
+          --divider-border-color: #576B95;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #3a4a6c;
+          --table-header-color: #4e4f63;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme {
+          --widget-bg: #ffffff !important;
+          --widget-text-color: #0f1029;
+          --scrollbar-bg-color: #d3d8ea;
+          --divider-border-color: #d3d8ea;
+          --sidebar-item-color: #4e4f63;
+          --sidebar-item-active-bg: #e5e8f2;
+          --table-header-color: #6b6d7a;
+          --table-text-color: #0f1029;
+      }
+
+      html.dark-theme {
+          --widget-bg: #232330 !important;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: #303045;
+          --divider-border-color: #303045;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #5f6368;
+          --table-header-color: #b5b5b5;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme body, html.dark-theme body {
+          background-color: var(--widget-bg) !important;
+          color: var(--widget-text-color);
+      }
+
+      ::-webkit-scrollbar {
+          width: 12px;
+          height: 12px;
+      }
+
+      ::-webkit-scrollbar-thumb {
+          border-radius: 10px;
+          border: 3px solid transparent;
+          background: var(--scrollbar-bg-color);
+          background-clip: content-box;
+      }
+
+      ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
+          background-color: transparent;
+      }
+
+      body {
+          float: left;
+          width: 100%;
+          padding: 0;
+          margin: 0;
+          box-sizing: border-box;
+          background-color: var(--widget-bg);
+          color: var(--widget-text-color);
+          overflow-y: hidden;
+      }
+
+      .container {
+          width: 100%;
+          display: flex;
+          float: left;
+      }
+
+      p {
+          margin: 0;
+      }
+
+      .invalid-url {
+          width: 100%;
+          border: 0;
+          height: 200px;
+          padding: 0 20px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+      }
+
+      .nothing-found {
+          width: 100%;
+          float: left;
+          padding: 20px 0;
+          text-align: center;
+          color: var(--widget-text-color);
+          font-family: initial;
+          font-weight: 600;
+      }
+
+      .content-iframe {
+          width: 100%;
+          border: 0;
+          height: 100vh;
+      }
+
+      .entities {
+          height: 100vh;
+          float: left;
+          min-width: 180px;
+          min-height: 275px;
+          overflow-y: auto;
+          border-right: 1px solid var(--divider-border-color);
+      }
+
+      .entities-content {
+          float: left;
+          width: 100%;
+      }
+
+      .widget-text {
+          display: flex;
+          align-items: center;
+      }
+
+      span.container-list-item {
+          font-weight: 400;
+          cursor: pointer;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          padding: 10px;
+          color: var(--sidebar-item-color);
+          display: block;
+      }
+
+      span.container-list-item.active {
+          background: var(--sidebar-item-active-bg);
+          color: var(--widget-text-color);
+          font-weight: 700;
+      }
+
+      .widget-text table tbody tr th {
+          vertical-align: initial !important;
+          text-align: left;
+          text-transform: capitalize;
+          font-weight: 400;
+          font-size: 14px;
+          line-height: 22px;
+          color: var(--table-header-color);
+          width: 130px;
+      }
+
+      .widget-text tr td {
+          font-style: normal;
+          font-weight: 600;
+          font-size: 14px;
+          line-height: 18px;
+          color: var(--table-text-color);
+      }
+
+      #content iframe {
+          display: none;
+      }
+
+      #content iframe:first-child {
+          display: block;
+      }
+  </style>
+</head>
+<body>
+<div class="container" id="container" style="font-family: Open Sans, serif; font-size: 12px;">
+  <div class="entities" id="entitiesList"></div>
+  <div class="entities-content">
+    <div class="widget-text" id="content"></div>
+  </div>
+</div>
+
+<script>
+    const ThemeSettings = {
+        LIGHT_THEME_CLASS: 'light-theme',
+        DARK_THEME_CLASS: 'dark-theme',
+    };
+
+    const LIGHT_THEME_HEX = "#bdc1c6";
+    const DARK_THEME_HEX = "#282837";
+    const GRAY_THEME_HEX = "#2f3d5c";
+
+    function handleThemeUpdate(event) {
+        if (event.source !== window.parent) {
+            return;
+        }
+        const styles = event.data;
+        if (typeof styles !== 'object' || styles === null) return;
+
+        const bg = styles.background || styles.backgroundColor || '';
+        let isLight = false;
+        let isDark = false;
+        let isGray = false;
+        const colorString = bg.toLowerCase();
+
+        if (colorString === LIGHT_THEME_HEX) isLight = true;
+        else if (colorString === DARK_THEME_HEX) isDark = true;
+        else if (colorString === GRAY_THEME_HEX) isGray = true;
+        else {
+            let r, g, b;
+            const rgbMatch = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+            if (rgbMatch) { r = parseInt(rgbMatch[1]); g = parseInt(rgbMatch[2]); b = parseInt(rgbMatch[3]); }
+            else if (bg.startsWith('#')) {
+                const hex = bg.replace('#', '');
+                const fH = hex.length === 3 ? hex.split('').map(c => c + c).join('') : hex;
+                if (fH.length === 6) { r = parseInt(fH.substring(0, 2), 16); g = parseInt(fH.substring(2, 4), 16); b = parseInt(fH.substring(4, 6), 16); }
+            }
+            if (r !== undefined) {
+                const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                if (brightness > 128) isLight = true;
+            }
+        }
+
+        const html = document.documentElement;
+
+        if (isLight) {
+            html.classList.add(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        } else if (isDark) {
+            html.classList.add(ThemeSettings.DARK_THEME_CLASS); html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS);
+        } else {
+            html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        }
+    }
+
+    window.addEventListener('message', handleThemeUpdate);
+    window.onmessage = handleThemeUpdate;
+
+    window.addEventListener("load", init, false);
+    let entitiesData = new Map();
+    const listElement = document.getElementById("entitiesList");
+    const contentElement = document.getElementById("content");
+    const containerElement = document.getElementById("container");
+    let activeItem;
+
+    const actionListData = [{stepInstanceName}.JsonResult];
+
+    function init() {
+        const replacedData = getReplacedData();
+        const dataExists = !isEmptyArray(replacedData);
+        if (dataExists) {
+            setEntitiesData(replacedData);
+            setHtml();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function getReplacedData() {
+        return actionListData.iocs.map(item => [item.identifier, item.details.widget_link, item.details.widget_html]);
+    }
+
+    function setEntitiesData(replacedData) {
+        replacedData.forEach(([entity, widgetUrl, cachedHtmlWidget]) => {
+            entitiesData.set(entity, {widgetUrl, cachedHtmlWidget});
+        });
+    }
+
+    function setHtml() {
+        let validEntitiesData = new Map();
+
+        entitiesData.forEach((value, entity) => {
+            const {widgetUrl, cachedHtmlWidget} = value;
+            if (widgetUrl !== null && widgetUrl !== "" && cachedHtmlWidget !== null && cachedHtmlWidget !== "") {
+                validEntitiesData.set(entity, value);
+            }
+        });
+
+        if (validEntitiesData.size > 0) {
+            entitiesData = validEntitiesData;
+            setListElements();
+            addListenerToListElement();
+            setFirstItemData();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function setListElements() {
+        let listHtml = "";
+        entitiesData.forEach((value, entity) => {
+            listHtml += getListItemHtml(entity);
+        });
+        listElement.innerHTML = listHtml;
+        if (entitiesData.size === 1) {
+            listElement.style.display = 'none';
+        }
+    }
+
+    function addListenerToListElement() {
+        listElement.addEventListener("click", onListClick);
+    }
+
+    function onListClick(event) {
+        const targetElement = event.target;
+        if (targetElement.dataset.hasOwnProperty("id")) {
+            activeItem.classList.remove("active");
+            const entity = event.target.dataset.id;
+            targetElement.classList.add("active");
+            setActiveItem(targetElement);
+            setContent(entity);
+        }
+    }
+
+    function getListItemHtml(entity) {
+        return `<span class="container-list-item" data-id="${entity}">${entity}</span>`;
+    }
+
+    function setContent(entity) {
+        const data = entitiesData.get(entity);
+        const url = data.widgetUrl;
+        let cachedHtmlWidget = data.cachedHtmlWidget;
+
+        // Immediately display the live widget.
+        contentElement.innerHTML = `<iframe class="content-iframe" src="${url}"></iframe>`;
+
+        // In parallel (in the background, without blocking the UI rendering),
+        // verify if the link has expired.
+        fetch(url)
+            .then(async response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                const htmlContent = await response.text();
+                if (htmlContent.includes('rel="error"') && cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                }
+            })
+            .catch(error => {
+                console.error('Error validating iframe content:', error);
+                if (cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                } else {
+                    setNothingFound();
+                }
+            });
+    }
+
+    function setNothingFound() {
+        containerElement.innerHTML = '<p class="nothing-found"> <b> No information found in Google Threat Intelligence.</b></p>';
+    }
+
+    function setFirstItemData() {
+        const firstKey = entitiesData.keys().next().value;
+        setContent(firstKey);
+        setActiveItem(listElement.children[0]);
+    }
+
+    function setActiveItem(item) {
+        activeItem = item;
+        activeItem.classList.add("active");
+    }
+
+    function isEmptyArray(arr) {
+        return !arr || !arr.length || arr.length === 0;
+    }
+
+</script>
+</body>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Domain.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Domain.yaml
@@ -1,0 +1,27 @@
+title: Enrich Domain
+description: This widget returns information about the IOCs that were enriched by
+    GoogleThreatIntelligence.
+identifier: 7bf94a8a-509f-4516-a337-f363d732feba
+order: 8
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 400
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: 6fe5992f-0f57-4c58-a214-3589268cbef6
+step_id: 28dbe9f4-849b-439c-8138-1152cfec3446
+block_step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+present_if_empty: false
+conditions_group:
+    conditions:
+    -   field_name: '[{stepInstanceName}.JsonResult]'
+        value: widget_
+        match_type: contains
+        custom_operator_name: null
+    logical_operator: and
+integration_name: GoogleThreatIntelligence

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Hash.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Hash.html
@@ -1,0 +1,371 @@
+<!-- Custom Widget / Integration Version when it was updated 13.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"/>
+  <link href="https://www.siemplify.co/wp-content/cache/min/1/wp-content/themes/siemplify/assets/fonts/fonts.min.css?ver=1628709624" rel="stylesheet"/>
+  <title>Google Threat Intelligence - Enrich IOCs</title>
+  <style>
+      :root {
+          --widget-bg: #212C44;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: hsl(221, 26%, 46%);
+          --divider-border-color: #576B95;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #3a4a6c;
+          --table-header-color: #4e4f63;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme {
+          --widget-bg: #ffffff !important;
+          --widget-text-color: #0f1029;
+          --scrollbar-bg-color: #d3d8ea;
+          --divider-border-color: #d3d8ea;
+          --sidebar-item-color: #4e4f63;
+          --sidebar-item-active-bg: #e5e8f2;
+          --table-header-color: #6b6d7a;
+          --table-text-color: #0f1029;
+      }
+
+      html.dark-theme {
+          --widget-bg: #232330 !important;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: #303045;
+          --divider-border-color: #303045;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #5f6368;
+          --table-header-color: #b5b5b5;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme body, html.dark-theme body {
+          background-color: var(--widget-bg) !important;
+          color: var(--widget-text-color);
+      }
+
+      ::-webkit-scrollbar {
+          width: 12px;
+          height: 12px;
+      }
+
+      ::-webkit-scrollbar-thumb {
+          border-radius: 10px;
+          border: 3px solid transparent;
+          background: var(--scrollbar-bg-color);
+          background-clip: content-box;
+      }
+
+      ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
+          background-color: transparent;
+      }
+
+      body {
+          float: left;
+          width: 100%;
+          padding: 0;
+          margin: 0;
+          box-sizing: border-box;
+          background-color: var(--widget-bg);
+          color: var(--widget-text-color);
+          overflow-y: hidden;
+      }
+
+      .container {
+          width: 100%;
+          display: flex;
+          float: left;
+      }
+
+      p {
+          margin: 0;
+      }
+
+      .invalid-url {
+          width: 100%;
+          border: 0;
+          height: 200px;
+          padding: 0 20px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+      }
+
+      .nothing-found {
+          width: 100%;
+          float: left;
+          padding: 20px 0;
+          text-align: center;
+          color: var(--widget-text-color);
+          font-family: initial;
+          font-weight: 600;
+      }
+
+      .content-iframe {
+          width: 100%;
+          border: 0;
+          height: 100vh;
+      }
+
+      .entities {
+          height: 100vh;
+          float: left;
+          min-width: 180px;
+          min-height: 275px;
+          overflow-y: auto;
+          border-right: 1px solid var(--divider-border-color);
+      }
+
+      .entities-content {
+          float: left;
+          width: 100%;
+      }
+
+      .widget-text {
+          display: flex;
+          align-items: center;
+      }
+
+      span.container-list-item {
+          font-weight: 400;
+          cursor: pointer;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          padding: 10px;
+          color: var(--sidebar-item-color);
+          display: block;
+      }
+
+      span.container-list-item.active {
+          background: var(--sidebar-item-active-bg);
+          color: var(--widget-text-color);
+          font-weight: 700;
+      }
+
+      .widget-text table tbody tr th {
+          vertical-align: initial !important;
+          text-align: left;
+          text-transform: capitalize;
+          font-weight: 400;
+          font-size: 14px;
+          line-height: 22px;
+          color: var(--table-header-color);
+          width: 130px;
+      }
+
+      .widget-text tr td {
+          font-style: normal;
+          font-weight: 600;
+          font-size: 14px;
+          line-height: 18px;
+          color: var(--table-text-color);
+      }
+
+      #content iframe {
+          display: none;
+      }
+
+      #content iframe:first-child {
+          display: block;
+      }
+  </style>
+</head>
+<body>
+<div class="container" id="container" style="font-family: Open Sans, serif; font-size: 12px;">
+  <div class="entities" id="entitiesList"></div>
+  <div class="entities-content">
+    <div class="widget-text" id="content"></div>
+  </div>
+</div>
+
+<script>
+    const ThemeSettings = {
+        LIGHT_THEME_CLASS: 'light-theme',
+        DARK_THEME_CLASS: 'dark-theme',
+    };
+
+    const LIGHT_THEME_HEX = "#bdc1c6";
+    const DARK_THEME_HEX = "#282837";
+    const GRAY_THEME_HEX = "#2f3d5c";
+
+    function handleThemeUpdate(event) {
+        if (event.source !== window.parent) {
+            return;
+        }
+        const styles = event.data;
+        if (typeof styles !== 'object' || styles === null) return;
+
+        const bg = styles.background || styles.backgroundColor || '';
+        let isLight = false;
+        let isDark = false;
+        let isGray = false;
+        const colorString = bg.toLowerCase();
+
+        if (colorString === LIGHT_THEME_HEX) isLight = true;
+        else if (colorString === DARK_THEME_HEX) isDark = true;
+        else if (colorString === GRAY_THEME_HEX) isGray = true;
+        else {
+            let r, g, b;
+            const rgbMatch = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+            if (rgbMatch) { r = parseInt(rgbMatch[1]); g = parseInt(rgbMatch[2]); b = parseInt(rgbMatch[3]); }
+            else if (bg.startsWith('#')) {
+                const hex = bg.replace('#', '');
+                const fH = hex.length === 3 ? hex.split('').map(c => c + c).join('') : hex;
+                if (fH.length === 6) { r = parseInt(fH.substring(0, 2), 16); g = parseInt(fH.substring(2, 4), 16); b = parseInt(fH.substring(4, 6), 16); }
+            }
+            if (r !== undefined) {
+                const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                if (brightness > 128) isLight = true;
+            }
+        }
+
+        const html = document.documentElement;
+
+        if (isLight) {
+            html.classList.add(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        } else if (isDark) {
+            html.classList.add(ThemeSettings.DARK_THEME_CLASS); html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS);
+        } else {
+            html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        }
+    }
+
+    window.addEventListener('message', handleThemeUpdate);
+    window.onmessage = handleThemeUpdate;
+
+    window.addEventListener("load", init, false);
+    let entitiesData = new Map();
+    const listElement = document.getElementById("entitiesList");
+    const contentElement = document.getElementById("content");
+    const containerElement = document.getElementById("container");
+    let activeItem;
+
+    const actionListData = [{stepInstanceName}.JsonResult];
+
+    function init() {
+        const replacedData = getReplacedData();
+        const dataExists = !isEmptyArray(replacedData);
+        if (dataExists) {
+            setEntitiesData(replacedData);
+            setHtml();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function getReplacedData() {
+        return actionListData.iocs.map(item => [item.identifier, item.details.widget_link, item.details.widget_html]);
+    }
+
+    function setEntitiesData(replacedData) {
+        replacedData.forEach(([entity, widgetUrl, cachedHtmlWidget]) => {
+            entitiesData.set(entity, {widgetUrl, cachedHtmlWidget});
+        });
+    }
+
+    function setHtml() {
+        let validEntitiesData = new Map();
+
+        entitiesData.forEach((value, entity) => {
+            const {widgetUrl, cachedHtmlWidget} = value;
+            if (widgetUrl !== null && widgetUrl !== "" && cachedHtmlWidget !== null && cachedHtmlWidget !== "") {
+                validEntitiesData.set(entity, value);
+            }
+        });
+
+        if (validEntitiesData.size > 0) {
+            entitiesData = validEntitiesData;
+            setListElements();
+            addListenerToListElement();
+            setFirstItemData();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function setListElements() {
+        let listHtml = "";
+        entitiesData.forEach((value, entity) => {
+            listHtml += getListItemHtml(entity);
+        });
+        listElement.innerHTML = listHtml;
+        if (entitiesData.size === 1) {
+            listElement.style.display = 'none';
+        }
+    }
+
+    function addListenerToListElement() {
+        listElement.addEventListener("click", onListClick);
+    }
+
+    function onListClick(event) {
+        const targetElement = event.target;
+        if (targetElement.dataset.hasOwnProperty("id")) {
+            activeItem.classList.remove("active");
+            const entity = event.target.dataset.id;
+            targetElement.classList.add("active");
+            setActiveItem(targetElement);
+            setContent(entity);
+        }
+    }
+
+    function getListItemHtml(entity) {
+        return `<span class="container-list-item" data-id="${entity}">${entity}</span>`;
+    }
+
+    function setContent(entity) {
+        const data = entitiesData.get(entity);
+        const url = data.widgetUrl;
+        let cachedHtmlWidget = data.cachedHtmlWidget;
+
+        // Immediately display the live widget.
+        contentElement.innerHTML = `<iframe class="content-iframe" src="${url}"></iframe>`;
+
+        // In parallel (in the background, without blocking the UI rendering),
+        // verify if the link has expired.
+        fetch(url)
+            .then(async response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                const htmlContent = await response.text();
+                if (htmlContent.includes('rel="error"') && cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                }
+            })
+            .catch(error => {
+                console.error('Error validating iframe content:', error);
+                if (cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                } else {
+                    setNothingFound();
+                }
+            });
+    }
+
+    function setNothingFound() {
+        containerElement.innerHTML = '<p class="nothing-found"> <b> No information found in Google Threat Intelligence.</b></p>';
+    }
+
+    function setFirstItemData() {
+        const firstKey = entitiesData.keys().next().value;
+        setContent(firstKey);
+        setActiveItem(listElement.children[0]);
+    }
+
+    function setActiveItem(item) {
+        activeItem = item;
+        activeItem.classList.add("active");
+    }
+
+    function isEmptyArray(arr) {
+        return !arr || !arr.length || arr.length === 0;
+    }
+
+</script>
+</body>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Hash.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich Hash.yaml
@@ -1,0 +1,27 @@
+title: Enrich Hash
+description: This widget returns information about the IOCs that were enriched by
+    GoogleThreatIntelligence.
+identifier: 4be297fb-fe1b-443b-83e8-9868f8a8e5cc
+order: 7
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 400
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: 6fe5992f-0f57-4c58-a214-3589268cbef6
+step_id: 97c81055-947c-4280-b420-93d93b0a5f09
+block_step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+present_if_empty: false
+conditions_group:
+    conditions:
+    -   field_name: '[{stepInstanceName}.JsonResult]'
+        value: widget_
+        match_type: contains
+        custom_operator_name: null
+    logical_operator: and
+integration_name: GoogleThreatIntelligence

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich IP Address.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich IP Address.html
@@ -1,0 +1,371 @@
+<!-- Custom Widget / Integration Version when it was updated 13.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"/>
+  <link href="https://www.siemplify.co/wp-content/cache/min/1/wp-content/themes/siemplify/assets/fonts/fonts.min.css?ver=1628709624" rel="stylesheet"/>
+  <title>Google Threat Intelligence - Enrich IOCs</title>
+  <style>
+      :root {
+          --widget-bg: #212C44;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: hsl(221, 26%, 46%);
+          --divider-border-color: #576B95;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #3a4a6c;
+          --table-header-color: #4e4f63;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme {
+          --widget-bg: #ffffff !important;
+          --widget-text-color: #0f1029;
+          --scrollbar-bg-color: #d3d8ea;
+          --divider-border-color: #d3d8ea;
+          --sidebar-item-color: #4e4f63;
+          --sidebar-item-active-bg: #e5e8f2;
+          --table-header-color: #6b6d7a;
+          --table-text-color: #0f1029;
+      }
+
+      html.dark-theme {
+          --widget-bg: #232330 !important;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: #303045;
+          --divider-border-color: #303045;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #5f6368;
+          --table-header-color: #b5b5b5;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme body, html.dark-theme body {
+          background-color: var(--widget-bg) !important;
+          color: var(--widget-text-color);
+      }
+
+      ::-webkit-scrollbar {
+          width: 12px;
+          height: 12px;
+      }
+
+      ::-webkit-scrollbar-thumb {
+          border-radius: 10px;
+          border: 3px solid transparent;
+          background: var(--scrollbar-bg-color);
+          background-clip: content-box;
+      }
+
+      ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
+          background-color: transparent;
+      }
+
+      body {
+          float: left;
+          width: 100%;
+          padding: 0;
+          margin: 0;
+          box-sizing: border-box;
+          background-color: var(--widget-bg);
+          color: var(--widget-text-color);
+          overflow-y: hidden;
+      }
+
+      .container {
+          width: 100%;
+          display: flex;
+          float: left;
+      }
+
+      p {
+          margin: 0;
+      }
+
+      .invalid-url {
+          width: 100%;
+          border: 0;
+          height: 200px;
+          padding: 0 20px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+      }
+
+      .nothing-found {
+          width: 100%;
+          float: left;
+          padding: 20px 0;
+          text-align: center;
+          color: var(--widget-text-color);
+          font-family: initial;
+          font-weight: 600;
+      }
+
+      .content-iframe {
+          width: 100%;
+          border: 0;
+          height: 100vh;
+      }
+
+      .entities {
+          height: 100vh;
+          float: left;
+          min-width: 180px;
+          min-height: 275px;
+          overflow-y: auto;
+          border-right: 1px solid var(--divider-border-color);
+      }
+
+      .entities-content {
+          float: left;
+          width: 100%;
+      }
+
+      .widget-text {
+          display: flex;
+          align-items: center;
+      }
+
+      span.container-list-item {
+          font-weight: 400;
+          cursor: pointer;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          padding: 10px;
+          color: var(--sidebar-item-color);
+          display: block;
+      }
+
+      span.container-list-item.active {
+          background: var(--sidebar-item-active-bg);
+          color: var(--widget-text-color);
+          font-weight: 700;
+      }
+
+      .widget-text table tbody tr th {
+          vertical-align: initial !important;
+          text-align: left;
+          text-transform: capitalize;
+          font-weight: 400;
+          font-size: 14px;
+          line-height: 22px;
+          color: var(--table-header-color);
+          width: 130px;
+      }
+
+      .widget-text tr td {
+          font-style: normal;
+          font-weight: 600;
+          font-size: 14px;
+          line-height: 18px;
+          color: var(--table-text-color);
+      }
+
+      #content iframe {
+          display: none;
+      }
+
+      #content iframe:first-child {
+          display: block;
+      }
+  </style>
+</head>
+<body>
+<div class="container" id="container" style="font-family: Open Sans, serif; font-size: 12px;">
+  <div class="entities" id="entitiesList"></div>
+  <div class="entities-content">
+    <div class="widget-text" id="content"></div>
+  </div>
+</div>
+
+<script>
+    const ThemeSettings = {
+        LIGHT_THEME_CLASS: 'light-theme',
+        DARK_THEME_CLASS: 'dark-theme',
+    };
+
+    const LIGHT_THEME_HEX = "#bdc1c6";
+    const DARK_THEME_HEX = "#282837";
+    const GRAY_THEME_HEX = "#2f3d5c";
+
+    function handleThemeUpdate(event) {
+        if (event.source !== window.parent) {
+            return;
+        }
+        const styles = event.data;
+        if (typeof styles !== 'object' || styles === null) return;
+
+        const bg = styles.background || styles.backgroundColor || '';
+        let isLight = false;
+        let isDark = false;
+        let isGray = false;
+        const colorString = bg.toLowerCase();
+
+        if (colorString === LIGHT_THEME_HEX) isLight = true;
+        else if (colorString === DARK_THEME_HEX) isDark = true;
+        else if (colorString === GRAY_THEME_HEX) isGray = true;
+        else {
+            let r, g, b;
+            const rgbMatch = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+            if (rgbMatch) { r = parseInt(rgbMatch[1]); g = parseInt(rgbMatch[2]); b = parseInt(rgbMatch[3]); }
+            else if (bg.startsWith('#')) {
+                const hex = bg.replace('#', '');
+                const fH = hex.length === 3 ? hex.split('').map(c => c + c).join('') : hex;
+                if (fH.length === 6) { r = parseInt(fH.substring(0, 2), 16); g = parseInt(fH.substring(2, 4), 16); b = parseInt(fH.substring(4, 6), 16); }
+            }
+            if (r !== undefined) {
+                const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                if (brightness > 128) isLight = true;
+            }
+        }
+
+        const html = document.documentElement;
+
+        if (isLight) {
+            html.classList.add(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        } else if (isDark) {
+            html.classList.add(ThemeSettings.DARK_THEME_CLASS); html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS);
+        } else {
+            html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        }
+    }
+
+    window.addEventListener('message', handleThemeUpdate);
+    window.onmessage = handleThemeUpdate;
+
+    window.addEventListener("load", init, false);
+    let entitiesData = new Map();
+    const listElement = document.getElementById("entitiesList");
+    const contentElement = document.getElementById("content");
+    const containerElement = document.getElementById("container");
+    let activeItem;
+
+    const actionListData = [{stepInstanceName}.JsonResult];
+
+    function init() {
+        const replacedData = getReplacedData();
+        const dataExists = !isEmptyArray(replacedData);
+        if (dataExists) {
+            setEntitiesData(replacedData);
+            setHtml();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function getReplacedData() {
+        return actionListData.iocs.map(item => [item.identifier, item.details.widget_link, item.details.widget_html]);
+    }
+
+    function setEntitiesData(replacedData) {
+        replacedData.forEach(([entity, widgetUrl, cachedHtmlWidget]) => {
+            entitiesData.set(entity, {widgetUrl, cachedHtmlWidget});
+        });
+    }
+
+    function setHtml() {
+        let validEntitiesData = new Map();
+
+        entitiesData.forEach((value, entity) => {
+            const {widgetUrl, cachedHtmlWidget} = value;
+            if (widgetUrl !== null && widgetUrl !== "" && cachedHtmlWidget !== null && cachedHtmlWidget !== "") {
+                validEntitiesData.set(entity, value);
+            }
+        });
+
+        if (validEntitiesData.size > 0) {
+            entitiesData = validEntitiesData;
+            setListElements();
+            addListenerToListElement();
+            setFirstItemData();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function setListElements() {
+        let listHtml = "";
+        entitiesData.forEach((value, entity) => {
+            listHtml += getListItemHtml(entity);
+        });
+        listElement.innerHTML = listHtml;
+        if (entitiesData.size === 1) {
+            listElement.style.display = 'none';
+        }
+    }
+
+    function addListenerToListElement() {
+        listElement.addEventListener("click", onListClick);
+    }
+
+    function onListClick(event) {
+        const targetElement = event.target;
+        if (targetElement.dataset.hasOwnProperty("id")) {
+            activeItem.classList.remove("active");
+            const entity = event.target.dataset.id;
+            targetElement.classList.add("active");
+            setActiveItem(targetElement);
+            setContent(entity);
+        }
+    }
+
+    function getListItemHtml(entity) {
+        return `<span class="container-list-item" data-id="${entity}">${entity}</span>`;
+    }
+
+    function setContent(entity) {
+        const data = entitiesData.get(entity);
+        const url = data.widgetUrl;
+        let cachedHtmlWidget = data.cachedHtmlWidget;
+
+        // Immediately display the live widget.
+        contentElement.innerHTML = `<iframe class="content-iframe" src="${url}"></iframe>`;
+
+        // In parallel (in the background, without blocking the UI rendering),
+        // verify if the link has expired.
+        fetch(url)
+            .then(async response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                const htmlContent = await response.text();
+                if (htmlContent.includes('rel="error"') && cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                }
+            })
+            .catch(error => {
+                console.error('Error validating iframe content:', error);
+                if (cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                } else {
+                    setNothingFound();
+                }
+            });
+    }
+
+    function setNothingFound() {
+        containerElement.innerHTML = '<p class="nothing-found"> <b> No information found in Google Threat Intelligence.</b></p>';
+    }
+
+    function setFirstItemData() {
+        const firstKey = entitiesData.keys().next().value;
+        setContent(firstKey);
+        setActiveItem(listElement.children[0]);
+    }
+
+    function setActiveItem(item) {
+        activeItem = item;
+        activeItem.classList.add("active");
+    }
+
+    function isEmptyArray(arr) {
+        return !arr || !arr.length || arr.length === 0;
+    }
+
+</script>
+</body>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich IP Address.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich IP Address.yaml
@@ -1,0 +1,27 @@
+title: Enrich IP Address
+description: This widget returns information about the IOCs that were enriched by
+    GoogleThreatIntelligence.
+identifier: ccfdde01-68ef-4dcf-a8f7-674408778544
+order: 5
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 400
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: 6fe5992f-0f57-4c58-a214-3589268cbef6
+step_id: b357190a-c9d2-4078-a4ec-d9d8dc1327a0
+block_step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+present_if_empty: false
+conditions_group:
+    conditions:
+    -   field_name: '[{stepInstanceName}.JsonResult]'
+        value: widget_
+        match_type: contains
+        custom_operator_name: null
+    logical_operator: and
+integration_name: GoogleThreatIntelligence

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich URL.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich URL.html
@@ -1,0 +1,371 @@
+<!-- Custom Widget / Integration Version when it was updated 13.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet"/>
+  <link href="https://www.siemplify.co/wp-content/cache/min/1/wp-content/themes/siemplify/assets/fonts/fonts.min.css?ver=1628709624" rel="stylesheet"/>
+  <title>Google Threat Intelligence - Enrich IOCs</title>
+  <style>
+      :root {
+          --widget-bg: #212C44;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: hsl(221, 26%, 46%);
+          --divider-border-color: #576B95;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #3a4a6c;
+          --table-header-color: #4e4f63;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme {
+          --widget-bg: #ffffff !important;
+          --widget-text-color: #0f1029;
+          --scrollbar-bg-color: #d3d8ea;
+          --divider-border-color: #d3d8ea;
+          --sidebar-item-color: #4e4f63;
+          --sidebar-item-active-bg: #e5e8f2;
+          --table-header-color: #6b6d7a;
+          --table-text-color: #0f1029;
+      }
+
+      html.dark-theme {
+          --widget-bg: #232330 !important;
+          --widget-text-color: #ffffff;
+          --scrollbar-bg-color: #303045;
+          --divider-border-color: #303045;
+          --sidebar-item-color: #c3d2e8;
+          --sidebar-item-active-bg: #5f6368;
+          --table-header-color: #b5b5b5;
+          --table-text-color: #ffffff;
+      }
+
+      html.light-theme body, html.dark-theme body {
+          background-color: var(--widget-bg) !important;
+          color: var(--widget-text-color);
+      }
+
+      ::-webkit-scrollbar {
+          width: 12px;
+          height: 12px;
+      }
+
+      ::-webkit-scrollbar-thumb {
+          border-radius: 10px;
+          border: 3px solid transparent;
+          background: var(--scrollbar-bg-color);
+          background-clip: content-box;
+      }
+
+      ::-webkit-scrollbar-track, ::-webkit-scrollbar-corner {
+          background-color: transparent;
+      }
+
+      body {
+          float: left;
+          width: 100%;
+          padding: 0;
+          margin: 0;
+          box-sizing: border-box;
+          background-color: var(--widget-bg);
+          color: var(--widget-text-color);
+          overflow-y: hidden;
+      }
+
+      .container {
+          width: 100%;
+          display: flex;
+          float: left;
+      }
+
+      p {
+          margin: 0;
+      }
+
+      .invalid-url {
+          width: 100%;
+          border: 0;
+          height: 200px;
+          padding: 0 20px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+      }
+
+      .nothing-found {
+          width: 100%;
+          float: left;
+          padding: 20px 0;
+          text-align: center;
+          color: var(--widget-text-color);
+          font-family: initial;
+          font-weight: 600;
+      }
+
+      .content-iframe {
+          width: 100%;
+          border: 0;
+          height: 100vh;
+      }
+
+      .entities {
+          height: 100vh;
+          float: left;
+          min-width: 180px;
+          min-height: 275px;
+          overflow-y: auto;
+          border-right: 1px solid var(--divider-border-color);
+      }
+
+      .entities-content {
+          float: left;
+          width: 100%;
+      }
+
+      .widget-text {
+          display: flex;
+          align-items: center;
+      }
+
+      span.container-list-item {
+          font-weight: 400;
+          cursor: pointer;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          padding: 10px;
+          color: var(--sidebar-item-color);
+          display: block;
+      }
+
+      span.container-list-item.active {
+          background: var(--sidebar-item-active-bg);
+          color: var(--widget-text-color);
+          font-weight: 700;
+      }
+
+      .widget-text table tbody tr th {
+          vertical-align: initial !important;
+          text-align: left;
+          text-transform: capitalize;
+          font-weight: 400;
+          font-size: 14px;
+          line-height: 22px;
+          color: var(--table-header-color);
+          width: 130px;
+      }
+
+      .widget-text tr td {
+          font-style: normal;
+          font-weight: 600;
+          font-size: 14px;
+          line-height: 18px;
+          color: var(--table-text-color);
+      }
+
+      #content iframe {
+          display: none;
+      }
+
+      #content iframe:first-child {
+          display: block;
+      }
+  </style>
+</head>
+<body>
+<div class="container" id="container" style="font-family: Open Sans, serif; font-size: 12px;">
+  <div class="entities" id="entitiesList"></div>
+  <div class="entities-content">
+    <div class="widget-text" id="content"></div>
+  </div>
+</div>
+
+<script>
+    const ThemeSettings = {
+        LIGHT_THEME_CLASS: 'light-theme',
+        DARK_THEME_CLASS: 'dark-theme',
+    };
+
+    const LIGHT_THEME_HEX = "#bdc1c6";
+    const DARK_THEME_HEX = "#282837";
+    const GRAY_THEME_HEX = "#2f3d5c";
+
+    function handleThemeUpdate(event) {
+        if (event.source !== window.parent) {
+            return;
+        }
+        const styles = event.data;
+        if (typeof styles !== 'object' || styles === null) return;
+
+        const bg = styles.background || styles.backgroundColor || '';
+        let isLight = false;
+        let isDark = false;
+        let isGray = false;
+        const colorString = bg.toLowerCase();
+
+        if (colorString === LIGHT_THEME_HEX) isLight = true;
+        else if (colorString === DARK_THEME_HEX) isDark = true;
+        else if (colorString === GRAY_THEME_HEX) isGray = true;
+        else {
+            let r, g, b;
+            const rgbMatch = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+            if (rgbMatch) { r = parseInt(rgbMatch[1]); g = parseInt(rgbMatch[2]); b = parseInt(rgbMatch[3]); }
+            else if (bg.startsWith('#')) {
+                const hex = bg.replace('#', '');
+                const fH = hex.length === 3 ? hex.split('').map(c => c + c).join('') : hex;
+                if (fH.length === 6) { r = parseInt(fH.substring(0, 2), 16); g = parseInt(fH.substring(2, 4), 16); b = parseInt(fH.substring(4, 6), 16); }
+            }
+            if (r !== undefined) {
+                const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                if (brightness > 128) isLight = true;
+            }
+        }
+
+        const html = document.documentElement;
+
+        if (isLight) {
+            html.classList.add(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        } else if (isDark) {
+            html.classList.add(ThemeSettings.DARK_THEME_CLASS); html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS);
+        } else {
+            html.classList.remove(ThemeSettings.LIGHT_THEME_CLASS); html.classList.remove(ThemeSettings.DARK_THEME_CLASS);
+        }
+    }
+
+    window.addEventListener('message', handleThemeUpdate);
+    window.onmessage = handleThemeUpdate;
+
+    window.addEventListener("load", init, false);
+    let entitiesData = new Map();
+    const listElement = document.getElementById("entitiesList");
+    const contentElement = document.getElementById("content");
+    const containerElement = document.getElementById("container");
+    let activeItem;
+
+    const actionListData = [{stepInstanceName}.JsonResult];
+
+    function init() {
+        const replacedData = getReplacedData();
+        const dataExists = !isEmptyArray(replacedData);
+        if (dataExists) {
+            setEntitiesData(replacedData);
+            setHtml();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function getReplacedData() {
+        return actionListData.iocs.map(item => [item.identifier, item.details.widget_link, item.details.widget_html]);
+    }
+
+    function setEntitiesData(replacedData) {
+        replacedData.forEach(([entity, widgetUrl, cachedHtmlWidget]) => {
+            entitiesData.set(entity, {widgetUrl, cachedHtmlWidget});
+        });
+    }
+
+    function setHtml() {
+        let validEntitiesData = new Map();
+
+        entitiesData.forEach((value, entity) => {
+            const {widgetUrl, cachedHtmlWidget} = value;
+            if (widgetUrl !== null && widgetUrl !== "" && cachedHtmlWidget !== null && cachedHtmlWidget !== "") {
+                validEntitiesData.set(entity, value);
+            }
+        });
+
+        if (validEntitiesData.size > 0) {
+            entitiesData = validEntitiesData;
+            setListElements();
+            addListenerToListElement();
+            setFirstItemData();
+        } else {
+            setNothingFound();
+        }
+    }
+
+    function setListElements() {
+        let listHtml = "";
+        entitiesData.forEach((value, entity) => {
+            listHtml += getListItemHtml(entity);
+        });
+        listElement.innerHTML = listHtml;
+        if (entitiesData.size === 1) {
+            listElement.style.display = 'none';
+        }
+    }
+
+    function addListenerToListElement() {
+        listElement.addEventListener("click", onListClick);
+    }
+
+    function onListClick(event) {
+        const targetElement = event.target;
+        if (targetElement.dataset.hasOwnProperty("id")) {
+            activeItem.classList.remove("active");
+            const entity = event.target.dataset.id;
+            targetElement.classList.add("active");
+            setActiveItem(targetElement);
+            setContent(entity);
+        }
+    }
+
+    function getListItemHtml(entity) {
+        return `<span class="container-list-item" data-id="${entity}">${entity}</span>`;
+    }
+
+    function setContent(entity) {
+        const data = entitiesData.get(entity);
+        const url = data.widgetUrl;
+        let cachedHtmlWidget = data.cachedHtmlWidget;
+
+        // Immediately display the live widget.
+        contentElement.innerHTML = `<iframe class="content-iframe" src="${url}"></iframe>`;
+
+        // In parallel (in the background, without blocking the UI rendering),
+        // verify if the link has expired.
+        fetch(url)
+            .then(async response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                const htmlContent = await response.text();
+                if (htmlContent.includes('rel="error"') && cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                }
+            })
+            .catch(error => {
+                console.error('Error validating iframe content:', error);
+                if (cachedHtmlWidget) {
+                    contentElement.innerHTML = `<iframe class="content-iframe" srcdoc="${cachedHtmlWidget}"></iframe>`;
+                } else {
+                    setNothingFound();
+                }
+            });
+    }
+
+    function setNothingFound() {
+        containerElement.innerHTML = '<p class="nothing-found"> <b> No information found in Google Threat Intelligence.</b></p>';
+    }
+
+    function setFirstItemData() {
+        const firstKey = entitiesData.keys().next().value;
+        setContent(firstKey);
+        setActiveItem(listElement.children[0]);
+    }
+
+    function setActiveItem(item) {
+        activeItem = item;
+        activeItem.classList.add("active");
+    }
+
+    function isEmptyArray(arr) {
+        return !arr || !arr.length || arr.length === 0;
+    }
+
+</script>
+</body>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich URL.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Enrich URL.yaml
@@ -1,0 +1,27 @@
+title: Enrich URL
+description: This widget returns information about the IOCs that were enriched by
+    GoogleThreatIntelligence.
+identifier: 897b75bd-00e5-43bc-b9fd-728b301903d1
+order: 6
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 400
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: 6fe5992f-0f57-4c58-a214-3589268cbef6
+step_id: 3142a80a-4290-4245-b0f7-42a539fced40
+block_step_id: c7dbebd3-6c21-46bb-997f-5ab88e6519a6
+present_if_empty: false
+conditions_group:
+    conditions:
+    -   field_name: '[{stepInstanceName}.JsonResult]'
+        value: widget_
+        match_type: contains
+        custom_operator_name: null
+    logical_operator: and
+integration_name: GoogleThreatIntelligence

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Phishing Investigation Result.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Phishing Investigation Result.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<style>
+	body {
+		background-color: #EDEFF6;
+		color: #4E4F63;
+		font-family: Source Sans;
+	}
+</style>
+</head>
+
+<body>
+[Alert.phishing_investigation_result]
+</body>
+<script>
+	//This script enables the widget theme to reflect the user's choice in the platform.
+	//Removing this script will result in your HTML widget permanently displayed in the light theme.
+	onmessage = evt => {
+		for (const [key, value] of Object.entries(evt.data)) {
+			document.body.style[key] = value;
+		}
+	}
+</script>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Phishing Investigation Result.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Phishing Investigation Result.yaml
@@ -1,0 +1,22 @@
+title: Phishing Investigation Result
+description: ''
+identifier: 8924345a-f6d1-4d42-8aff-96ff429890f0
+order: 2
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 700
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: null
+step_id: null
+block_step_id: null
+present_if_empty: false
+conditions_group:
+    conditions: []
+    logical_operator: and
+integration_name: ''

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Search Outbound Connection.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Search Outbound Connection.html
@@ -1,0 +1,908 @@
+<!-- Custom Widget / Integration Version when it was updated 49.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link
+    href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i"
+    rel="stylesheet">
+  <link
+    href='https://fonts.googleapis.com/css?family=Source Sans Pro'
+    rel='stylesheet'>
+  <title>Execute UDM Query</title>
+  <style>
+    /* Root Variables */
+    :root {
+      --widget-bg: rgb(33, 44, 68);
+      --widget-font-family: 'Source Sans Pro', sans-serif;
+      --widget-text-color: rgb(255, 255, 255);
+      --widget-scrollbar-size: 12px;
+      --widget-row-highlight-bg: rgb(47 61 91);
+      /*Logo styles*/
+      --logo-size: 48px;
+      --logo-color: rgb(255, 255, 255);
+      /*Logo styles*/
+      /*Table styles*/
+      --table-color-even-row: rgb(26 32 50);
+      --table-title-size: 600 14px/18px var(--widget-font-family);
+      --table-th-size: 600 14px/18px var(--widget-font-family);
+      --table-td-size: 400 14px/18px var(--widget-font-family);
+    }
+
+    /*Normalize CSS */
+    * {
+      margin: 0;
+      padding: 0;
+      outline: none;
+      box-sizing: border-box;
+    }
+
+    *:hover, *:focus, *:active {
+      outline: none;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border-spacing: 0;
+    }
+
+    ol, ul {
+      list-style: none;
+    }
+
+    button,
+    input,
+    textarea {
+      font-family: inherit;
+      background: transparent;
+      border: 0;
+      color: inherit;
+      text-align: left;
+    }
+
+    button, a[href] {
+      cursor: pointer;
+    }
+
+    /*Normalize CSS */
+    /* Custom Scrollbar */
+    ::-webkit-scrollbar {
+      width: 18px;
+      height: 18px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: rgba(137, 151, 180, 1);
+      border: 6px solid var(--widget-bg);
+      border-radius: 63px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: transparent;
+      border: 4px solid transparent;
+      border-radius: 44px;
+    }
+
+    ::-webkit-scrollbar-corner {
+      background-color: transparent;
+      border-color: transparent;
+    }
+
+    body {
+      font-family: var(--widget-font-family), serif;
+      color: var(--widget-text-color);
+      background-color: var(--widget-bg);
+      overflow: hidden;
+    }
+
+    /*Global styles*/
+    .text-ellipsis {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .tooltip {
+      max-width: 100%;
+      position: absolute;
+      padding: 8px 16px 8px 16px;
+      border-radius: 4px;
+      background-color: rgb(204 204 218);
+      color: rgb(22, 22, 37);
+      font: 400 14px/18px var(--widget-font-family);
+      z-index: 99;
+      word-wrap: break-word;
+    }
+
+    .tooltip-triangle {
+      position: absolute;
+      top: 100%;
+      border-top: solid 8px rgb(195, 210, 232);
+      border-left: solid 8px transparent;
+      border-right: solid 8px transparent;
+    }
+
+    .input {
+      border: 1px solid #6275A3;
+      border-radius: 4px;
+      padding: 4px 8px;
+      background-color: transparent;
+      font-size: 14px;
+      color: var(--widget-text-color);
+    }
+
+    .input::placeholder {
+      color: var(--widget-text-color);
+    }
+
+    input[type="checkbox"] {
+      max-width: 13px;
+      max-height: 13px;
+    }
+
+    /*Global styles*/
+    /*Table*/
+    .table-wrapper {
+      margin-top: 8px;
+      position: relative;
+    }
+
+    .table-search {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .table-container {
+      overflow: auto;
+      max-height: calc(100vh - 102px);
+    }
+
+    .table {
+      table-layout: fixed;
+    }
+
+    .table thead {
+      position: sticky;
+      top: 0;
+      z-index: 9;
+    }
+
+    .table th {
+      width: 250px;
+      background-color: var(--widget-row-highlight-bg);
+      color: var(--widget-text-color);
+      font: var(--table-th-size);
+      padding: 6px 12px;
+      text-transform: uppercase;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    .table tr:nth-child(even) {
+      background-color: var(--table-color-even-row);
+    }
+
+    .table-resizable-line {
+      position: absolute;
+      inset: 3px 6px 3px auto;
+      width: 2px;
+      cursor: col-resize;
+      user-select: none;
+      background-color: rgb(98, 117, 163);
+      z-index: 9;
+    }
+
+    .table-resizable-line::before, .table-resizable-line::after {
+      content: '';
+      position: absolute;
+      inset: 0 auto;
+      width: 6px;
+    }
+
+    .table-resizable-line::before {
+      left: -6px;
+    }
+
+    .table-resizable-line::after {
+      right: -6px;
+    }
+
+    .table td {
+      padding: 8px 12px;
+      font: var(--table-td-size);
+      color: var(--widget-text-color);
+      vertical-align: top;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .logo {
+      min-width: var(--logo-size);
+      min-height: var(--logo-size);
+      max-width: var(--logo-size);
+      max-height: var(--logo-size);
+      color: var(--logo-color);
+    }
+
+    .counter {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin: 0 auto;
+    }
+
+    .counter-number {
+      font: 600 20px/24px var(--widget-font-family);
+      text-align: center;
+    }
+
+    .counter-title {
+      font: 600 16px/22px var(--widget-font-family);
+      text-transform: uppercase;
+      text-align: center;
+    }
+
+    .table-events {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      justify-content: flex-end;
+      margin-bottom: 12px;
+      padding: 0 6px;
+    }
+
+    .table-udm-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding-left: 4px;
+      cursor: pointer;
+    }
+
+    .table-udm-label-text {
+      font-size: 14px;
+    }
+
+    /* Dropdown */
+    .dropdown-button {
+      width: 24px;
+      height: 24px;
+      cursor: pointer;
+    }
+
+    .dropdown-container {
+      width: 24px;
+      height: 24px;
+      margin-right: auto;
+      position: relative;
+    }
+
+    .dropdown {
+      position: absolute;
+      top: 100%;
+      background-color: var(--widget-bg);
+      min-width: 270px;
+      max-width: 280px;
+      padding: 12px 16px;
+      z-index: 99;
+      box-shadow: 0 4px 6px 3px rgba(0, 0, 0, 0.6);
+      border-radius: 4px;
+      flex-direction: column;
+      display: none;
+    }
+
+    @media (max-height: 400px) {
+      .dropdown {
+        max-height: 280px;
+      }
+    }
+
+    .dropdown.show {
+      display: flex;
+    }
+
+    .dropdown-list {
+      margin-top: 12px;
+      margin-right: -15px;
+      max-height: 300px;
+      overflow: auto;
+    }
+
+    .dropdown-events {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .dropdown-search {
+      width: 100%;
+    }
+
+    .dropdown-list-select {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+    }
+
+    .dropdown-list-select-text {
+      font-size: 14px;
+      white-space: nowrap;
+    }
+
+    .dropdown-list-label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      width: 100%;
+      cursor: pointer;
+      padding: 12px 0;
+    }
+  </style>
+</head>
+<body>
+<div class="header">
+  <div class="counter">
+    <h1 class="counter-number" id="counterNumber"></h1>
+    <h2 class="counter-title" id="counterTitle"></h2>
+  </div>
+  <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 23" width="100%" height="100%" fill="currentColor"> <defs> <style> .cls-1 { stroke-width: 0px; } </style> </defs> <path class="cls-1" d="M15.51,4.79H5.49c-.4,0-.72.32-.72.72v5.75c0,2.3,1.71,4.15,3.69,5.38.54.34,1.1.62,1.66.86l.09.04c.06.02.12.05.18.06.03,0,.07,0,.1,0,.1,0,.19-.03.28-.07l.09-.04c.76-.33,2.22-1.03,3.46-2.24,1.24-1.22,1.89-2.6,1.89-4v-5.75c0-.4-.32-.72-.72-.72ZM14.32,11.26c0,.88-.44,1.77-1.32,2.63-.65.64-1.55,1.22-2.5,1.68-.95-.46-1.84-1.04-2.5-1.68-.88-.86-1.32-1.75-1.32-2.63v-4.55h7.64v4.55ZM20.28,0H.72c-.4,0-.72.32-.72.72v10.77c0,2.56,1.18,4.99,3.51,7.21,2.29,2.18,5.12,3.56,6.61,4.2l.09.04s.1.04.15.05c.04,0,.09.01.13.01.1,0,.19-.02.28-.06l.09-.04c.53-.23,1.23-.55,2.02-.97,1.42-.75,3.11-1.82,4.59-3.23,2.33-2.22,3.51-4.64,3.51-7.21V.72c0-.4-.32-.72-.72-.72ZM16.17,17.31c-1.9,1.81-4.24,3.04-5.67,3.69-1.43-.65-3.77-1.88-5.67-3.69-1.94-1.84-2.92-3.8-2.92-5.82V1.92h17.18v9.57c0,2.02-.98,3.98-2.92,5.82Z"></path></svg>
+</div>
+<div class="table-wrapper" id="tableWrapper">
+  <div class="table-events">
+    <div class="dropdown-container">
+      <svg class="dropdown-button" id="columnsIcon" width="24" height="24"
+           viewBox="0 0 24 24"
+           xmlns="http://www.w3.org/2000/svg"
+           fill="currentColor">
+        <path
+          d="M4 6v12.444h16V6H4zm4.738 10.667h-2.96v-8.89h2.96v8.89zm4.746 0h-2.96v-8.89h2.96v8.89zm4.738 0h-2.96v-8.89h2.96v8.89z"></path>
+      </svg>
+      <div id="dropdown" class="dropdown">
+        <div class="dropdown-events">
+          <input class="input dropdown-search" type="text" id="dropdownSearch"
+                 placeholder="Search (regex)">
+          <label class="dropdown-list-select" for="selectAll">
+            <span class="dropdown-list-select-text" id="selectAllText"></span>
+            <input type="checkbox" id="selectAll" checked>
+          </label>
+        </div>
+        <div class="dropdown-list" id="dropdownList"></div>
+      </div>
+    </div>
+    <label class="table-udm-label" for="predefinedFieldsCheckbox"
+           id="predefinedFieldsCheckboxLabel">
+      <input type="checkbox" id="predefinedFieldsCheckbox">
+      <span class="table-udm-label-text">Important UDM</span>
+    </label>
+    <input class="input table-search" type="text" autocomplete="off" id="searchInput"
+           placeholder="Search (regex)"/>
+  </div>
+  <div class="table-container">
+    <table class="table">
+      <thead id="tableHeader"></thead>
+      <tbody id="tableBody"></tbody>
+    </table>
+  </div>
+</div>
+<script>
+
+  const actionListData = [[{stepInstanceName}.JsonResult | "events"]];
+
+  // Create a new array, 'specifiedKeys', by mapping over an existing array.
+  const specifiedKeys = ["entity.asset.asset_id", "entity.asset.hostname", "entity.asset.ip", "entity.asset.mac", "entity.asset.product_object_id", "entity.file", "entity.group.email_address", "entity.group.product_object_id", "entity.group.windows_sid", "entity.hostname", "entity.resource.name", "entity.resource.product_object_id", "entity.url", "entity.user.email_address", "entity.user.employee_id", "entity.user.product_object_id", "entity.user.userid", "entity.user.windows_sid", "metadata.collected_timestamp", "metadata.threat", "metadata.description", "metadata.event_timestamp", "metadata.event_type", "metadata.ingestion_labels.key", "metadata.ingestion_labels.value", "metadata.product_deployment_id", "metadata.product_event_type", "metadata.product_log_id", "metadata.product_name", "metadata.vendor_name", "network.application_protocol", "network.dns_domain", "network.dns.answers.data", "network.dns.answers.name", "network.dns.answers.type", "network.dns.questions.name", "network.dns.questions.type", "network.email.bcc", "network.email.email.cc", "network.email.from", "network.email.reply_to", "network.email.subject", "network.email.to", "network.ftp.command", "network.http.method", "network.http.referral_url", "network.http.response_code", "network.http.user_agent", "network.ip_protocol", "principal.asset_id", "principal.asset.asset_id", "principal.asset.hostname", "principal.asset.ip", "principal.asset.mac", "principal.cloud.environment", "principal.file.full_path", "principal.file.md5", "principal.file.sha1", "principal.file.sha256", "principal.hostname", "principal.ip", "principal.mac", "principal.process.command_line", "principal.process.file.full_path", "principal.process.parent_process", "principal.process.parent_process.command_line", "principal.process.parent_process.file.full_path", "principal.process.pid", "principal.process.product_specific_process_id", "principal.registry.registry_key", "principal.registry.registry_value_name", "principal.resource.attribute.cloud.project.name", "principal.resource.attribute.cloud.project.resource_subtype", "principal.resource.name", "principal.url", "principal.user.attribute.permissions.name", "principal.user.attribute.permissions.type", "principal.user.attribute.roles.description", "principal.user.attribute.roles.name", "principal.user.email_address", "principal.user.product_object_id", "principal.user.userid", "principal.user.windows_sid", "security_result.action", "security_result.category", "security_result.description", "security_result.detection_fields.key", "security_result.detection_fields.value", "security_result.summary", "security_result.threat_id", "security_result.threat_id_namespace", "security_result.threat_name", "source.asset_id", "source.asset.asset_id", "source.asset.hostname", "source.asset.ip", "source.asset.mac", "source.file.md5", "source.file.sha1", "source.file.sha256", "source.hostname", "source.ip", "source.mac", "source.process.parent_process", "source.process.product_specific_process_id", "source.user.email_address", "source.user.product_object_id", "source.user.userid", "source.user.windows_sid", "target.application", "target.asset_id", "target.asset.asset_id", "target.asset.hostname", "target.asset.ip", "target.asset.mac", "target.cloud.environment", "target.cloud.project.name", "target.file.full_path", "target.file.md5", "target.file.sha1", "target.file.sha256", "target.hostname", "target.ip", "target.mac", "target.port", "target.process.command_line", "target.process.file.full_path", "target.process.parent_process", "target.process.parent_process.command_line", "target.process.parent_process.file.full_path", "target.process.pid", "target.process.product_specific_process_id", "target.registry.registry_key", "target.registry.registry_value_name", "target.resource.name", "target.resource.resource_type", "target.user.email_address", "target.user.product_object_id", "target.user.userid", "target.user.windows_sid"].map(key => key.replace(/[\W_]/g, "").toLowerCase());
+
+  // Set to "true" to have with specifiedKeys on initial load
+  predefinedFieldsCheckbox.checked = false;
+
+  // Constants and let for tooltip positioning
+  const tooltipGap = 25;
+  const tooltipTriangleHeight = 8;
+  const tooltipTriangleMinGap = 5;
+  const triangleWidth = 16;
+  let tooltipTimeout = undefined;
+
+  // Extract keys and values from actionListData
+  const allKeys = getAllKeys(actionListData);
+  const allValues = getAllValues(actionListData);
+
+  // Modify keys for uniformity and prepare for filtering
+  const modifiedAllKeys = allKeys.map(key => key.replace(/^udm\./, "").replace(/[\W_]/g, "").toLowerCase());
+
+  // Initialize arrays and objects for processing
+  const specifiedKeysInAll = [];
+  const allKeysRecords = {};
+
+  // Populate specifiedKeysInAll and allKeysRecords
+  modifiedAllKeys.forEach((key, index) => {
+    const keyInAll = allKeys[index];
+    allKeysRecords[keyInAll] = index;
+    if (specifiedKeys.includes(key)) {
+      specifiedKeysInAll.push(keyInAll);
+    }
+  });
+
+  // Event listeners for UI interactions
+  columnsIcon.addEventListener("click", function (event) {
+    dropdown.classList.toggle("show");
+    event.stopPropagation();
+  });
+  document.addEventListener("click", function (event) {
+    if (!dropdown.contains(event.target) && event.target !== columnsIcon) {
+      dropdown.classList.remove("show");
+    }
+  });
+  dropdownSearch.addEventListener("input", debounce(filterDropdown, 300));
+  searchInput.addEventListener("input", debounce(generateTable, 500));
+  selectAll.addEventListener("change", function () {
+    getDropdownListCheckboxes().forEach(function (checkbox) {
+      checkbox.checked = selectAll.checked;
+    });
+    generateTable();
+  });
+  predefinedFieldsCheckbox.addEventListener("change", () => {
+    generateDropdown();
+    generateTable();
+  });
+  const tooltipDetectResizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const target = entry.target;
+      if (target) {
+        const {offsetWidth, scrollWidth} = target;
+        if (scrollWidth > offsetWidth) {
+          target.addEventListener("mouseover", createTooltipListener);
+          target.addEventListener("mouseout", removeTooltipListener);
+        } else {
+          target.removeEventListener("mouseover", createTooltipListener);
+          target.removeEventListener("mouseout", removeTooltipListener);
+        }
+      }
+    }
+  });
+
+  // Generate dropdown on page load
+  generateDropdown();
+
+  if (specifiedKeys.length === 0) {
+    predefinedFieldsCheckboxLabel.remove();
+  }
+
+  /**
+   * Function to get selected column indexes
+   */
+  function getSelectedColumnsIndexes() {
+    const selectedCheckBoxes = getDropdownListCheckboxes().filter(checkbox => !!checkbox.checked);
+    return selectedCheckBoxes.map(checkbox => allKeysRecords[checkbox.value]);
+  }
+
+  function escapeRegExp(string) {
+    return string.replace(/([+])/g, "\\$1");
+  }
+
+  /**
+   * Generates the table based on current selections and filters.
+   */
+  function generateTable() {
+    const searchQuery = getSearchValue();
+    const selectedColumnIndexes = getSelectedColumnsIndexes();
+    const isSelectAll = selectedColumnIndexes.length === allKeys.length;
+    const rowValues = isSelectAll ? allValues : allValues.map(rowData => rowData.filter((data, index) => selectedColumnIndexes.includes(index)));
+    const escapedQuery = escapeRegExp(searchQuery);
+    const regexPattern = new RegExp(escapedQuery, "gi");
+
+    generateTableHeader(isSelectAll ? undefined : selectedColumnIndexes);
+
+    if (!searchQuery) {
+      generateTableBody(rowValues);
+    } else {
+      const filteredRows = rowValues.filter(item =>
+        item.some(value =>
+          (typeof value === "string" && regexPattern.test(value)) ||
+          (typeof value === "number" && regexPattern.test(value.toString())),
+        ),
+      );
+      generateTableBody(filteredRows, searchQuery);
+    }
+  }
+
+  /**
+   * Generates the table header based on selected columns.
+   */
+  function generateTableHeader(indexesToRender) {
+    let keysToRender = allKeys;
+    tableHeader.innerHTML = "";
+    if (Array.isArray(indexesToRender)) {
+      if (indexesToRender.length === 0) {
+        return;
+      }
+      keysToRender = allKeys.filter((key, index) => indexesToRender.includes(index));
+    }
+    const table_tr = document.createElement("tr");
+    keysToRender.forEach((key) => {
+      const table_th = document.createElement("th");
+      const table_th_div = document.createElement("div");
+      renderWithTooltip(table_th_div, key.replace(/\./g, "."));
+      table_th.appendChild(table_th_div);
+      table_tr.appendChild(table_th);
+      tableHeader.appendChild(table_tr);
+    });
+
+    resizableGrid();
+
+  }
+
+  /**
+   * Generates the table body based on rows to render and search query.
+   */
+  function generateTableBody(rowsToRender, searchQuery = "") {
+    tableBody.innerHTML = "";
+
+    const escapedQuery = escapeRegExp(searchQuery);
+    const regexPattern = new RegExp(escapedQuery, "gi");
+
+    rowsToRender.forEach(item => {
+      const row = document.createElement("tr");
+      item.forEach(value => {
+        const cell = document.createElement("td");
+        renderWithTooltip(cell, value);
+        if (typeof value === "string" && searchQuery && regexPattern.test(value)) {
+          cell.innerHTML = value.replace(regexPattern, match => `<mark style="pointer-events: none">${match}</mark>`);
+        } else if (typeof value === "number" && searchQuery && regexPattern.test(value.toString())) {
+          cell.innerHTML = value.toString().replace(regexPattern, match => `<mark style="pointer-events: none">${match}</mark>`);
+        } else if (value === undefined || value === null || value === "") {
+          cell.textContent = "N/A";
+        } else {
+          cell.textContent = value;
+        }
+        row.appendChild(cell);
+      });
+      tableBody.appendChild(row);
+    });
+
+    updateCounter();
+  }
+
+  /**
+   * Updates the counter displaying the number of rows in the table.
+   */
+  function updateCounter() {
+    const rowCount = tableBody.rows.length;
+    counterTitle.innerText = rowCount === 1 ? "Event found" : "Events found";
+    counterNumber.innerText = rowCount;
+  }
+
+  /**
+   * Retrieves all unique keys from nested data structures.
+   */
+  function getAllKeys(data) {
+    const allKeys = new Set();
+    const prePathMaxIndexesMap = new Map();
+
+    function traverse(obj, path = "") {
+      for (const key in obj) {
+        if (Array.isArray(obj[key])) {
+          obj[key].forEach((item, index) => {
+            if (typeof item === "object" && item !== null) traverse(item, `${path}${key}.${index}.`);
+            else {
+              const prePath = `${path}${key}`;
+              if (!allKeys.has(prePath)) allKeys.add(prePath);
+              else {
+                const currentMaxIndex = prePathMaxIndexesMap.get(prePath) ?? -1;
+                if (index > currentMaxIndex) prePathMaxIndexesMap.set(prePath, index);
+              }
+            }
+          });
+        } else if (typeof obj[key] === "object" && obj[key] !== null) traverse(obj[key], `${path}${key}.`);
+        else allKeys.add(`${path}${key}`);
+      }
+    }
+
+    data.forEach((item) => traverse(item));
+    return Array.from(allKeys).flatMap(key => {
+      if (prePathMaxIndexesMap.has(key)) {
+        const maxIndex = prePathMaxIndexesMap.get(key);
+        return Array.from(Array(maxIndex + 1).keys()).map(index => `${key}.${index}`);
+      }
+      return key;
+    });
+  }
+
+  /**
+   * Retrieves all values corresponding to keys from nested data.
+   */
+  function getAllValues(data) {
+    const allValues = data.map(item => flattenObject(item));
+    return allValues.map((obj) => allKeys.map(key => obj[key] !== undefined ? obj[key] : ""));
+  }
+
+  /**
+   * Flattens nested objects into key-value pairs.
+   */
+  function flattenObject(obj, prefix = "") {
+    return Object.keys(obj).reduce((acc, key) => {
+      const pre = prefix.length ? `${prefix}.` : "";
+      if (typeof obj[key] === "object" && obj[key] !== null && !Array.isArray(obj[key])) {
+        Object.assign(acc, flattenObject(obj[key], `${pre}${key}`));
+      } else if (Array.isArray(obj[key])) {
+        obj[key].forEach((item, index) => {
+          if (typeof item === "object" && item !== null) Object.assign(acc, flattenObject(item, `${pre}${key}.${index}`));
+          else acc[`${pre}${key}.${index}`] = item;
+        });
+      } else acc[`${pre}${key}`] = obj[key];
+      return acc;
+    }, {});
+  }
+
+  /**
+   * Retrieves the current search value from the input field.
+   */
+  function getSearchValue() {
+    return searchInput.value.trim().toLowerCase() ?? "";
+  }
+
+  /**
+   * Retrieves the state of the UDM list checkbox.
+   */
+  function getUDMListChecked() {
+    return !!predefinedFieldsCheckbox.checked;
+  }
+
+  /**
+   * Retrieves checkboxes within the dropdown list.
+   */
+  function getDropdownListCheckboxes() {
+    return Array.from(dropdownList.querySelectorAll("[data=\"dropdown-list-checkbox\"]"));
+  }
+
+  /**
+   * Debounce function execution to optimize performance.
+   */
+  function debounce(func, delay) {
+    let timeoutId;
+    return function (...args) {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => func.apply(this, args), delay);
+    };
+  }
+
+  /**
+   * Generates the dropdown menu based on selected options.
+   */
+  function generateDropdown() {
+    dropdownList.innerHTML = "";
+    selectAllText.innerText = "Select all";
+    const isUdmListChecked = getUDMListChecked();
+    const keysToGenerate = isUdmListChecked ? specifiedKeysInAll : allKeys;
+    keysToGenerate.forEach(key => {
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.value = key;
+      checkbox.setAttribute("data", "dropdown-list-checkbox");
+      checkbox.checked = true;
+      checkbox.addEventListener("change", () => {
+        generateTable();
+        updateSelectAllCheckbox();
+      });
+      const label = document.createElement("label");
+      label.className = "dropdown-list-label";
+      label.setAttribute("data", "dropdown-list-label");
+      const labelKey = document.createElement("span");
+      label.appendChild(checkbox);
+      labelKey.appendChild(document.createTextNode(key));
+      renderWithTooltip(labelKey, key);
+      label.appendChild(labelKey);
+      dropdownList.appendChild(label);
+    });
+  }
+
+  /**
+   * Update the selectAll checkbox state based on individual checkboxes
+   */
+  function updateSelectAllCheckbox() {
+    const checkboxes = getDropdownListCheckboxes();
+    const allChecked = checkboxes.every(checkbox => checkbox.checked);
+    selectAll.checked = allChecked;
+  }
+
+  /**
+   * Filters dropdown options based on user input.
+   */
+  function filterDropdown() {
+    const searchTerm = dropdownSearch.value.trim();
+    const regex = new RegExp(searchTerm, "gi");
+    dropdownList.querySelectorAll("[data=\"dropdown-list-label\"]").forEach(label => {
+      const checkbox = label.children[0];
+      label.style.display = checkbox?.value.match(regex) ? "flex" : "none";
+    });
+  }
+
+  /**
+   * Creates a tooltip with given text and position.
+   */
+  function createTooltip(text, x, y, trianglePointX, placeAtBottom, contentOverflowWindow) {
+    removeTooltip();
+    const tooltip = document.createElement("div");
+    tooltip.classList.add("tooltip");
+    tooltip.textContent = text;
+    tooltip.style.left = `${x}px`;
+    tooltip.style.top = `${y}px`;
+    if (contentOverflowWindow) {
+      tooltip.style.right = `${tooltipGap}px`;
+    }
+    const tooltipTriangle = document.createElement("span");
+    tooltipTriangle.classList.add("tooltip-triangle");
+    tooltipTriangle.style.left = `${trianglePointX}px`;
+    if (placeAtBottom) {
+      tooltipTriangle.style.top = "-8px";
+      tooltipTriangle.style.borderTop = "0";
+      tooltipTriangle.style.borderBottom = "solid 8px rgb(195, 210, 232)";
+    }
+    tooltip.append(tooltipTriangle);
+    document.body.append(tooltip);
+  }
+
+  /**
+   * Removes any existing tooltip from the DOM.
+   */
+  function removeTooltip() {
+    const tooltip = document.querySelectorAll(".tooltip");
+    tooltip.forEach((item) => {
+      if (item) {
+        item.remove();
+      }
+    });
+  }
+
+  /**
+   * Sets a timeout to calculate and show tooltip position after a delay.
+   */
+  function createTooltipListener(event) {
+    tooltipTimeout = setTimeout(() => calculateTooltipPosition(event), 1000);
+  }
+
+  /**
+   * Clears any existing tooltip timeout and removes the tooltip.
+   */
+  function removeTooltipListener() {
+    if (tooltipTimeout) {
+      clearTimeout(tooltipTimeout);
+    }
+    removeTooltip();
+  }
+
+  /**
+   * Calculates and positions the tooltip relative to the event target.
+   */
+  function calculateTooltipPosition(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    const viewportWidth = window.innerWidth;
+    const rect = target.getBoundingClientRect();
+    const tooltipContent = document.createElement("div");
+    tooltipContent.classList.add("tooltip");
+    tooltipContent.style.top = "0";
+    tooltipContent.textContent = target.textContent;
+    document.body.appendChild(tooltipContent);
+    let contentOverflowWindow = false;
+    // Determine if window width would not be enough for content of tooltip
+    if (tooltipGap * 2 + tooltipContent.offsetWidth >= viewportWidth) {
+      // setting left, right positions to get correct tooltipContentWidth and tooltipContentHeight
+      tooltipContent.style.left = `${tooltipGap}px`;
+      tooltipContent.style.right = `${tooltipGap}px`;
+      contentOverflowWindow = true;
+    }
+    const tooltipContentWidth = tooltipContent.offsetWidth;
+    const tooltipContentHeight = tooltipContent.offsetHeight;
+    tooltipContent.remove();
+    const elementMidX = rect.left + (rect.width / 2);
+    const placeOnRight = elementMidX + tooltipContentWidth / 2 + tooltipGap > viewportWidth;
+    const x = Math.max(tooltipGap, placeOnRight ? viewportWidth - tooltipContentWidth - tooltipGap : elementMidX - tooltipContentWidth / 2);
+    const placeAtBottom = rect.top < tooltipContentHeight;
+    const y = placeAtBottom ? rect.bottom + tooltipTriangleHeight : rect.top - tooltipContentHeight;
+    // Calculating trianglePointX relative to window width, to guarantee that it is not out of window
+    const trianglePointX = Math.min(Math.max(elementMidX - x, tooltipTriangleMinGap), tooltipContentWidth - tooltipTriangleMinGap - triangleWidth);
+    createTooltip(target.textContent, x, y, trianglePointX, placeAtBottom, contentOverflowWindow);
+  }
+
+  /**
+   * Renders an item with text and sets up tooltip behavior.
+   */
+  function renderWithTooltip(item, text) {
+    item.innerText = text;
+    item.classList.add("text-ellipsis");
+    tooltipDetectResizeObserver.observe(item);
+  }
+
+  /**
+   * Function to make a table resizable
+   */
+  function resizableGrid() {
+    const table = document.querySelector(".table");
+    if (!table) return;
+
+    const row = table.getElementsByTagName("tr")[0],
+      cols = row ? row.children : undefined;
+    if (!cols) return;
+
+    for (let i = 0; i < cols.length; i++) {
+      const div = createDiv();
+      cols[i].appendChild(div);
+      cols[i].style.position = "relative";
+      setListeners(div);
+    }
+
+    function setListeners(div) {
+      let pageX, curCol, nxtCol, curColWidth, nxtColWidth, tableWidth;
+
+      div.addEventListener("mousedown", function (e) {
+        curCol = e.target.parentElement;
+        nxtCol = curCol.nextElementSibling;
+        pageX = e.pageX;
+
+        const padding = paddingDiff(curCol);
+
+        curColWidth = curCol.offsetWidth - padding;
+        if (nxtCol) {
+          nxtColWidth = nxtCol.offsetWidth - padding;
+        }
+      });
+
+      document.addEventListener("mousemove", function (e) {
+        if (curCol) {
+          const diffX = e.pageX - pageX;
+          if (nxtCol) {
+            nxtCol.style.width = nxtColWidth - diffX + "px";
+          }
+          curCol.style.width = curColWidth + diffX + "px";
+          table.style.width = tableWidth + diffX + "px";
+        }
+      });
+
+      document.addEventListener("mouseup", function () {
+        curCol = undefined;
+        nxtCol = undefined;
+        pageX = undefined;
+        nxtColWidth = undefined;
+        curColWidth = undefined;
+        tableWidth = undefined;
+      });
+    }
+
+    function createDiv() {
+      const div = document.createElement("div");
+      div.classList.add("table-resizable-line");
+      return div;
+    }
+
+    function paddingDiff(col) {
+      if (getStyleVal(col, "box-sizing") === "border-box") {
+        return 0;
+      }
+
+      const padLeft = getStyleVal(col, "padding-left");
+      const padRight = getStyleVal(col, "padding-right");
+      return parseInt(padLeft) + parseInt(padRight);
+    }
+
+    function getStyleVal(elm, css) {
+      return window.getComputedStyle(elm, null).getPropertyValue(css);
+    }
+  }
+
+  window.addEventListener("load", () => {
+    // Generate table on page load
+    generateTable();
+  });
+</script>
+</body>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Search Outbound Connection.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Search Outbound Connection.yaml
@@ -1,0 +1,31 @@
+title: Search Outbound Connection
+description: This widget highlights the most important items in Execute UDM Query
+    - Google Chronicle.
+identifier: 523391ef-54b0-44d1-8e9b-9807480fe66c
+order: 3
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 400
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: 8e0de0a4-1302-4866-970b-6c0fc4bb3b4d
+step_id: b70e342a-5ac0-4cad-be78-e23e7d7f0a2f
+block_step_id: null
+present_if_empty: false
+conditions_group:
+    conditions:
+    -   field_name: '[{stepInstanceName}.is_success]'
+        value: 'true'
+        match_type: equal
+        custom_operator_name: null
+    -   field_name: '[{stepInstanceName}.JsonResult]'
+        value: '{'
+        match_type: contains
+        custom_operator_name: null
+    logical_operator: and
+integration_name: GoogleChronicle

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Search for Other Potentially Impacted Users.html
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Search for Other Potentially Impacted Users.html
@@ -1,0 +1,908 @@
+<!-- Custom Widget / Integration Version when it was updated 49.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link
+    href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i"
+    rel="stylesheet">
+  <link
+    href='https://fonts.googleapis.com/css?family=Source Sans Pro'
+    rel='stylesheet'>
+  <title>Execute UDM Query</title>
+  <style>
+    /* Root Variables */
+    :root {
+      --widget-bg: rgb(33, 44, 68);
+      --widget-font-family: 'Source Sans Pro', sans-serif;
+      --widget-text-color: rgb(255, 255, 255);
+      --widget-scrollbar-size: 12px;
+      --widget-row-highlight-bg: rgb(47 61 91);
+      /*Logo styles*/
+      --logo-size: 48px;
+      --logo-color: rgb(255, 255, 255);
+      /*Logo styles*/
+      /*Table styles*/
+      --table-color-even-row: rgb(26 32 50);
+      --table-title-size: 600 14px/18px var(--widget-font-family);
+      --table-th-size: 600 14px/18px var(--widget-font-family);
+      --table-td-size: 400 14px/18px var(--widget-font-family);
+    }
+
+    /*Normalize CSS */
+    * {
+      margin: 0;
+      padding: 0;
+      outline: none;
+      box-sizing: border-box;
+    }
+
+    *:hover, *:focus, *:active {
+      outline: none;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border-spacing: 0;
+    }
+
+    ol, ul {
+      list-style: none;
+    }
+
+    button,
+    input,
+    textarea {
+      font-family: inherit;
+      background: transparent;
+      border: 0;
+      color: inherit;
+      text-align: left;
+    }
+
+    button, a[href] {
+      cursor: pointer;
+    }
+
+    /*Normalize CSS */
+    /* Custom Scrollbar */
+    ::-webkit-scrollbar {
+      width: 18px;
+      height: 18px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: rgba(137, 151, 180, 1);
+      border: 6px solid var(--widget-bg);
+      border-radius: 63px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: transparent;
+      border: 4px solid transparent;
+      border-radius: 44px;
+    }
+
+    ::-webkit-scrollbar-corner {
+      background-color: transparent;
+      border-color: transparent;
+    }
+
+    body {
+      font-family: var(--widget-font-family), serif;
+      color: var(--widget-text-color);
+      background-color: var(--widget-bg);
+      overflow: hidden;
+    }
+
+    /*Global styles*/
+    .text-ellipsis {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .tooltip {
+      max-width: 100%;
+      position: absolute;
+      padding: 8px 16px 8px 16px;
+      border-radius: 4px;
+      background-color: rgb(204 204 218);
+      color: rgb(22, 22, 37);
+      font: 400 14px/18px var(--widget-font-family);
+      z-index: 99;
+      word-wrap: break-word;
+    }
+
+    .tooltip-triangle {
+      position: absolute;
+      top: 100%;
+      border-top: solid 8px rgb(195, 210, 232);
+      border-left: solid 8px transparent;
+      border-right: solid 8px transparent;
+    }
+
+    .input {
+      border: 1px solid #6275A3;
+      border-radius: 4px;
+      padding: 4px 8px;
+      background-color: transparent;
+      font-size: 14px;
+      color: var(--widget-text-color);
+    }
+
+    .input::placeholder {
+      color: var(--widget-text-color);
+    }
+
+    input[type="checkbox"] {
+      max-width: 13px;
+      max-height: 13px;
+    }
+
+    /*Global styles*/
+    /*Table*/
+    .table-wrapper {
+      margin-top: 8px;
+      position: relative;
+    }
+
+    .table-search {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .table-container {
+      overflow: auto;
+      max-height: calc(100vh - 102px);
+    }
+
+    .table {
+      table-layout: fixed;
+    }
+
+    .table thead {
+      position: sticky;
+      top: 0;
+      z-index: 9;
+    }
+
+    .table th {
+      width: 250px;
+      background-color: var(--widget-row-highlight-bg);
+      color: var(--widget-text-color);
+      font: var(--table-th-size);
+      padding: 6px 12px;
+      text-transform: uppercase;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    .table tr:nth-child(even) {
+      background-color: var(--table-color-even-row);
+    }
+
+    .table-resizable-line {
+      position: absolute;
+      inset: 3px 6px 3px auto;
+      width: 2px;
+      cursor: col-resize;
+      user-select: none;
+      background-color: rgb(98, 117, 163);
+      z-index: 9;
+    }
+
+    .table-resizable-line::before, .table-resizable-line::after {
+      content: '';
+      position: absolute;
+      inset: 0 auto;
+      width: 6px;
+    }
+
+    .table-resizable-line::before {
+      left: -6px;
+    }
+
+    .table-resizable-line::after {
+      right: -6px;
+    }
+
+    .table td {
+      padding: 8px 12px;
+      font: var(--table-td-size);
+      color: var(--widget-text-color);
+      vertical-align: top;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .logo {
+      min-width: var(--logo-size);
+      min-height: var(--logo-size);
+      max-width: var(--logo-size);
+      max-height: var(--logo-size);
+      color: var(--logo-color);
+    }
+
+    .counter {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin: 0 auto;
+    }
+
+    .counter-number {
+      font: 600 20px/24px var(--widget-font-family);
+      text-align: center;
+    }
+
+    .counter-title {
+      font: 600 16px/22px var(--widget-font-family);
+      text-transform: uppercase;
+      text-align: center;
+    }
+
+    .table-events {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      justify-content: flex-end;
+      margin-bottom: 12px;
+      padding: 0 6px;
+    }
+
+    .table-udm-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding-left: 4px;
+      cursor: pointer;
+    }
+
+    .table-udm-label-text {
+      font-size: 14px;
+    }
+
+    /* Dropdown */
+    .dropdown-button {
+      width: 24px;
+      height: 24px;
+      cursor: pointer;
+    }
+
+    .dropdown-container {
+      width: 24px;
+      height: 24px;
+      margin-right: auto;
+      position: relative;
+    }
+
+    .dropdown {
+      position: absolute;
+      top: 100%;
+      background-color: var(--widget-bg);
+      min-width: 270px;
+      max-width: 280px;
+      padding: 12px 16px;
+      z-index: 99;
+      box-shadow: 0 4px 6px 3px rgba(0, 0, 0, 0.6);
+      border-radius: 4px;
+      flex-direction: column;
+      display: none;
+    }
+
+    @media (max-height: 400px) {
+      .dropdown {
+        max-height: 280px;
+      }
+    }
+
+    .dropdown.show {
+      display: flex;
+    }
+
+    .dropdown-list {
+      margin-top: 12px;
+      margin-right: -15px;
+      max-height: 300px;
+      overflow: auto;
+    }
+
+    .dropdown-events {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .dropdown-search {
+      width: 100%;
+    }
+
+    .dropdown-list-select {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+    }
+
+    .dropdown-list-select-text {
+      font-size: 14px;
+      white-space: nowrap;
+    }
+
+    .dropdown-list-label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      width: 100%;
+      cursor: pointer;
+      padding: 12px 0;
+    }
+  </style>
+</head>
+<body>
+<div class="header">
+  <div class="counter">
+    <h1 class="counter-number" id="counterNumber"></h1>
+    <h2 class="counter-title" id="counterTitle"></h2>
+  </div>
+  <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 23" width="100%" height="100%" fill="currentColor"> <defs> <style> .cls-1 { stroke-width: 0px; } </style> </defs> <path class="cls-1" d="M15.51,4.79H5.49c-.4,0-.72.32-.72.72v5.75c0,2.3,1.71,4.15,3.69,5.38.54.34,1.1.62,1.66.86l.09.04c.06.02.12.05.18.06.03,0,.07,0,.1,0,.1,0,.19-.03.28-.07l.09-.04c.76-.33,2.22-1.03,3.46-2.24,1.24-1.22,1.89-2.6,1.89-4v-5.75c0-.4-.32-.72-.72-.72ZM14.32,11.26c0,.88-.44,1.77-1.32,2.63-.65.64-1.55,1.22-2.5,1.68-.95-.46-1.84-1.04-2.5-1.68-.88-.86-1.32-1.75-1.32-2.63v-4.55h7.64v4.55ZM20.28,0H.72c-.4,0-.72.32-.72.72v10.77c0,2.56,1.18,4.99,3.51,7.21,2.29,2.18,5.12,3.56,6.61,4.2l.09.04s.1.04.15.05c.04,0,.09.01.13.01.1,0,.19-.02.28-.06l.09-.04c.53-.23,1.23-.55,2.02-.97,1.42-.75,3.11-1.82,4.59-3.23,2.33-2.22,3.51-4.64,3.51-7.21V.72c0-.4-.32-.72-.72-.72ZM16.17,17.31c-1.9,1.81-4.24,3.04-5.67,3.69-1.43-.65-3.77-1.88-5.67-3.69-1.94-1.84-2.92-3.8-2.92-5.82V1.92h17.18v9.57c0,2.02-.98,3.98-2.92,5.82Z"></path></svg>
+</div>
+<div class="table-wrapper" id="tableWrapper">
+  <div class="table-events">
+    <div class="dropdown-container">
+      <svg class="dropdown-button" id="columnsIcon" width="24" height="24"
+           viewBox="0 0 24 24"
+           xmlns="http://www.w3.org/2000/svg"
+           fill="currentColor">
+        <path
+          d="M4 6v12.444h16V6H4zm4.738 10.667h-2.96v-8.89h2.96v8.89zm4.746 0h-2.96v-8.89h2.96v8.89zm4.738 0h-2.96v-8.89h2.96v8.89z"></path>
+      </svg>
+      <div id="dropdown" class="dropdown">
+        <div class="dropdown-events">
+          <input class="input dropdown-search" type="text" id="dropdownSearch"
+                 placeholder="Search (regex)">
+          <label class="dropdown-list-select" for="selectAll">
+            <span class="dropdown-list-select-text" id="selectAllText"></span>
+            <input type="checkbox" id="selectAll" checked>
+          </label>
+        </div>
+        <div class="dropdown-list" id="dropdownList"></div>
+      </div>
+    </div>
+    <label class="table-udm-label" for="predefinedFieldsCheckbox"
+           id="predefinedFieldsCheckboxLabel">
+      <input type="checkbox" id="predefinedFieldsCheckbox">
+      <span class="table-udm-label-text">Important UDM</span>
+    </label>
+    <input class="input table-search" type="text" autocomplete="off" id="searchInput"
+           placeholder="Search (regex)"/>
+  </div>
+  <div class="table-container">
+    <table class="table">
+      <thead id="tableHeader"></thead>
+      <tbody id="tableBody"></tbody>
+    </table>
+  </div>
+</div>
+<script>
+
+  const actionListData = [[{stepInstanceName}.JsonResult | "events"]];
+
+  // Create a new array, 'specifiedKeys', by mapping over an existing array.
+  const specifiedKeys = ["entity.asset.asset_id", "entity.asset.hostname", "entity.asset.ip", "entity.asset.mac", "entity.asset.product_object_id", "entity.file", "entity.group.email_address", "entity.group.product_object_id", "entity.group.windows_sid", "entity.hostname", "entity.resource.name", "entity.resource.product_object_id", "entity.url", "entity.user.email_address", "entity.user.employee_id", "entity.user.product_object_id", "entity.user.userid", "entity.user.windows_sid", "metadata.collected_timestamp", "metadata.threat", "metadata.description", "metadata.event_timestamp", "metadata.event_type", "metadata.ingestion_labels.key", "metadata.ingestion_labels.value", "metadata.product_deployment_id", "metadata.product_event_type", "metadata.product_log_id", "metadata.product_name", "metadata.vendor_name", "network.application_protocol", "network.dns_domain", "network.dns.answers.data", "network.dns.answers.name", "network.dns.answers.type", "network.dns.questions.name", "network.dns.questions.type", "network.email.bcc", "network.email.email.cc", "network.email.from", "network.email.reply_to", "network.email.subject", "network.email.to", "network.ftp.command", "network.http.method", "network.http.referral_url", "network.http.response_code", "network.http.user_agent", "network.ip_protocol", "principal.asset_id", "principal.asset.asset_id", "principal.asset.hostname", "principal.asset.ip", "principal.asset.mac", "principal.cloud.environment", "principal.file.full_path", "principal.file.md5", "principal.file.sha1", "principal.file.sha256", "principal.hostname", "principal.ip", "principal.mac", "principal.process.command_line", "principal.process.file.full_path", "principal.process.parent_process", "principal.process.parent_process.command_line", "principal.process.parent_process.file.full_path", "principal.process.pid", "principal.process.product_specific_process_id", "principal.registry.registry_key", "principal.registry.registry_value_name", "principal.resource.attribute.cloud.project.name", "principal.resource.attribute.cloud.project.resource_subtype", "principal.resource.name", "principal.url", "principal.user.attribute.permissions.name", "principal.user.attribute.permissions.type", "principal.user.attribute.roles.description", "principal.user.attribute.roles.name", "principal.user.email_address", "principal.user.product_object_id", "principal.user.userid", "principal.user.windows_sid", "security_result.action", "security_result.category", "security_result.description", "security_result.detection_fields.key", "security_result.detection_fields.value", "security_result.summary", "security_result.threat_id", "security_result.threat_id_namespace", "security_result.threat_name", "source.asset_id", "source.asset.asset_id", "source.asset.hostname", "source.asset.ip", "source.asset.mac", "source.file.md5", "source.file.sha1", "source.file.sha256", "source.hostname", "source.ip", "source.mac", "source.process.parent_process", "source.process.product_specific_process_id", "source.user.email_address", "source.user.product_object_id", "source.user.userid", "source.user.windows_sid", "target.application", "target.asset_id", "target.asset.asset_id", "target.asset.hostname", "target.asset.ip", "target.asset.mac", "target.cloud.environment", "target.cloud.project.name", "target.file.full_path", "target.file.md5", "target.file.sha1", "target.file.sha256", "target.hostname", "target.ip", "target.mac", "target.port", "target.process.command_line", "target.process.file.full_path", "target.process.parent_process", "target.process.parent_process.command_line", "target.process.parent_process.file.full_path", "target.process.pid", "target.process.product_specific_process_id", "target.registry.registry_key", "target.registry.registry_value_name", "target.resource.name", "target.resource.resource_type", "target.user.email_address", "target.user.product_object_id", "target.user.userid", "target.user.windows_sid"].map(key => key.replace(/[\W_]/g, "").toLowerCase());
+
+  // Set to "true" to have with specifiedKeys on initial load
+  predefinedFieldsCheckbox.checked = false;
+
+  // Constants and let for tooltip positioning
+  const tooltipGap = 25;
+  const tooltipTriangleHeight = 8;
+  const tooltipTriangleMinGap = 5;
+  const triangleWidth = 16;
+  let tooltipTimeout = undefined;
+
+  // Extract keys and values from actionListData
+  const allKeys = getAllKeys(actionListData);
+  const allValues = getAllValues(actionListData);
+
+  // Modify keys for uniformity and prepare for filtering
+  const modifiedAllKeys = allKeys.map(key => key.replace(/^udm\./, "").replace(/[\W_]/g, "").toLowerCase());
+
+  // Initialize arrays and objects for processing
+  const specifiedKeysInAll = [];
+  const allKeysRecords = {};
+
+  // Populate specifiedKeysInAll and allKeysRecords
+  modifiedAllKeys.forEach((key, index) => {
+    const keyInAll = allKeys[index];
+    allKeysRecords[keyInAll] = index;
+    if (specifiedKeys.includes(key)) {
+      specifiedKeysInAll.push(keyInAll);
+    }
+  });
+
+  // Event listeners for UI interactions
+  columnsIcon.addEventListener("click", function (event) {
+    dropdown.classList.toggle("show");
+    event.stopPropagation();
+  });
+  document.addEventListener("click", function (event) {
+    if (!dropdown.contains(event.target) && event.target !== columnsIcon) {
+      dropdown.classList.remove("show");
+    }
+  });
+  dropdownSearch.addEventListener("input", debounce(filterDropdown, 300));
+  searchInput.addEventListener("input", debounce(generateTable, 500));
+  selectAll.addEventListener("change", function () {
+    getDropdownListCheckboxes().forEach(function (checkbox) {
+      checkbox.checked = selectAll.checked;
+    });
+    generateTable();
+  });
+  predefinedFieldsCheckbox.addEventListener("change", () => {
+    generateDropdown();
+    generateTable();
+  });
+  const tooltipDetectResizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const target = entry.target;
+      if (target) {
+        const {offsetWidth, scrollWidth} = target;
+        if (scrollWidth > offsetWidth) {
+          target.addEventListener("mouseover", createTooltipListener);
+          target.addEventListener("mouseout", removeTooltipListener);
+        } else {
+          target.removeEventListener("mouseover", createTooltipListener);
+          target.removeEventListener("mouseout", removeTooltipListener);
+        }
+      }
+    }
+  });
+
+  // Generate dropdown on page load
+  generateDropdown();
+
+  if (specifiedKeys.length === 0) {
+    predefinedFieldsCheckboxLabel.remove();
+  }
+
+  /**
+   * Function to get selected column indexes
+   */
+  function getSelectedColumnsIndexes() {
+    const selectedCheckBoxes = getDropdownListCheckboxes().filter(checkbox => !!checkbox.checked);
+    return selectedCheckBoxes.map(checkbox => allKeysRecords[checkbox.value]);
+  }
+
+  function escapeRegExp(string) {
+    return string.replace(/([+])/g, "\\$1");
+  }
+
+  /**
+   * Generates the table based on current selections and filters.
+   */
+  function generateTable() {
+    const searchQuery = getSearchValue();
+    const selectedColumnIndexes = getSelectedColumnsIndexes();
+    const isSelectAll = selectedColumnIndexes.length === allKeys.length;
+    const rowValues = isSelectAll ? allValues : allValues.map(rowData => rowData.filter((data, index) => selectedColumnIndexes.includes(index)));
+    const escapedQuery = escapeRegExp(searchQuery);
+    const regexPattern = new RegExp(escapedQuery, "gi");
+
+    generateTableHeader(isSelectAll ? undefined : selectedColumnIndexes);
+
+    if (!searchQuery) {
+      generateTableBody(rowValues);
+    } else {
+      const filteredRows = rowValues.filter(item =>
+        item.some(value =>
+          (typeof value === "string" && regexPattern.test(value)) ||
+          (typeof value === "number" && regexPattern.test(value.toString())),
+        ),
+      );
+      generateTableBody(filteredRows, searchQuery);
+    }
+  }
+
+  /**
+   * Generates the table header based on selected columns.
+   */
+  function generateTableHeader(indexesToRender) {
+    let keysToRender = allKeys;
+    tableHeader.innerHTML = "";
+    if (Array.isArray(indexesToRender)) {
+      if (indexesToRender.length === 0) {
+        return;
+      }
+      keysToRender = allKeys.filter((key, index) => indexesToRender.includes(index));
+    }
+    const table_tr = document.createElement("tr");
+    keysToRender.forEach((key) => {
+      const table_th = document.createElement("th");
+      const table_th_div = document.createElement("div");
+      renderWithTooltip(table_th_div, key.replace(/\./g, "."));
+      table_th.appendChild(table_th_div);
+      table_tr.appendChild(table_th);
+      tableHeader.appendChild(table_tr);
+    });
+
+    resizableGrid();
+
+  }
+
+  /**
+   * Generates the table body based on rows to render and search query.
+   */
+  function generateTableBody(rowsToRender, searchQuery = "") {
+    tableBody.innerHTML = "";
+
+    const escapedQuery = escapeRegExp(searchQuery);
+    const regexPattern = new RegExp(escapedQuery, "gi");
+
+    rowsToRender.forEach(item => {
+      const row = document.createElement("tr");
+      item.forEach(value => {
+        const cell = document.createElement("td");
+        renderWithTooltip(cell, value);
+        if (typeof value === "string" && searchQuery && regexPattern.test(value)) {
+          cell.innerHTML = value.replace(regexPattern, match => `<mark style="pointer-events: none">${match}</mark>`);
+        } else if (typeof value === "number" && searchQuery && regexPattern.test(value.toString())) {
+          cell.innerHTML = value.toString().replace(regexPattern, match => `<mark style="pointer-events: none">${match}</mark>`);
+        } else if (value === undefined || value === null || value === "") {
+          cell.textContent = "N/A";
+        } else {
+          cell.textContent = value;
+        }
+        row.appendChild(cell);
+      });
+      tableBody.appendChild(row);
+    });
+
+    updateCounter();
+  }
+
+  /**
+   * Updates the counter displaying the number of rows in the table.
+   */
+  function updateCounter() {
+    const rowCount = tableBody.rows.length;
+    counterTitle.innerText = rowCount === 1 ? "Event found" : "Events found";
+    counterNumber.innerText = rowCount;
+  }
+
+  /**
+   * Retrieves all unique keys from nested data structures.
+   */
+  function getAllKeys(data) {
+    const allKeys = new Set();
+    const prePathMaxIndexesMap = new Map();
+
+    function traverse(obj, path = "") {
+      for (const key in obj) {
+        if (Array.isArray(obj[key])) {
+          obj[key].forEach((item, index) => {
+            if (typeof item === "object" && item !== null) traverse(item, `${path}${key}.${index}.`);
+            else {
+              const prePath = `${path}${key}`;
+              if (!allKeys.has(prePath)) allKeys.add(prePath);
+              else {
+                const currentMaxIndex = prePathMaxIndexesMap.get(prePath) ?? -1;
+                if (index > currentMaxIndex) prePathMaxIndexesMap.set(prePath, index);
+              }
+            }
+          });
+        } else if (typeof obj[key] === "object" && obj[key] !== null) traverse(obj[key], `${path}${key}.`);
+        else allKeys.add(`${path}${key}`);
+      }
+    }
+
+    data.forEach((item) => traverse(item));
+    return Array.from(allKeys).flatMap(key => {
+      if (prePathMaxIndexesMap.has(key)) {
+        const maxIndex = prePathMaxIndexesMap.get(key);
+        return Array.from(Array(maxIndex + 1).keys()).map(index => `${key}.${index}`);
+      }
+      return key;
+    });
+  }
+
+  /**
+   * Retrieves all values corresponding to keys from nested data.
+   */
+  function getAllValues(data) {
+    const allValues = data.map(item => flattenObject(item));
+    return allValues.map((obj) => allKeys.map(key => obj[key] !== undefined ? obj[key] : ""));
+  }
+
+  /**
+   * Flattens nested objects into key-value pairs.
+   */
+  function flattenObject(obj, prefix = "") {
+    return Object.keys(obj).reduce((acc, key) => {
+      const pre = prefix.length ? `${prefix}.` : "";
+      if (typeof obj[key] === "object" && obj[key] !== null && !Array.isArray(obj[key])) {
+        Object.assign(acc, flattenObject(obj[key], `${pre}${key}`));
+      } else if (Array.isArray(obj[key])) {
+        obj[key].forEach((item, index) => {
+          if (typeof item === "object" && item !== null) Object.assign(acc, flattenObject(item, `${pre}${key}.${index}`));
+          else acc[`${pre}${key}.${index}`] = item;
+        });
+      } else acc[`${pre}${key}`] = obj[key];
+      return acc;
+    }, {});
+  }
+
+  /**
+   * Retrieves the current search value from the input field.
+   */
+  function getSearchValue() {
+    return searchInput.value.trim().toLowerCase() ?? "";
+  }
+
+  /**
+   * Retrieves the state of the UDM list checkbox.
+   */
+  function getUDMListChecked() {
+    return !!predefinedFieldsCheckbox.checked;
+  }
+
+  /**
+   * Retrieves checkboxes within the dropdown list.
+   */
+  function getDropdownListCheckboxes() {
+    return Array.from(dropdownList.querySelectorAll("[data=\"dropdown-list-checkbox\"]"));
+  }
+
+  /**
+   * Debounce function execution to optimize performance.
+   */
+  function debounce(func, delay) {
+    let timeoutId;
+    return function (...args) {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => func.apply(this, args), delay);
+    };
+  }
+
+  /**
+   * Generates the dropdown menu based on selected options.
+   */
+  function generateDropdown() {
+    dropdownList.innerHTML = "";
+    selectAllText.innerText = "Select all";
+    const isUdmListChecked = getUDMListChecked();
+    const keysToGenerate = isUdmListChecked ? specifiedKeysInAll : allKeys;
+    keysToGenerate.forEach(key => {
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.value = key;
+      checkbox.setAttribute("data", "dropdown-list-checkbox");
+      checkbox.checked = true;
+      checkbox.addEventListener("change", () => {
+        generateTable();
+        updateSelectAllCheckbox();
+      });
+      const label = document.createElement("label");
+      label.className = "dropdown-list-label";
+      label.setAttribute("data", "dropdown-list-label");
+      const labelKey = document.createElement("span");
+      label.appendChild(checkbox);
+      labelKey.appendChild(document.createTextNode(key));
+      renderWithTooltip(labelKey, key);
+      label.appendChild(labelKey);
+      dropdownList.appendChild(label);
+    });
+  }
+
+  /**
+   * Update the selectAll checkbox state based on individual checkboxes
+   */
+  function updateSelectAllCheckbox() {
+    const checkboxes = getDropdownListCheckboxes();
+    const allChecked = checkboxes.every(checkbox => checkbox.checked);
+    selectAll.checked = allChecked;
+  }
+
+  /**
+   * Filters dropdown options based on user input.
+   */
+  function filterDropdown() {
+    const searchTerm = dropdownSearch.value.trim();
+    const regex = new RegExp(searchTerm, "gi");
+    dropdownList.querySelectorAll("[data=\"dropdown-list-label\"]").forEach(label => {
+      const checkbox = label.children[0];
+      label.style.display = checkbox?.value.match(regex) ? "flex" : "none";
+    });
+  }
+
+  /**
+   * Creates a tooltip with given text and position.
+   */
+  function createTooltip(text, x, y, trianglePointX, placeAtBottom, contentOverflowWindow) {
+    removeTooltip();
+    const tooltip = document.createElement("div");
+    tooltip.classList.add("tooltip");
+    tooltip.textContent = text;
+    tooltip.style.left = `${x}px`;
+    tooltip.style.top = `${y}px`;
+    if (contentOverflowWindow) {
+      tooltip.style.right = `${tooltipGap}px`;
+    }
+    const tooltipTriangle = document.createElement("span");
+    tooltipTriangle.classList.add("tooltip-triangle");
+    tooltipTriangle.style.left = `${trianglePointX}px`;
+    if (placeAtBottom) {
+      tooltipTriangle.style.top = "-8px";
+      tooltipTriangle.style.borderTop = "0";
+      tooltipTriangle.style.borderBottom = "solid 8px rgb(195, 210, 232)";
+    }
+    tooltip.append(tooltipTriangle);
+    document.body.append(tooltip);
+  }
+
+  /**
+   * Removes any existing tooltip from the DOM.
+   */
+  function removeTooltip() {
+    const tooltip = document.querySelectorAll(".tooltip");
+    tooltip.forEach((item) => {
+      if (item) {
+        item.remove();
+      }
+    });
+  }
+
+  /**
+   * Sets a timeout to calculate and show tooltip position after a delay.
+   */
+  function createTooltipListener(event) {
+    tooltipTimeout = setTimeout(() => calculateTooltipPosition(event), 1000);
+  }
+
+  /**
+   * Clears any existing tooltip timeout and removes the tooltip.
+   */
+  function removeTooltipListener() {
+    if (tooltipTimeout) {
+      clearTimeout(tooltipTimeout);
+    }
+    removeTooltip();
+  }
+
+  /**
+   * Calculates and positions the tooltip relative to the event target.
+   */
+  function calculateTooltipPosition(event) {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+    const viewportWidth = window.innerWidth;
+    const rect = target.getBoundingClientRect();
+    const tooltipContent = document.createElement("div");
+    tooltipContent.classList.add("tooltip");
+    tooltipContent.style.top = "0";
+    tooltipContent.textContent = target.textContent;
+    document.body.appendChild(tooltipContent);
+    let contentOverflowWindow = false;
+    // Determine if window width would not be enough for content of tooltip
+    if (tooltipGap * 2 + tooltipContent.offsetWidth >= viewportWidth) {
+      // setting left, right positions to get correct tooltipContentWidth and tooltipContentHeight
+      tooltipContent.style.left = `${tooltipGap}px`;
+      tooltipContent.style.right = `${tooltipGap}px`;
+      contentOverflowWindow = true;
+    }
+    const tooltipContentWidth = tooltipContent.offsetWidth;
+    const tooltipContentHeight = tooltipContent.offsetHeight;
+    tooltipContent.remove();
+    const elementMidX = rect.left + (rect.width / 2);
+    const placeOnRight = elementMidX + tooltipContentWidth / 2 + tooltipGap > viewportWidth;
+    const x = Math.max(tooltipGap, placeOnRight ? viewportWidth - tooltipContentWidth - tooltipGap : elementMidX - tooltipContentWidth / 2);
+    const placeAtBottom = rect.top < tooltipContentHeight;
+    const y = placeAtBottom ? rect.bottom + tooltipTriangleHeight : rect.top - tooltipContentHeight;
+    // Calculating trianglePointX relative to window width, to guarantee that it is not out of window
+    const trianglePointX = Math.min(Math.max(elementMidX - x, tooltipTriangleMinGap), tooltipContentWidth - tooltipTriangleMinGap - triangleWidth);
+    createTooltip(target.textContent, x, y, trianglePointX, placeAtBottom, contentOverflowWindow);
+  }
+
+  /**
+   * Renders an item with text and sets up tooltip behavior.
+   */
+  function renderWithTooltip(item, text) {
+    item.innerText = text;
+    item.classList.add("text-ellipsis");
+    tooltipDetectResizeObserver.observe(item);
+  }
+
+  /**
+   * Function to make a table resizable
+   */
+  function resizableGrid() {
+    const table = document.querySelector(".table");
+    if (!table) return;
+
+    const row = table.getElementsByTagName("tr")[0],
+      cols = row ? row.children : undefined;
+    if (!cols) return;
+
+    for (let i = 0; i < cols.length; i++) {
+      const div = createDiv();
+      cols[i].appendChild(div);
+      cols[i].style.position = "relative";
+      setListeners(div);
+    }
+
+    function setListeners(div) {
+      let pageX, curCol, nxtCol, curColWidth, nxtColWidth, tableWidth;
+
+      div.addEventListener("mousedown", function (e) {
+        curCol = e.target.parentElement;
+        nxtCol = curCol.nextElementSibling;
+        pageX = e.pageX;
+
+        const padding = paddingDiff(curCol);
+
+        curColWidth = curCol.offsetWidth - padding;
+        if (nxtCol) {
+          nxtColWidth = nxtCol.offsetWidth - padding;
+        }
+      });
+
+      document.addEventListener("mousemove", function (e) {
+        if (curCol) {
+          const diffX = e.pageX - pageX;
+          if (nxtCol) {
+            nxtCol.style.width = nxtColWidth - diffX + "px";
+          }
+          curCol.style.width = curColWidth + diffX + "px";
+          table.style.width = tableWidth + diffX + "px";
+        }
+      });
+
+      document.addEventListener("mouseup", function () {
+        curCol = undefined;
+        nxtCol = undefined;
+        pageX = undefined;
+        nxtColWidth = undefined;
+        curColWidth = undefined;
+        tableWidth = undefined;
+      });
+    }
+
+    function createDiv() {
+      const div = document.createElement("div");
+      div.classList.add("table-resizable-line");
+      return div;
+    }
+
+    function paddingDiff(col) {
+      if (getStyleVal(col, "box-sizing") === "border-box") {
+        return 0;
+      }
+
+      const padLeft = getStyleVal(col, "padding-left");
+      const padRight = getStyleVal(col, "padding-right");
+      return parseInt(padLeft) + parseInt(padRight);
+    }
+
+    function getStyleVal(elm, css) {
+      return window.getComputedStyle(elm, null).getPropertyValue(css);
+    }
+  }
+
+  window.addEventListener("load", () => {
+    // Generate table on page load
+    generateTable();
+  });
+</script>
+</body>
+</html>

--- a/content/playbooks/third_party/community/phishing_investigation/widgets/Search for Other Potentially Impacted Users.yaml
+++ b/content/playbooks/third_party/community/phishing_investigation/widgets/Search for Other Potentially Impacted Users.yaml
@@ -1,0 +1,31 @@
+title: Search for Other Potentially Impacted Users
+description: This widget highlights the most important items in Execute UDM Query
+    - Google Chronicle.
+identifier: 98b8ca05-2022-4ad5-969e-8a1ce23c267d
+order: 4
+template_identifier: f18a5a38-1924-419e-82fe-fec809ce2969
+type: html
+block_step_instance_name: null
+data_definition:
+    html_height: 400
+    safe_rendering: false
+    widget_definition_scope: both
+    type: html
+widget_size: half_width
+step_integration: null
+action_widget_template_id: 8e0de0a4-1302-4866-970b-6c0fc4bb3b4d
+step_id: 8b3f68ed-6182-4d37-8870-67f98f287734
+block_step_id: null
+present_if_empty: false
+conditions_group:
+    conditions:
+    -   field_name: '[{stepInstanceName}.is_success]'
+        value: 'true'
+        match_type: equal
+        custom_operator_name: null
+    -   field_name: '[{stepInstanceName}.JsonResult]'
+        value: '{'
+        match_type: contains
+        custom_operator_name: null
+    logical_operator: and
+integration_name: GoogleChronicle


### PR DESCRIPTION
## Summary

Adds a new third-party block for Phishing Investigation.

## Description

The Playbook ingests and parses .eml/.msg files to extract key email data for Email Header Analysis and Entities & Artifacts Enrichment Blocks. It identifies potentially impacted users and counts those who clicked malicious links. Findings are consolidated and presented through insights, providing a clear, structured view of email threats, user exposure, and risk confidence level.

## Type of Contribution

- [x] Block

## Validation

- [x] `mp validate` passed

## Notes

- No sensitive or internal data included.
- Block tested in SOAR environment before submission.
