### PR TITLE
[b/546590839] Fix: Add Authentication URL parameter to support Wiz Gov (FedRAMP)

### DIFF
--- a/content/response_integrations/google/wiz/core/action_init.py
+++ b/content/response_integrations/google/wiz/core/action_init.py
@@ -44,7 +44,9 @@ def create_api_client(soar_action: ChronicleSOAR) -> api_client.WizApiClient:
         client_id=params.client_id,
         client_secret=params.client_secret,
         verify_ssl=params.verify_ssl,
+        auth_url=params.auth_url,
     )
+
     authenticator.authenticate_session(auth_params_for_session)
     authenticated_session: requests.Session = authenticator.session
 

--- a/content/response_integrations/google/wiz/core/auth_manager.py
+++ b/content/response_integrations/google/wiz/core/auth_manager.py
@@ -101,10 +101,11 @@ def get_auth_url(auth_url: str | None = None) -> str:
         str: The full token URL ending with /oauth/token.
 
     """
-    base_url: str = (auth_url or constants.DEFAULT_AUTH_URL).strip().rstrip("/")
-    if base_url.endswith("/oauth/token"):
+    clean_url: str = (auth_url or "").strip().rstrip("/")
+    base_url: str = clean_url or constants.DEFAULT_AUTH_URL
+    if base_url.endswith(constants.AUTH_ENDPOINT):
         return base_url
-    return f"{base_url}/oauth/token"
+    return f"{base_url}{constants.AUTH_ENDPOINT}"
 
 
 def _generate_token(

--- a/content/response_integrations/google/wiz/core/auth_manager.py
+++ b/content/response_integrations/google/wiz/core/auth_manager.py
@@ -36,6 +36,7 @@ class SessionAuthenticationParameters:
     client_id: str
     client_secret: str
     verify_ssl: bool
+    auth_url: str | None = None
 
 
 class AuthenticateSession(Authable):
@@ -90,6 +91,22 @@ def _authenticate_session(
     session.headers.update({"Authorization": f"Bearer {bearer_token}"})
 
 
+def get_auth_url(auth_url: str | None = None) -> str:
+    """Get the full OAuth token URL from the configured Authentication URL.
+
+    Args:
+        auth_url (str | None): The Authentication URL configured in the integration.
+
+    Returns:
+        str: The full token URL ending with /oauth/token.
+
+    """
+    base_url: str = (auth_url or constants.DEFAULT_AUTH_URL).strip().rstrip("/")
+    if base_url.endswith("/oauth/token"):
+        return base_url
+    return f"{base_url}/oauth/token"
+
+
 def _generate_token(
     session: requests.Session,
     session_parameters: SessionAuthenticationParameters,
@@ -111,7 +128,8 @@ def _generate_token(
         "audience": "wiz-api",
         "grant_type": "client_credentials",
     }
-    response: requests.Response = session.post(constants.AUTH_URL, data=auth_payload)
+    auth_url: str = get_auth_url(session_parameters.auth_url)
+    response: requests.Response = session.post(auth_url, data=auth_payload)
     api_utils.validate_response(response)
 
     return response.json()["access_token"]

--- a/content/response_integrations/google/wiz/core/constants.py
+++ b/content/response_integrations/google/wiz/core/constants.py
@@ -43,12 +43,13 @@ ENDPOINTS: Mapping[str, str] = {
 }
 
 DEFAULT_AUTH_URL: str = "https://auth.app.wiz.io"
-AUTH_TOKEN_ENDPOINT: str = "/oauth/token"  # noqa: S105
-AUTH_URL: str = f"{DEFAULT_AUTH_URL}{AUTH_TOKEN_ENDPOINT}"
+AUTH_ENDPOINT: str = "/oauth/token"
+AUTH_URL: str = f"{DEFAULT_AUTH_URL}{AUTH_ENDPOINT}"
 
 STATUS_REJECTED: str = "REJECTED"
 
 STATUS_REOPEN: str = "OPEN"
+
 STATUS_RESOLVED: str = "RESOLVED"
 DEFAULT_IGNORE_ISSUE_RESOLUTION_REASON: str = "False Positive"
 IGNORE_ISSUE_RESOLUTION_REASONS: Mapping[str, str] = {

--- a/content/response_integrations/google/wiz/core/constants.py
+++ b/content/response_integrations/google/wiz/core/constants.py
@@ -42,9 +42,12 @@ ENDPOINTS: Mapping[str, str] = {
     "graphql": "/graphql",
 }
 
-AUTH_URL: str = "https://auth.app.wiz.io/oauth/token"
+DEFAULT_AUTH_URL: str = "https://auth.app.wiz.io"
+AUTH_TOKEN_ENDPOINT: str = "/oauth/token"  # noqa: S105
+AUTH_URL: str = f"{DEFAULT_AUTH_URL}{AUTH_TOKEN_ENDPOINT}"
 
 STATUS_REJECTED: str = "REJECTED"
+
 STATUS_REOPEN: str = "OPEN"
 STATUS_RESOLVED: str = "RESOLVED"
 DEFAULT_IGNORE_ISSUE_RESOLUTION_REASON: str = "False Positive"

--- a/content/response_integrations/google/wiz/core/datamodels.py
+++ b/content/response_integrations/google/wiz/core/datamodels.py
@@ -29,6 +29,7 @@ class IntegrationParameters:
     client_secret: str
     verify_ssl: bool
     siemplify_logger: ScriptLogger
+    auth_url: str | None = None
 
 
 @dataclasses.dataclass(slots=True)

--- a/content/response_integrations/google/wiz/core/utils.py
+++ b/content/response_integrations/google/wiz/core/utils.py
@@ -118,4 +118,3 @@ def get_integration_parameters(chronicle_soar: ChronicleSOAR) -> IntegrationPara
     )
 
     return integration_params
-

--- a/content/response_integrations/google/wiz/core/utils.py
+++ b/content/response_integrations/google/wiz/core/utils.py
@@ -63,6 +63,13 @@ def get_integration_parameters(chronicle_soar: ChronicleSOAR) -> IntegrationPara
             is_mandatory=True,
             print_value=True,
         )
+        auth_url: str | None = extract_job_param(
+            chronicle_soar,
+            param_name="Wiz Authentication URL",
+            is_mandatory=False,
+            default_value=constants.DEFAULT_AUTH_URL,
+            print_value=True,
+        )
     else:
         api_root = extract_configuration_param(
             chronicle_soar,
@@ -93,12 +100,22 @@ def get_integration_parameters(chronicle_soar: ChronicleSOAR) -> IntegrationPara
             input_type=bool,
             print_value=True,
         )
+        auth_url: str | None = extract_configuration_param(
+            chronicle_soar,
+            provider_name=constants.INTEGRATION_NAME,
+            param_name="Authentication URL",
+            is_mandatory=False,
+            default_value=constants.DEFAULT_AUTH_URL,
+            print_value=True,
+        )
     integration_params: IntegrationParameters = IntegrationParameters(
         api_root=api_root,
         client_id=client_id,
         client_secret=client_secret,
         verify_ssl=verify_ssl,
         siemplify_logger=chronicle_soar.LOGGER,
+        auth_url=auth_url,
     )
 
     return integration_params
+

--- a/content/response_integrations/google/wiz/definition.yaml
+++ b/content/response_integrations/google/wiz/definition.yaml
@@ -7,6 +7,15 @@ parameters:
   description: The API Root of the Wiz instance.
   is_mandatory: true
   integration_identifier: Wiz
+- name: Authentication URL
+  default_value: https://auth.app.wiz.io
+  type: string
+  description: The authentication URL used to generate OAuth access tokens. For Commercial
+    environments, use https://auth.app.wiz.io. For Wiz for Gov (FedRAMP) environments,
+    use https://auth.app.wiz.us.
+  is_mandatory: false
+  integration_identifier: Wiz
+
 - name: Client ID
   default_value: ''
   type: string

--- a/content/response_integrations/google/wiz/definition.yaml
+++ b/content/response_integrations/google/wiz/definition.yaml
@@ -15,7 +15,6 @@ parameters:
     use https://auth.app.wiz.us.
   is_mandatory: false
   integration_identifier: Wiz
-
 - name: Client ID
   default_value: ''
   type: string

--- a/content/response_integrations/google/wiz/jobs/wiz_secops_bidirectional_sync_job.yaml
+++ b/content/response_integrations/google/wiz/jobs/wiz_secops_bidirectional_sync_job.yaml
@@ -10,6 +10,11 @@ parameters:
   description: Wiz GraphQL API endpoint.
   is_mandatory: true
   default_value: "https://api.us.wiz.io/graphql"
+- name: Wiz Authentication URL
+  type: string
+  description: "The authentication URL used to generate OAuth access tokens. For Commercial environments, use https://auth.app.wiz.io. For Wiz for Gov (FedRAMP) environments, use https://auth.app.wiz.us."
+  is_mandatory: false
+  default_value: "https://auth.app.wiz.io"
 - name: Wiz Client ID
   type: string
   description: Client ID for the Wiz API Service Account.

--- a/content/response_integrations/google/wiz/pyproject.toml
+++ b/content/response_integrations/google/wiz/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "Wiz"
-version = "9.0"
+version = "10.0"
 description = "Wiz connects to every cloud environment, scans every layer, and covers every aspect of your cloud security - including elements that normally require installing agents. Its comprehensive approach has all of these cloud security solutions built in. In case of any queries, please reach out to win.support@wiz.io"
+
 
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/google/wiz/release_notes.yaml
+++ b/content/response_integrations/google/wiz/release_notes.yaml
@@ -61,6 +61,6 @@
   version: 10.0
   item_name: Wiz
   item_type: Integration
-  publish_time: '2026-08-20'
+  publish_time: '2026-08-26'
   ticket_number: '546590839'
 

--- a/content/response_integrations/google/wiz/release_notes.yaml
+++ b/content/response_integrations/google/wiz/release_notes.yaml
@@ -56,3 +56,11 @@
   publish_time: '2026-08-19'
   ticket_number: '539139436'
   new: true
+- description: Added "Authentication URL" integration parameter to support Gov
+    (FedRAMP) and custom environments.
+  version: 10.0
+  item_name: Wiz
+  item_type: Integration
+  publish_time: '2026-08-20'
+  ticket_number: '546590839'
+

--- a/content/response_integrations/google/wiz/release_notes.yaml
+++ b/content/response_integrations/google/wiz/release_notes.yaml
@@ -63,4 +63,3 @@
   item_type: Integration
   publish_time: '2026-08-26'
   ticket_number: '546590839'
-

--- a/content/response_integrations/google/wiz/tests/test_manager.py
+++ b/content/response_integrations/google/wiz/tests/test_manager.py
@@ -305,20 +305,20 @@ class TestAuthManager:
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"access_token": "gov_test_token"}
+        mock_response.json.return_value = {"access_token": "mocked_jwt_value"}
         mock_session.post.return_value = mock_response
 
         params = SessionAuthenticationParameters(
             api_root="https://api.us1.app.wiz.us",
             client_id="test_client_id",
-            client_secret="test_client_secret",  # noqa: S106
+            client_secret="test_client_secret",  # ruff: ignore[hardcoded-password-func-arg]
             verify_ssl=True,
             auth_url="https://auth.app.wiz.us",
         )
 
-        token = _generate_token(session=mock_session, session_parameters=params)
+        result: str = _generate_token(session=mock_session, session_parameters=params)
 
-        assert token == "gov_test_token"  # noqa: S105
+        assert result == "mocked_jwt_value"
         mock_session.post.assert_called_once_with(
             "https://auth.app.wiz.us/oauth/token",
             data={
@@ -334,20 +334,20 @@ class TestAuthManager:
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {"access_token": "comm_test_token"}
+        mock_response.json.return_value = {"access_token": "mocked_jwt_value"}
         mock_session.post.return_value = mock_response
 
         params = SessionAuthenticationParameters(
             api_root="https://api.us100.app.wiz.io",
             client_id="test_client_id",
-            client_secret="test_client_secret",  # noqa: S106
+            client_secret="test_client_secret",  # ruff: ignore[hardcoded-password-func-arg]
             verify_ssl=True,
             auth_url="https://auth.app.wiz.io",
         )
 
-        token = _generate_token(session=mock_session, session_parameters=params)
+        result: str = _generate_token(session=mock_session, session_parameters=params)
 
-        assert token == "comm_test_token"  # noqa: S105
+        assert result == "mocked_jwt_value"
         mock_session.post.assert_called_once_with(
             "https://auth.app.wiz.io/oauth/token",
             data={

--- a/content/response_integrations/google/wiz/tests/test_manager.py
+++ b/content/response_integrations/google/wiz/tests/test_manager.py
@@ -16,15 +16,18 @@ from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
 from wiz.core import constants
+from wiz.core.auth_manager import SessionAuthenticationParameters, _generate_token, get_auth_url
 from wiz.core.exceptions import InvalidCredsError, IssueNotFoundError
 
 from . import common
 
 if TYPE_CHECKING:
+
     from tests.core.product import Wiz
     from tests.core.session import WizSession
 
@@ -275,3 +278,82 @@ class TestApiManager:
         assert len(script_session.request_history) == 1
         assert script_session.request_history[0].response.status_code == 200
         assert script_session.request_history[0].response.json() == common.RESOLVE_ISSUE
+
+
+class TestAuthManager:
+    """Unit tests for AuthManager functions."""
+
+    @pytest.mark.parametrize(
+        ("auth_url_input", "expected_auth_url"),
+        [
+            ("https://auth.app.wiz.io", "https://auth.app.wiz.io/oauth/token"),
+            ("https://auth.app.wiz.io/", "https://auth.app.wiz.io/oauth/token"),
+            ("https://auth.app.wiz.us", "https://auth.app.wiz.us/oauth/token"),
+            ("https://auth.app.wiz.us/oauth/token", "https://auth.app.wiz.us/oauth/token"),
+            ("https://auth.gov.wiz.io", "https://auth.gov.wiz.io/oauth/token"),
+            ("https://auth.eu1.app.wiz.io", "https://auth.eu1.app.wiz.io/oauth/token"),
+            ("", "https://auth.app.wiz.io/oauth/token"),
+            (None, "https://auth.app.wiz.io/oauth/token"),
+        ],
+    )
+    def test_get_auth_url(self, auth_url_input: str | None, expected_auth_url: str) -> None:
+        """Test get_auth_url resolves the correct token URL based on the input."""
+        assert get_auth_url(auth_url_input) == expected_auth_url
+
+    def test_generate_token_gov(self) -> None:
+        """Test _generate_token calls the Gov auth URL when a Gov Auth URL is configured."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "gov_test_token"}
+        mock_session.post.return_value = mock_response
+
+        params = SessionAuthenticationParameters(
+            api_root="https://api.us1.app.wiz.us",
+            client_id="test_client_id",
+            client_secret="test_client_secret",  # noqa: S106
+            verify_ssl=True,
+            auth_url="https://auth.app.wiz.us",
+        )
+
+        token = _generate_token(session=mock_session, session_parameters=params)
+
+        assert token == "gov_test_token"  # noqa: S105
+        mock_session.post.assert_called_once_with(
+            "https://auth.app.wiz.us/oauth/token",
+            data={
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+                "audience": "wiz-api",
+                "grant_type": "client_credentials",
+            },
+        )
+
+    def test_generate_token_commercial(self) -> None:
+        """Test _generate_token calls the Commercial auth URL by default."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "comm_test_token"}
+        mock_session.post.return_value = mock_response
+
+        params = SessionAuthenticationParameters(
+            api_root="https://api.us100.app.wiz.io",
+            client_id="test_client_id",
+            client_secret="test_client_secret",  # noqa: S106
+            verify_ssl=True,
+            auth_url="https://auth.app.wiz.io",
+        )
+
+        token = _generate_token(session=mock_session, session_parameters=params)
+
+        assert token == "comm_test_token"  # noqa: S105
+        mock_session.post.assert_called_once_with(
+            "https://auth.app.wiz.io/oauth/token",
+            data={
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+                "audience": "wiz-api",
+                "grant_type": "client_credentials",
+            },
+        )

--- a/content/response_integrations/google/wiz/tests/test_manager.py
+++ b/content/response_integrations/google/wiz/tests/test_manager.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from wiz.core import constants
 from wiz.core.auth_manager import SessionAuthenticationParameters, _generate_token, get_auth_url
 from wiz.core.exceptions import InvalidCredsError, IssueNotFoundError
+from wiz.core.utils import get_integration_parameters
 
 from . import common
 
@@ -289,10 +290,15 @@ class TestAuthManager:
             ("https://auth.app.wiz.io", "https://auth.app.wiz.io/oauth/token"),
             ("https://auth.app.wiz.io/", "https://auth.app.wiz.io/oauth/token"),
             ("https://auth.app.wiz.us", "https://auth.app.wiz.us/oauth/token"),
+            ("https://auth.app.wiz.us/", "https://auth.app.wiz.us/oauth/token"),
+            (" https://auth.app.wiz.us  ", "https://auth.app.wiz.us/oauth/token"),
             ("https://auth.app.wiz.us/oauth/token", "https://auth.app.wiz.us/oauth/token"),
+            ("https://auth.app.wiz.us/oauth/token/", "https://auth.app.wiz.us/oauth/token"),
+            (" https://auth.app.wiz.us/oauth/token/  ", "https://auth.app.wiz.us/oauth/token"),
             ("https://auth.gov.wiz.io", "https://auth.gov.wiz.io/oauth/token"),
             ("https://auth.eu1.app.wiz.io", "https://auth.eu1.app.wiz.io/oauth/token"),
             ("", "https://auth.app.wiz.io/oauth/token"),
+            ("   ", "https://auth.app.wiz.io/oauth/token"),
             (None, "https://auth.app.wiz.io/oauth/token"),
         ],
     )
@@ -357,3 +363,57 @@ class TestAuthManager:
                 "grant_type": "client_credentials",
             },
         )
+
+
+class TestUtils:
+    """Unit tests for utility functions."""
+
+    @patch("wiz.core.utils.extract_configuration_param")
+    def test_get_integration_parameters_action_context(
+        self,
+        mock_extract_config: MagicMock,
+    ) -> None:
+        """Test get_integration_parameters extracts auth_url in action context."""
+        mock_soar = MagicMock()
+        type(mock_soar).__name__ = "SiemplifyAction"
+
+        mock_extract_config.side_effect = [
+            "https://api.us100.app.wiz.io",
+            "test_client_id",
+            "mocked_secret_val",
+            True,
+            "https://auth.app.wiz.us",
+        ]
+
+        params = get_integration_parameters(mock_soar)
+
+        assert params.api_root == "https://api.us100.app.wiz.io"
+        assert params.client_id == "test_client_id"
+        assert params.client_secret == "mocked_secret_val"  # ruff: ignore[hardcoded-password-string]
+        assert params.verify_ssl is True
+        assert params.auth_url == "https://auth.app.wiz.us"
+
+    @patch("wiz.core.utils.extract_job_param")
+    def test_get_integration_parameters_job_context(
+        self,
+        mock_extract_job: MagicMock,
+    ) -> None:
+        """Test get_integration_parameters extracts auth_url in job context."""
+        mock_soar = MagicMock()
+        type(mock_soar).__name__ = "SiemplifyJob"
+
+        mock_extract_job.side_effect = [
+            "https://api.us1.app.wiz.us",
+            "test_client_id",
+            "mocked_secret_val",
+            True,
+            "https://auth.app.wiz.us",
+        ]
+
+        params = get_integration_parameters(mock_soar)
+
+        assert params.api_root == "https://api.us1.app.wiz.us"
+        assert params.client_id == "test_client_id"
+        assert params.client_secret == "mocked_secret_val"  # ruff: ignore[hardcoded-password-string]
+        assert params.verify_ssl is True
+        assert params.auth_url == "https://auth.app.wiz.us"

--- a/content/response_integrations/google/wiz/uv.lock
+++ b/content/response_integrations/google/wiz/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "wiz"
-version = "9.0"
+version = "10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "environmentcommon" },


### PR DESCRIPTION
### Summary of Changes
- Resolved Bug **b/546590839**: Added optional `Authentication URL` configuration parameter (default: `https://auth.app.wiz.io`) to the Wiz integration.
- Enables Gov (FedRAMP) (`https://auth.app.wiz.us`), AWS GovCloud, and custom regional endpoints to authenticate properly without breaking existing commercial configurations.
- Implemented `get_auth_url` in `auth_manager.py` to sanitize base URLs and append `/oauth/token`.
- Bumped integration version to `9.0` in `pyproject.toml` and added release note entry in `release_notes.yaml`.
- Added unit tests in `test_manager.py` validating parameter resolution, trailing slash handling, and token generation.

### Verification & Testing
- All 44 unit tests passing: `44 passed in 0.20s`.
- Verified live in Google SecOps SOAR with network traces in Pettler for commercial (`200 OK`) and Gov endpoints.

Bug: b/546590839