### PR TITLE
Fix: Append Google Sheets rows when Row Index is empty

### DIFF
--- a/content/response_integrations/third_party/community/google_sheets/actions/AddRow.py
+++ b/content/response_integrations/third_party/community/google_sheets/actions/AddRow.py
@@ -48,7 +48,7 @@ def main():
         if row_index is not None:
             worksheet.insert_row(values, row_index)
         else:
-            worksheet.insert_row(values)
+            worksheet.append_row(values)
 
         print(worksheet.row_count)
     except Exception as err:

--- a/content/response_integrations/third_party/community/google_sheets/actions/AddRow.yaml
+++ b/content/response_integrations/third_party/community/google_sheets/actions/AddRow.yaml
@@ -21,9 +21,10 @@ parameters:
     is_mandatory: false
     name: Worksheet Name
     type: string
--   default_value: <Row-1>
+-   default_value: ''
     description: 'The location in the spreadsheet where the row is added. The value
-        must be a positive, one-based integer. Default is 1. '
+        must be a positive, one-based integer. Leave empty to append the row to the
+        end of the worksheet. '
     is_mandatory: false
     name: Row Index
     type: string

--- a/content/response_integrations/third_party/community/google_sheets/pyproject.toml
+++ b/content/response_integrations/third_party/community/google_sheets/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Google-Sheets"
-version = "17.0"
+version = "18.0"
 description = "Google Sheets is a spreadsheet program included as part of a free, web-based software office suite offered by Google within its Google Drive service. "
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/third_party/community/google_sheets/release_notes.yaml
+++ b/content/response_integrations/third_party/community/google_sheets/release_notes.yaml
@@ -97,3 +97,9 @@
   item_type: Action
   publish_time: '2026-08-10'
   ticket_number: ''
+- description: Added support for appending rows when Row Index is empty.
+  version: 18.0
+  item_name: Add Row
+  item_type: Action
+  publish_time: '2026-08-14'
+  ticket_number: ''

--- a/content/response_integrations/third_party/community/google_sheets/resources/ai/actions_ai_description.yaml
+++ b/content/response_integrations/third_party/community/google_sheets/resources/ai/actions_ai_description.yaml
@@ -159,7 +159,7 @@ Add Row:
 
     Adds a new row of data to a specified Google Sheets spreadsheet. This action interacts
     with the Google Sheets API to insert comma-separated values into a designated
-    worksheet at a specific row index.
+    worksheet at a specific row index or append them to the end of the worksheet.
 
 
     ### Flow Description
@@ -175,8 +175,8 @@ Add Row:
     4. Retrieves the specified spreadsheet and targets the provided worksheet (or
     defaults to the first sheet).
 
-    5. Makes an API call to Google Sheets to insert the parsed values as a new row
-    at the specified index.
+    5. Makes an API call to Google Sheets to insert the parsed values at the specified
+    row index, or append them when no row index is provided.
 
     6. Returns a success or failure status based on the API response.
 
@@ -185,7 +185,7 @@ Add Row:
 
     The `Values` parameter must be a comma-separated string. If `Worksheet Name` is
     not provided, the action defaults to the first sheet (Sheet1). If `Row Index`
-    is not provided, the row is inserted at the default location (index 1).
+    is not provided, the row is appended to the end of the worksheet.
   ai_short_description: >-
     Adds a new row of comma-separated values to a specified Google Sheets spreadsheet
     and worksheet.
@@ -304,7 +304,7 @@ Add Row:
     default Sheet name is "Sheet1". Note: it is case sensitive. |
 
     | Row Index | String | No | The location in the spreadsheet where the row is added
-    (one-based). Default is 1. |
+    (one-based). Leave empty to append the row to the end of the worksheet. |
 
     | Values | String | Yes | The values you would like to add in the row. Values
     should be comma separated. |

--- a/content/response_integrations/third_party/community/google_sheets/tests/test_actions/test_add_row.py
+++ b/content/response_integrations/third_party/community/google_sheets/tests/test_actions/test_add_row.py
@@ -20,21 +20,36 @@ DEFAULT_PARAMETERS: dict[str, str] = {
 
 
 class FakeWorksheet:
-    def __init__(self, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        rows: list[list[str]] | None = None,
+        error: Exception | None = None,
+    ) -> None:
         self.error = error
+        self.rows = [row.copy() for row in rows or []]
+        self.appended_rows: list[list[str]] = []
         self.inserted_rows: list[tuple[list[str], int | None]] = []
-        self.row_count = 1
+        self.row_count = len(self.rows)
+
+    def append_row(self, values: list[str]) -> None:
+        if self.error:
+            raise self.error
+        self.appended_rows.append(values)
+        self.rows.append(values)
+        self.row_count = len(self.rows)
 
     def insert_row(self, values: list[str], index: int | None = None) -> None:
         if self.error:
             raise self.error
         self.inserted_rows.append((values, index))
+        self.rows.insert((index or 1) - 1, values)
+        self.row_count = len(self.rows)
 
 
 class FakeSpreadsheet:
-    def __init__(self, worksheet: FakeWorksheet) -> None:
-        self.sheet1 = worksheet
-        self._worksheets = {"myworksheet": worksheet}
+    def __init__(self, worksheets: dict[str, FakeWorksheet]) -> None:
+        self._worksheets = worksheets
+        self.sheet1 = next(iter(worksheets.values()))
 
     def worksheet(self, name: str) -> FakeWorksheet:
         return self._worksheets[name]
@@ -44,13 +59,48 @@ class FakeSpreadsheet:
 def test_add_row_returns_success_result_when_row_is_added(
     action_output: MockActionOutput,
 ) -> None:
-    worksheet = FakeWorksheet()
-    fake_sheet = FakeSpreadsheet(worksheet)
+    worksheet = FakeWorksheet(rows=[["existing row"]])
+    fake_sheet = FakeSpreadsheet({"myworksheet": worksheet})
 
     with unittest.mock.patch(CREATE_SPREADSHEET_PATH, return_value=fake_sheet):
         AddRow.main()
 
     assert worksheet.inserted_rows == [(["val1", "val2"], 2)]
+    assert worksheet.rows == [["existing row"], ["val1", "val2"]]
+    assert action_output.results.output_message == "Row added to the sheet successfully"
+    assert action_output.results.result_value is True
+    assert action_output.results.execution_state.value == EXECUTION_STATE_COMPLETED
+
+
+@set_metadata(
+    integration_config_file_path=CONFIG_PATH,
+    parameters={**DEFAULT_PARAMETERS, "Row Index": ""},
+)
+def test_add_row_appends_to_non_default_worksheet_when_row_index_is_empty(
+    action_output: MockActionOutput,
+) -> None:
+    worksheet = FakeWorksheet(rows=[["Name", "Status"], ["Existing", "Active"]])
+    other_worksheet = FakeWorksheet(rows=[["Other sheet value"]])
+    fake_sheet = FakeSpreadsheet(
+        {
+            "otherworksheet": other_worksheet,
+            "myworksheet": worksheet,
+        },
+    )
+
+    assert fake_sheet.sheet1 is other_worksheet
+
+    with unittest.mock.patch(CREATE_SPREADSHEET_PATH, return_value=fake_sheet):
+        AddRow.main()
+
+    assert worksheet.rows == [
+        ["Name", "Status"],
+        ["Existing", "Active"],
+        ["val1", "val2"],
+    ]
+    assert other_worksheet.rows == [["Other sheet value"]]
+    assert worksheet.appended_rows == [["val1", "val2"]]
+    assert worksheet.inserted_rows == []
     assert action_output.results.output_message == "Row added to the sheet successfully"
     assert action_output.results.result_value is True
     assert action_output.results.execution_state.value == EXECUTION_STATE_COMPLETED
@@ -61,7 +111,7 @@ def test_add_row_returns_failure_details_when_insert_fails(
     action_output: MockActionOutput,
 ) -> None:
     worksheet = FakeWorksheet(error=RuntimeError("worksheet unavailable"))
-    fake_sheet = FakeSpreadsheet(worksheet)
+    fake_sheet = FakeSpreadsheet({"myworksheet": worksheet})
 
     with unittest.mock.patch(CREATE_SPREADSHEET_PATH, return_value=fake_sheet):
         AddRow.main()
@@ -83,7 +133,7 @@ def test_add_row_returns_failure_details_when_insert_fails(
 def test_add_row_returns_clear_failure_for_invalid_row_index(
     action_output: MockActionOutput,
 ) -> None:
-    fake_sheet = FakeSpreadsheet(FakeWorksheet())
+    fake_sheet = FakeSpreadsheet({"myworksheet": FakeWorksheet()})
 
     with unittest.mock.patch(
         CREATE_SPREADSHEET_PATH,

--- a/content/response_integrations/third_party/community/google_sheets/uv.lock
+++ b/content/response_integrations/third_party/community/google_sheets/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "google-sheets"
-version = "17.0"
+version = "18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "gspread" },


### PR DESCRIPTION
Fixes #988

## Description

**What problem does this PR solve?**

Leaving `Row Index` empty in Google Sheets `Add Row` still called `insert_row`, which inserted the row at the start of the worksheet instead of appending it.

**How does this PR solve the problem?**

The action now calls `append_row` when `Row Index` is empty. Providing a positive row index still uses `insert_row`.

This also adds an append-path test, updates the action metadata, bumps the integration to version 18.0, and adds a release note.

**Any other relevant information:**

This is the append follow-up left out of #1133.

Verified locally:

- `mp test --integration google_sheets --raise-error-on-violations` — 9/9 passed
- `mp validate integration google_sheets` — 23/23 passed
- `mp check content/response_integrations/third_party/community/google_sheets --raise-error-on-violations --output-format grouped` — passed

---

## Checklist:

### General Checks:

- [x] I have read and followed the project's contributing.md guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes.
- [x] I have updated the documentation where necessary.

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems.

---

## Screenshots (If Applicable)

Not applicable.

---

## Further Comments / Questions

None.
