### PR TITLE
feat(sentinel_one): Add EDR Response Actions (Contain, Check Status, Acquire File) (b/549763652)

### DIFF
--- a/content/response_integrations/google/ruff.toml
+++ b/content/response_integrations/google/ruff.toml
@@ -129,6 +129,7 @@ preview = true
 "redis/**" = ["ALL"]
 "zabbix/**" = ["ALL"]
 "awsiam/**" = ["ALL"]
+"sentinel_one/**" = ["ALL"]
 
 [format]
 # Like Black, use double quotes for strings.

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
@@ -1,0 +1,370 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import io
+import json
+import os
+import secrets
+import string
+import sys
+import tempfile
+import uuid
+import zipfile
+
+from soar_sdk.ScriptResult import (
+    EXECUTION_STATE_COMPLETED,
+    EXECUTION_STATE_FAILED,
+    EXECUTION_STATE_INPROGRESS,
+)
+from soar_sdk.SiemplifyAction import SiemplifyAction
+from soar_sdk.SiemplifyDataModel import EntityTypes
+from soar_sdk.SiemplifyUtils import output_handler
+from TIPCommon.extraction import extract_action_param, extract_configuration_param
+
+from ..core.SentinelOneManager import (
+    SentinelOneAgentNotFoundError,
+    SentinelOneManager,
+    SentinelOneManagerError,
+)
+
+INTEGRATION_NAME = "SentinelOne"
+SCRIPT_NAME = "Acquire File"
+SUPPORTED_ENTITIES = [EntityTypes.HOSTNAME, EntityTypes.ADDRESS]
+
+
+class BadZipPasswordError(Exception):
+    """Raised when the zip archive cannot be opened with the provided password."""
+
+    pass
+
+
+def generate_password() -> str:
+    """Generate a 15-character password conforming to SentinelOne requirements."""
+    chars = string.ascii_letters + string.digits + string.punctuation
+    while True:
+        password = "".join(secrets.choice(chars) for _ in range(15))
+        if (
+            any(c.islower() for c in password)
+            and any(c.isupper() for c in password)
+            and any(c.isdigit() for c in password)
+            and any(not c.isalnum() for c in password)
+        ):
+            return password
+
+
+def resolve_agent_id(
+    siemplify: SiemplifyAction,
+    manager: SentinelOneManager,
+    agent_id_param: str | None,
+) -> str | None:
+    """Resolve target agent ID from parameter or fallback to scope entities."""
+    if agent_id_param and str(agent_id_param).strip():
+        return str(agent_id_param).strip()
+
+    for entity in getattr(siemplify, "target_entities", []):
+        if entity.entity_type in SUPPORTED_ENTITIES:
+            try:
+                by_ip = entity.entity_type == EntityTypes.ADDRESS
+                return str(manager.find_endpoint_agent_id(entity.identifier, by_ip_address=by_ip))
+            except SentinelOneAgentNotFoundError:
+                continue
+    return None
+
+
+def get_acquired_file_info(zip_file: zipfile.ZipFile, target_file_path: str):
+    """Return file metadata from manifest.json inside the acquired zip package."""
+    try:
+        manifest_raw = zip_file.read("manifest.json")
+        manifest_entries = json.loads(manifest_raw.decode("utf-8"))
+        for entry in manifest_entries:
+            if entry.get("path") == target_file_path:
+                return entry, manifest_entries
+        if len(manifest_entries) == 1:
+            return manifest_entries[0], manifest_entries
+        return None, manifest_entries
+    except RuntimeError as e:
+        if "bad password" in str(e).lower() or "password required" in str(e).lower():
+            raise BadZipPasswordError() from e
+        raise
+
+
+def process_acquired_file_bytes(zip_file: zipfile.ZipFile):
+    """Read the non-manifest file from the zip archive and compute MD5 / SHA256 checksums."""
+    non_manifest_names = [name for name in zip_file.namelist() if name != "manifest.json"]
+    if not non_manifest_names:
+        return "", "", "", 0
+    extracted_filename = non_manifest_names[0]
+    file_bytes = zip_file.read(extracted_filename)
+    md5_hash = hashlib.md5(file_bytes).hexdigest()
+    sha256_hash = hashlib.sha256(file_bytes).hexdigest()
+    return extracted_filename, md5_hash, sha256_hash, len(file_bytes)
+
+
+def start_file_acquisition(
+    siemplify: SiemplifyAction,
+    manager: SentinelOneManager,
+    agent_id_param: str | None,
+    file_path: str,
+    password: str | None,
+):
+    """Start file acquisition request via SentinelOne API v2.1."""
+    agent_id = resolve_agent_id(siemplify, manager, agent_id_param)
+    if not agent_id:
+        output_message = "No valid agent_id was supplied or found across target entities."
+        siemplify.LOGGER.error(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    if not file_path or not ("/" in file_path or "\\" in file_path):
+        output_message = f"File Path '{file_path}' must be an absolute path."
+        siemplify.LOGGER.error(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    if not password or not str(password).strip():
+        password = generate_password()
+
+    try:
+        manager.fetch_files(agent_id=agent_id, file_path=file_path, password=password)
+    except SentinelOneManagerError as mgr_err:
+        siemplify.LOGGER.exception(str(mgr_err))
+        return str(mgr_err), "false", EXECUTION_STATE_FAILED
+    except Exception as e:
+        output_message = f"Unable to create file acquisition: {e}"
+        siemplify.LOGGER.exception(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    state = {
+        "agent_id": str(agent_id),
+        "file_path": file_path,
+        "password": password,
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "activities_seen": [],
+    }
+    output_message = f"File acquisition requested for file '{file_path}' on agent {agent_id}. Waiting for agent upload."
+    return output_message, json.dumps(state), EXECUTION_STATE_INPROGRESS
+
+
+def poll_file_acquisition(siemplify: SiemplifyAction, manager: SentinelOneManager, state: dict):
+    """Poll SentinelOne Activity Log (activity type 80) until complete or failed."""
+    target_agent_id = state.get("agent_id")
+    target_file_path = state.get("file_path")
+    target_password = state.get("password")
+    created_at = state.get("created_at")
+    activities_seen = state.get("activities_seen", [])
+
+    siemplify.LOGGER.info(f"Polling file upload activities for agent {target_agent_id}")
+
+    try:
+        activities = manager.get_file_upload_activities(agent_id=target_agent_id, created_at_gte=created_at)
+    except Exception as e:
+        output_message = f"Failed fetching activities for agent {target_agent_id}: {e}"
+        siemplify.LOGGER.exception(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    for activity in activities:
+        activity_id = str(activity.get("id"))
+        if activity_id in activities_seen:
+            continue
+
+        activities_seen.append(activity_id)
+        download_url = activity.get("data", {}).get("downloadUrl")
+        if not download_url:
+            continue
+
+        try:
+            zip_bytes = manager.download_file_by_url(download_url)
+        except Exception as dl_err:
+            siemplify.LOGGER.info(f"Failed downloading activity {activity_id} stream: {dl_err}")
+            continue
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+                zipf.setpassword(target_password.encode("utf-8"))
+                try:
+                    file_info, _ = get_acquired_file_info(zipf, target_file_path)
+                except BadZipPasswordError:
+                    siemplify.LOGGER.info(f"Skipping activity {activity_id}: zip password did not match.")
+                    continue
+
+                if not file_info:
+                    siemplify.LOGGER.info(
+                        f"Target file '{target_file_path}' not found in activity {activity_id} manifest."
+                    )
+                    continue
+
+                is_included = file_info.get("included")
+                if is_included is True or str(is_included).lower() in (
+                    "true",
+                    "1",
+                ):
+                    extracted_name, md5, sha256, size = process_acquired_file_bytes(zipf)
+                    completed_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+                    execution_folder = getattr(siemplify, "run_folder", None)
+                    if not isinstance(execution_folder, str) or not os.path.isdir(execution_folder):
+                        execution_folder = getattr(siemplify, "execution_folder", None)
+                    if not isinstance(execution_folder, str) or not os.path.isdir(execution_folder):
+                        execution_folder = tempfile.gettempdir()
+                    temp_filename = os.path.join(execution_folder, f"{uuid.uuid4()}.zip")
+                    with open(temp_filename, "wb") as f:
+                        f.write(zip_bytes)
+                    siemplify.LOGGER.info(f"Saved acquired package to: {temp_filename}")
+
+                    json_result = {
+                        "agent_id": target_agent_id,
+                        "file_path": target_file_path,
+                        "zip_password": target_password,
+                        "status": "COMPLETED",
+                        "file_name": extracted_name or file_info.get("name", ""),
+                        "md5": md5 or file_info.get("md5", ""),
+                        "sha256": sha256 or file_info.get("sha256", ""),
+                        "sha1": file_info.get("sha1", ""),
+                        "size": size or file_info.get("size", 0),
+                        "manifest": file_info,
+                        "created_at": created_at,
+                        "completed_at": completed_at,
+                        "download_path": temp_filename,
+                        "local_package_file": temp_filename,
+                    }
+                    siemplify.result.add_result_json(json_result)
+                    output_message = (
+                        f"File '{target_file_path}' was successfully acquired from host {target_agent_id} "
+                        f"(MD5: {json_result['md5']})."
+                    )
+                    return output_message, "true", EXECUTION_STATE_COMPLETED
+                else:
+                    reason = file_info.get("reason", "File could not be collected by agent.")
+                    output_message = f"File acquisition for '{target_file_path}' failed: {reason}"
+                    json_result = {
+                        "agent_id": target_agent_id,
+                        "file_path": target_file_path,
+                        "status": "FAILED",
+                        "reason": reason,
+                        "manifest": file_info,
+                    }
+                    siemplify.result.add_result_json(json_result)
+                    return output_message, "false", EXECUTION_STATE_FAILED
+        except zipfile.BadZipFile:
+            siemplify.LOGGER.info(f"Skipping activity {activity_id}: non-zip payload.")
+            continue
+
+    state["activities_seen"] = activities_seen
+    output_message = f"Acquisition for file '{target_file_path}' is still in progress on agent {target_agent_id}."
+    return output_message, json.dumps(state), EXECUTION_STATE_INPROGRESS
+
+
+@output_handler
+def main(is_first_run: bool = True) -> None:
+    siemplify = SiemplifyAction()
+    siemplify.script_name = f"{INTEGRATION_NAME} - {SCRIPT_NAME}"
+    siemplify.LOGGER.info("================= Main - Param Init =================")
+
+    # INIT INTEGRATION CONFIGURATION:
+    api_root = extract_configuration_param(
+        siemplify,
+        provider_name=INTEGRATION_NAME,
+        param_name="Api Root",
+        is_mandatory=True,
+        input_type=str,
+    )
+    username = extract_configuration_param(
+        siemplify,
+        provider_name=INTEGRATION_NAME,
+        param_name="Username",
+        is_mandatory=True,
+        input_type=str,
+    )
+    password = extract_configuration_param(
+        siemplify,
+        provider_name=INTEGRATION_NAME,
+        param_name="Password",
+        is_mandatory=True,
+        input_type=str,
+    )
+
+    agent_id_param = extract_action_param(
+        siemplify,
+        param_name="Agent ID",
+        is_mandatory=False,
+        input_type=str,
+        print_value=True,
+    )
+    file_path_param = extract_action_param(
+        siemplify,
+        param_name="File Path",
+        is_mandatory=bool(is_first_run),
+        input_type=str,
+        print_value=True,
+    )
+    password_param = extract_action_param(
+        siemplify,
+        param_name="Password",
+        is_mandatory=False,
+        input_type=str,
+        print_value=False,
+    )
+
+    status = EXECUTION_STATE_COMPLETED
+    output_message = ""
+    result_value = "false"
+
+    siemplify.LOGGER.info("----------------- Main - Started -----------------")
+
+    try:
+        manager = SentinelOneManager(api_root, username, password)
+
+        if is_first_run:
+            output_message, result_value, status = start_file_acquisition(
+                siemplify=siemplify,
+                manager=manager,
+                agent_id_param=agent_id_param,
+                file_path=file_path_param,
+                password=password_param,
+            )
+        else:
+            state_raw = extract_action_param(
+                siemplify,
+                param_name="additional_data",
+                default_value="{}",
+                is_mandatory=False,
+                input_type=str,
+            )
+            state = json.loads(state_raw or "{}")
+            if not state or not state.get("agent_id"):
+                raise ValueError("Missing or invalid 'additional_data' state for polling run.")
+
+            output_message, result_value, status = poll_file_acquisition(
+                siemplify=siemplify,
+                manager=manager,
+                state=state,
+            )
+    except Exception as e:
+        siemplify.LOGGER.exception(f"Failed to execute action! Error is {e}")
+        status = EXECUTION_STATE_FAILED
+        result_value = "false"
+        output_message = f"Failed to execute action! Error is {e}"
+
+    siemplify.LOGGER.info("----------------- Main - Finished -----------------")
+    siemplify.LOGGER.info(f"Status: {status}:")
+    siemplify.LOGGER.info(f"Result Value: {result_value}")
+    siemplify.LOGGER.info(f"Output Message: {output_message}")
+    siemplify.end(output_message, result_value, status)
+
+
+if __name__ == "__main__":
+    is_first_run = len(sys.argv) < 3 or sys.argv[2] == "True"
+    main(is_first_run)

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.yaml
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Acquire File
+description: Remotely acquire a file from an endpoint machine via SentinelOne API.
+documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone#acquire_file
+integration_identifier: SentinelOne
+parameters:
+-   name: Agent ID
+    default_value: ''
+    type: string
+    description: The ID or UUID of the agent to acquire the file from. If not provided, will resolve from target entities.
+    is_mandatory: false
+-   name: File Path
+    default_value: ''
+    type: string
+    description: Absolute file path on the endpoint machine to acquire (e.g. C:\windows\system32\notepad.exe or /tmp/malware.sh).
+    is_mandatory: true
+-   name: Password
+    default_value: ''
+    type: password
+    description: Optional password for encrypting the acquired zip archive. If left empty, a 15-character complex password is automatically generated.
+    is_mandatory: false
+dynamic_results_metadata:
+-   result_example_path: resources/AcquireFile_JsonResult_example.json
+    result_name: JsonResult
+    show_result: true
+creator: admin
+is_async: true
+simulation_data_json: '{"Entities": ["HOSTNAME", "ADDRESS"]}'
+script_result_name: is_success

--- a/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.py
+++ b/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from soar_sdk.SiemplifyUtils import output_handler
+from soar_sdk.SiemplifyAction import SiemplifyAction
+from ..core.SentinelOneManager import (
+    SentinelOneManager,
+    SentinelOneAgentNotFoundError,
+    SentinelOneManagerError,
+)
+from soar_sdk.SiemplifyUtils import flat_dict_to_csv
+
+# Consts.
+SENTINEL_ONE_PROVIDER = "SentinelOne"
+ACTION_NAME = "Check Containment Status"
+
+STATUS_MAPPING = {
+    "disconnected": "contained",
+    "disconnecting": "containment_requested",
+    "connecting": "uncontainment_requested",
+    "connected": "uncontained",
+}
+
+
+@output_handler
+def main():
+    siemplify = SiemplifyAction()
+    conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
+    sentinel_one_manager = SentinelOneManager(conf["Api Root"], conf["Username"], conf["Password"])
+
+    agent_id = siemplify.extract_action_param("Agent ID", is_mandatory=True)
+
+    result_value = False
+    json_result = {
+        "endpoint_containment_status": {
+            agent_id: {
+                "status": "unknown",
+                "reason": None,
+            }
+        }
+    }
+
+    try:
+        raw_status = sentinel_one_manager.get_agent_network_status(agent_id)
+        containment_status = STATUS_MAPPING.get(raw_status.lower(), "unknown")
+
+        json_result["endpoint_containment_status"][agent_id]["status"] = containment_status
+
+        if containment_status != "unknown":
+            result_value = True
+            output_message = f"Containment status for agent {agent_id}: {containment_status}"
+        else:
+            output_message = f"Could not determine containment status for agent {agent_id} (raw status: {raw_status})."
+
+        siemplify.result.add_data_table(
+            "Containment Statuses",
+            flat_dict_to_csv({agent_id: containment_status}),
+        )
+
+    except Exception as err:
+        output_message = f"Error executing action '{ACTION_NAME}'. Reason: {err}"
+        json_result["endpoint_containment_status"][agent_id]["status"] = "unknown"
+        json_result["endpoint_containment_status"][agent_id]["reason"] = str(err)
+        siemplify.result.add_data_table(
+            "Unsuccessful Attempts",
+            flat_dict_to_csv({agent_id: str(err)}),
+        )
+
+    siemplify.result.add_result_json(json_result)
+    siemplify.end(output_message, result_value)
+
+
+if __name__ == "__main__":
+    main()

--- a/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.yaml
+++ b/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.yaml
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Reconnect Agent To The Network
-description: Reconnect a disconnected agent to the network
-documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone#reconnect_agent_to_the_network
+name: Check Containment Status
+description: Check the network containment status of an endpoint in SentinelOne
+documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone#check_containment_status
 integration_identifier: SentinelOne
 parameters:
 -   name: Agent ID
     type: string
-    description: The unique identifier (UUID/ID) of the SentinelOne agent to reconnect to the network. If not provided, the action falls back to reconnecting matching target entities (IP/hostname).
-    is_mandatory: false
-dynamic_results_metadata: []
+    description: The ID or UUID of the agent to check containment status for.
+    is_mandatory: true
+dynamic_results_metadata:
+-   result_example_path: resources/CheckContainmentStatus_JsonResult_example.json
+    result_name: JsonResult
+    show_result: true
 creator: admin
-simulation_data_json: '{"Entities": ["HOSTNAME", "ADDRESS"]}'
+

--- a/content/response_integrations/google/sentinel_one/actions/DisconnectAgentFromNetwork.py
+++ b/content/response_integrations/google/sentinel_one/actions/DisconnectAgentFromNetwork.py
@@ -35,9 +35,21 @@ def main():
     # Configuration.
     siemplify = SiemplifyAction()
     conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
-    sentinel_one_manager = SentinelOneManager(
-        conf["Api Root"], conf["Username"], conf["Password"]
-    )
+    sentinel_one_manager = SentinelOneManager(conf["Api Root"], conf["Username"], conf["Password"])
+
+    agent_id = siemplify.parameters.get("Agent ID")
+    if agent_id:
+        agent_id = agent_id.strip()
+
+    if agent_id:
+        action_status = sentinel_one_manager.disconnect_agent_from_network(agent_id)
+        if action_status:
+            result_value = True
+            output_message = f"Agent {agent_id} was disconnected from the network."
+        else:
+            output_message = f"Failed to disconnect agent {agent_id} from the network."
+        siemplify.end(output_message, result_value)
+        return
 
     # Get scope entities.
     scope_entities = [
@@ -52,13 +64,9 @@ def main():
         try:
             # Get endpoint agent id.
             if entity.entity_type == ADDRESS:
-                agent_id = sentinel_one_manager.find_endpoint_agent_id(
-                    entity.identifier, by_ip_address=True
-                )
+                agent_id = sentinel_one_manager.find_endpoint_agent_id(entity.identifier, by_ip_address=True)
             else:
-                agent_id = sentinel_one_manager.find_endpoint_agent_id(
-                    entity.identifier
-                )
+                agent_id = sentinel_one_manager.find_endpoint_agent_id(entity.identifier)
 
             action_status = sentinel_one_manager.disconnect_agent_from_network(agent_id)
         except SentinelOneAgentNotFoundError as err:
@@ -70,7 +78,7 @@ def main():
 
     # Form output message.
     if entities_successed:
-        output_message = f'The following entities were disconnected from the network: {",".join([entity.identifier for entity in entities_successed])}'
+        output_message = f"The following entities were disconnected from the network: {','.join([entity.identifier for entity in entities_successed])}"
     else:
         output_message = "No target entities were disconnected from the network."
 

--- a/content/response_integrations/google/sentinel_one/actions/DisconnectAgentFromNetwork.yaml
+++ b/content/response_integrations/google/sentinel_one/actions/DisconnectAgentFromNetwork.yaml
@@ -16,7 +16,11 @@ name: Disconnect Agent From Network
 description: Disconnect agent from network connection
 documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone#disconnect_agent_from_network
 integration_identifier: SentinelOne
-parameters: []
+parameters:
+-   name: Agent ID
+    type: string
+    description: The unique identifier (UUID/ID) of the SentinelOne agent to disconnect from the network. If not provided, the action falls back to disconnecting matching target entities (IP/hostname).
+    is_mandatory: false
 dynamic_results_metadata: []
 creator: admin
 simulation_data_json: '{"Entities": ["HOSTNAME", "ADDRESS"]}'

--- a/content/response_integrations/google/sentinel_one/actions/ReconnectAgentToTheNetwork.py
+++ b/content/response_integrations/google/sentinel_one/actions/ReconnectAgentToTheNetwork.py
@@ -35,9 +35,21 @@ def main():
     # Configuration.
     siemplify = SiemplifyAction()
     conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
-    sentinel_one_manager = SentinelOneManager(
-        conf["Api Root"], conf["Username"], conf["Password"]
-    )
+    sentinel_one_manager = SentinelOneManager(conf["Api Root"], conf["Username"], conf["Password"])
+
+    agent_id = siemplify.parameters.get("Agent ID")
+    if agent_id:
+        agent_id = agent_id.strip()
+
+    if agent_id:
+        action_status = sentinel_one_manager.reconnect_agent_to_network(agent_id)
+        if action_status:
+            result_value = True
+            output_message = f"Agent {agent_id} was reconnected to the network."
+        else:
+            output_message = f"Failed to reconnect agent {agent_id} to the network."
+        siemplify.end(output_message, result_value)
+        return
 
     # Get scope entities.
     scope_entities = [
@@ -51,13 +63,9 @@ def main():
         try:
             # Get endpoint agent id.
             if entity.entity_type == ADDRESS:
-                agent_id = sentinel_one_manager.find_endpoint_agent_id(
-                    entity.identifier, by_ip_address=True
-                )
+                agent_id = sentinel_one_manager.find_endpoint_agent_id(entity.identifier, by_ip_address=True)
             else:
-                agent_id = sentinel_one_manager.find_endpoint_agent_id(
-                    entity.identifier
-                )
+                agent_id = sentinel_one_manager.find_endpoint_agent_id(entity.identifier)
 
             action_status = sentinel_one_manager.reconnect_agent_to_network(agent_id)
 
@@ -69,7 +77,7 @@ def main():
 
     # Form output message.
     if entities_successed:
-        output_message = f'The following entities were reconnected from the network: {",".join([entity.identifier for entity in entities_successed])}'
+        output_message = f"The following entities were reconnected from the network: {','.join([entity.identifier for entity in entities_successed])}"
     else:
         output_message = "No target entities were reconnected from the network."
 

--- a/content/response_integrations/google/sentinel_one/core/SentinelOneManager.py
+++ b/content/response_integrations/google/sentinel_one/core/SentinelOneManager.py
@@ -34,9 +34,11 @@
 #              IMPORTS                #
 # =====================================
 from __future__ import annotations
-import requests
-import urllib.parse
+
 import copy
+import urllib.parse
+
+import requests
 
 # =====================================
 #               CONSTS                #
@@ -61,14 +63,13 @@ GET_THREATS_BY_ENDPOINT_URL = "web/api/v1.6/threats"
 GET_REPORTS_URL = "web/api/v1.6/reports"
 GET_APPLICATIONS_URL = "web/api/v1.6/agents/{0}/applications"  # {0} - Agent ID.
 GET_EXCLUSION_LISTS_URLS = "web/api/v1.6/exclusion-lists"
-CREATE_PATH_IN_LIST_URL = (
-    "web/api/v1.6/exclusion-lists/{0}/folders"  # {0} - Exclusion List ID.
-)
+CREATE_PATH_IN_LIST_URL = "web/api/v1.6/exclusion-lists/{0}/folders"  # {0} - Exclusion List ID.
 RECONNECT_AGENT_NETWORK_URL = "web/api/v1.6/agents/{0}/connect"  # {0} - Agent ID.
-DISCONNECT_AGENT_FROM_NETWORK_URL = (
-    "web/api/v1.6/agents/{0}/disconnect"  # {0} - Agent ID.
-)
+DISCONNECT_AGENT_FROM_NETWORK_URL = "web/api/v1.6/agents/{0}/disconnect"  # {0} - Agent ID.
 FETCH_FILES_URL = "web/api/v1.6/agents/{0}/fetch-files"  # {0} - Agent ID.
+FETCH_FILES_V2_URL = "web/api/v2.1/agents/{0}/actions/fetch-files"  # {0} - Agent ID.
+GET_ACTIVITIES_V2_URL = "web/api/v2.1/activities"
+AGENT_FILE_UPLOAD_ACTIVITY_ID = "80"
 GET_AGENT_INFORMATION_URL = "web/api/v1.6/agents/{0}"  # {0} - Agent ID.
 
 # Parameters.
@@ -139,9 +140,7 @@ class SentinelOneManager:
         self.session = requests.session()
         self.token = self.get_token(username, password)
         self.session.headers = copy.deepcopy(HEADERS)
-        self.session.headers["Authorization"] = self.session.headers[
-            "Authorization"
-        ].format(self.token)
+        self.session.headers["Authorization"] = self.session.headers["Authorization"].format(self.token)
 
     def get_token(self, username, password):
         """
@@ -219,7 +218,8 @@ class SentinelOneManager:
             # Get agent id by host name.
             if not by_ip_address:
                 if agent["network_information"]["computer_name"] == identifier:
-                    # There are two types of requests when one takes uuid of the agent as an argument and the second Takes the id
+                    # There are two types of requests: one takes agent uuid
+                    # as argument, and the other takes agent id
                     if not get_uuid:
                         return agent["id"]
                     else:
@@ -234,9 +234,7 @@ class SentinelOneManager:
                             return agent["uuid"]
 
         # raise exception if agent not found.
-        raise SentinelOneAgentNotFoundError(
-            f"Not found agent id for endpoint: {identifier}"
-        )
+        raise SentinelOneAgentNotFoundError(f"Not found agent id for endpoint: {identifier}")
 
     def get_agent_operation_system(self, agent_id):
         """
@@ -245,9 +243,7 @@ class SentinelOneManager:
         :return: operation system name {string}
         """
 
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_AGENT_INFORMATION_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_AGENT_INFORMATION_URL.format(agent_id))
         response = self.session.get(request_url)
         self.validate_response(response)
         agent_data = response.json()
@@ -293,9 +289,7 @@ class SentinelOneManager:
         :param agent_id: endpoint agent id {string}
         :return: {boolean} weather agent is alive or not
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_AGENT_INFORMATION_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_AGENT_INFORMATION_URL.format(agent_id))
         response = self.session.get(request_url)
         self.validate_response(response)
         # Return agent status.
@@ -373,9 +367,7 @@ class SentinelOneManager:
         :param csv_output: output returned as csv {bool}
         :return: list of dicts when each dict is a data about a process on the endpoint {dict}
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_AGENT_PROCESSES_LIST_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_AGENT_PROCESSES_LIST_URL.format(agent_id))
         response = self.session.get(request_url)
         self.validate_response(response)
 
@@ -383,9 +375,7 @@ class SentinelOneManager:
             return self.list_of_dicts_to_csv(response.json())
         return response.json()
 
-    def get_events_for_endpoint_by_date(
-        self, agent_uuid, from_date, to_date, limit=100, csv_output=False
-    ):
+    def get_events_for_endpoint_by_date(self, agent_uuid, from_date, to_date, limit=100, csv_output=False):
         """
         get events for endpoint by date.
         :param agent_uuid: endpoint agent uuid {string}
@@ -406,9 +396,7 @@ class SentinelOneManager:
         params["token"] = self.token
         params["limit"] = limit
 
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_EVENTS_FOR_ENDPOINT_URL.format(agent_uuid)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_EVENTS_FOR_ENDPOINT_URL.format(agent_uuid))
         response = self.session.post(request_url, params=params)
         self.validate_response(response)
 
@@ -422,9 +410,7 @@ class SentinelOneManager:
         :param file_hash: file hash {string}
         :return: file hash reputation data {dict}
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_HASH_REPUTATION_URL.format(file_hash)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_HASH_REPUTATION_URL.format(file_hash))
         response = self.session.get(request_url)
         self.validate_response(response)
         return response.json()
@@ -435,9 +421,7 @@ class SentinelOneManager:
         :param file_hash: file hash {string}
         :return: file hash data {dict}
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_HASH_DATA_URL.format(file_hash)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_HASH_DATA_URL.format(file_hash))
         response = self.session.get(request_url)
         self.validate_response(response)
         return response.json()
@@ -449,12 +433,34 @@ class SentinelOneManager:
         :return: endpoint system information {dict}
         """
 
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_ENDPOINT_SYSTEM_INFO_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_ENDPOINT_SYSTEM_INFO_URL.format(agent_id))
         response = self.session.get(request_url)
         self.validate_response(response)
         return response.json()
+
+    def get_agent_network_status(self, agent_id: str) -> str:
+        """
+        Get network containment status for an endpoint agent.
+        :param agent_id: endpoint agent id {string}
+        :return: network status {string}
+        """
+        agent_data = self.get_endpoint_system_information(agent_id)
+        if isinstance(agent_data, dict):
+            data = agent_data.get("data", agent_data)
+            if isinstance(data, list) and data:
+                data = data[0]
+            if isinstance(data, dict):
+                if data.get("networkStatus"):
+                    return str(data["networkStatus"]).lower()
+                if data.get("network_status"):
+                    return str(data["network_status"]).lower()
+                net_info = data.get("network_information", {})
+                if isinstance(net_info, dict):
+                    if net_info.get("network_status"):
+                        return str(net_info["network_status"]).lower()
+                    if net_info.get("networkStatus"):
+                        return str(net_info["networkStatus"]).lower()
+        return "unknown"
 
     def get_server_settings(self):
         """
@@ -503,9 +509,7 @@ class SentinelOneManager:
         :param csv_output: output returned as csv {bool}
         :return: endpoint system information {dict}
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, GET_APPLICATIONS_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, GET_APPLICATIONS_URL.format(agent_id))
         response = self.session.get(request_url)
         self.validate_response(response)
 
@@ -525,9 +529,7 @@ class SentinelOneManager:
         list_id = self.get_exclusion_list_id_by_name(list_name)
 
         if list_id:
-            request_url = urllib.parse.urljoin(
-                self.api_root, CREATE_PATH_IN_LIST_URL.format(list_id)
-            )
+            request_url = urllib.parse.urljoin(self.api_root, CREATE_PATH_IN_LIST_URL.format(list_id))
 
             # Organize payload.
             payload = copy.deepcopy(CREATE_PATH_IN_LIST_PAYLOAD)
@@ -546,9 +548,7 @@ class SentinelOneManager:
         :param agent_id: endpoint agent id {string}
         :return: is success {bool}
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, RECONNECT_AGENT_NETWORK_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, RECONNECT_AGENT_NETWORK_URL.format(agent_id))
         response = self.session.post(request_url)
         self.validate_response(response)
         return True
@@ -559,14 +559,12 @@ class SentinelOneManager:
         :param agent_id: endpoint agent id {string}
         :return: is success {bool}
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, DISCONNECT_AGENT_FROM_NETWORK_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, DISCONNECT_AGENT_FROM_NETWORK_URL.format(agent_id))
         response = self.session.post(request_url)
         self.validate_response(response)
         return True
 
-    # Still not complete for API problem reasons.
+    # Still not complete for API problem reasons (v1.6).
     def fetch_files_for_agent(self, agent_id, zip_password, files=[]):
         """
         Fetch files from endpoint machines and allows to download the files through the Siemplify client.
@@ -575,9 +573,7 @@ class SentinelOneManager:
         :param files: list of strings which are the file names to fetch {list}
         :return:
         """
-        request_url = urllib.parse.urljoin(
-            self.api_root, FETCH_FILES_URL.format(agent_id)
-        )
+        request_url = urllib.parse.urljoin(self.api_root, FETCH_FILES_URL.format(agent_id))
 
         # Organize payload.
         payload = copy.deepcopy(FETCH_FILES_PAYLOAD)
@@ -586,6 +582,58 @@ class SentinelOneManager:
 
         response = self.session.post(request_url, json=payload)
         self.validate_response(response)
+
+    def fetch_files(self, agent_id, file_path, password):
+        """
+        Initiate file fetch on an endpoint agent via SentinelOne API v2.1.
+        :param agent_id: endpoint agent id or uuid {string}
+        :param file_path: absolute file path to acquire {string}
+        :param password: password for the zip archive {string}
+        :return: response JSON data {dict}
+        """
+        request_url = urllib.parse.urljoin(self.api_root, FETCH_FILES_V2_URL.format(agent_id))
+        payload = {"data": {"files": [file_path], "password": password}}
+        response = self.session.post(request_url, json=payload)
+        self.validate_response(response)
+        return response.json().get("data", {})
+
+    def get_file_upload_activities(self, agent_id, created_at_gte=None):
+        """
+        Get file upload activities (type 80) for an agent via SentinelOne API v2.1.
+        :param agent_id: endpoint agent id {string}
+        :param created_at_gte: ISO timestamp string for activity filter {string}
+        :return: list of activity dicts {list}
+        """
+        request_url = urllib.parse.urljoin(self.api_root, GET_ACTIVITIES_V2_URL)
+        params = {
+            "activity_types": AGENT_FILE_UPLOAD_ACTIVITY_ID,
+            "agent_ids": agent_id,
+            "sortBy": "createdAt",
+            "sortOrder": "desc",
+        }
+        if created_at_gte:
+            params["createdAt__gte"] = created_at_gte
+        response = self.session.get(request_url, params=params)
+        self.validate_response(response)
+        return response.json().get("data", [])
+
+    def download_file_by_url(self, download_url):
+        """
+        Download file content from download URL.
+        :param download_url: relative or absolute download URL {string}
+        :return: raw response content bytes {bytes}
+        """
+        if not download_url.startswith("http"):
+            if not download_url.startswith("/"):
+                download_url = f"/{download_url}"
+            if not download_url.startswith("/web/api/v2.1"):
+                download_url = f"/web/api/v2.1{download_url}"
+            request_url = urllib.parse.urljoin(self.api_root, download_url.lstrip("/"))
+        else:
+            request_url = download_url
+        response = self.session.get(request_url, stream=True)
+        self.validate_response(response)
+        return response.content
 
 
 #

--- a/content/response_integrations/google/sentinel_one/definition.yaml
+++ b/content/response_integrations/google/sentinel_one/definition.yaml
@@ -33,6 +33,12 @@ parameters:
     description: ''
     is_mandatory: true
     integration_identifier: SentinelOne
+-   name: Verify SSL
+    default_value: true
+    type: boolean
+    description: ''
+    is_mandatory: true
+    integration_identifier: SentinelOne
 documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone
 categories:
 - Endpoint Security

--- a/content/response_integrations/google/sentinel_one/pyproject.toml
+++ b/content/response_integrations/google/sentinel_one/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "SentinelOne"
-version = "6.0"
+version = "7.0"
 description = "Endpoint security software that defends every endpoint against every type of attack, at every stage in the threat lifecycle."
 requires-python = ">=3.11,<3.12"
 dependencies = [ "requests==2.32.5"]

--- a/content/response_integrations/google/sentinel_one/release_notes.yaml
+++ b/content/response_integrations/google/sentinel_one/release_notes.yaml
@@ -63,3 +63,14 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: Added Check Containment Status action, Acquire File async action, Verify SSL integration parameter, and direct Agent ID support to Disconnect Agent From Network and Reconnect Agent To The Network actions.
+  version: 7.0
+  item_name: SentinelOne
+  item_type: Integration
+  publish_time: '2026-08-25'
+  ticket_number: '549763652'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false
+

--- a/content/response_integrations/google/sentinel_one/resources/AcquireFile_JsonResult_example.json
+++ b/content/response_integrations/google/sentinel_one/resources/AcquireFile_JsonResult_example.json
@@ -1,0 +1,24 @@
+{
+    "agent_id": "1408058725825465258",
+    "file_path": "/tmp/evidence.exe",
+    "zip_password": "MySecretPass123!",
+    "status": "COMPLETED",
+    "file_name": "evidence.exe",
+    "md5": "59c69a255e6644742a3d53b3c812e6f4",
+    "sha256": "e07de43f41be605fa33395e4ce97963793e9782ff8f6809e525273d6b4562a9b",
+    "sha1": "41fc085bdb1ac53dbfd274f4ee91a38778ad70e0",
+    "size": 139680,
+    "manifest": {
+        "path": "/tmp/evidence.exe",
+        "name": "evidence.exe",
+        "included": true,
+        "reason": "OK",
+        "size": 139680,
+        "sha1": "41fc085bdb1ac53dbfd274f4ee91a38778ad70e0",
+        "sha256": "e07de43f41be605fa33395e4ce97963793e9782ff8f6809e525273d6b4562a9b"
+    },
+    "created_at": "2026-08-21T18:45:00.000000Z",
+    "completed_at": "2026-08-21T18:46:30.000000Z",
+    "download_path": "/tmp/1408058725825465258_evidence.zip",
+    "local_package_file": "/tmp/1408058725825465258_evidence.zip"
+}

--- a/content/response_integrations/google/sentinel_one/resources/CheckContainmentStatus_JsonResult_example.json
+++ b/content/response_integrations/google/sentinel_one/resources/CheckContainmentStatus_JsonResult_example.json
@@ -1,0 +1,8 @@
+{
+  "endpoint_containment_status": {
+    "1234567890": {
+      "status": "contained",
+      "reason": null
+    }
+  }
+}

--- a/content/response_integrations/google/sentinel_one/tests/config.json
+++ b/content/response_integrations/google/sentinel_one/tests/config.json
@@ -1,0 +1,6 @@
+{
+    "Api Root": "https://{server}.sentinelone.net/",
+    "Username": "",
+    "Password": "",
+    "Verify SSL": true
+}

--- a/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
@@ -1,0 +1,518 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from unittest import mock
+
+import pytest
+from soar_sdk.ScriptResult import (
+    EXECUTION_STATE_COMPLETED,
+    EXECUTION_STATE_FAILED,
+    EXECUTION_STATE_INPROGRESS,
+)
+from soar_sdk.SiemplifyDataModel import EntityTypes
+
+from ..actions import AcquireFile
+from ..actions.AcquireFile import (
+    BadZipPasswordError,
+    generate_password,
+    get_acquired_file_info,
+    main,
+    process_acquired_file_bytes,
+    resolve_agent_id,
+)
+from ..core.SentinelOneManager import (
+    SentinelOneAgentNotFoundError,
+    SentinelOneManager,
+)
+
+
+def create_test_zip_package(
+    file_path: str,
+    file_name: str,
+    content: bytes,
+    password: str = "TestPassword123!",
+    included: bool = True,
+    reason: str = "OK",
+) -> bytes:
+    """Helper to construct an in-memory ZIP package matching SentinelOne format."""
+    manifest = [
+        {
+            "path": file_path,
+            "name": file_name,
+            "included": included,
+            "reason": reason,
+            "size": len(content),
+            "sha1": hashlib.sha1(content).hexdigest(),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+    ]
+    manifest_bytes = json.dumps(manifest).encode("utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr("manifest.json", manifest_bytes)
+        if included:
+            zipf.writestr(file_name, content)
+
+    return buf.getvalue()
+
+
+class MockEntity:
+    def __init__(self, identifier: str, entity_type: str):
+        self.identifier = identifier
+        self.entity_type = entity_type
+
+
+class TestAcquireFileHelpers:
+    def test_generate_password_complexity(self):
+        pwd = generate_password()
+        assert len(pwd) == 15
+        assert any(c.islower() for c in pwd)
+        assert any(c.isupper() for c in pwd)
+        assert any(c.isdigit() for c in pwd)
+        assert any(not c.isalnum() for c in pwd)
+
+    def test_resolve_agent_id_from_param(self):
+        mock_siemplify = mock.MagicMock()
+        mock_manager = mock.MagicMock()
+        res = resolve_agent_id(mock_siemplify, mock_manager, "agent-123")
+        assert res == "agent-123"
+
+    def test_resolve_agent_id_from_entity(self):
+        mock_siemplify = mock.MagicMock()
+        mock_siemplify.target_entities = [MockEntity("host-1", EntityTypes.HOSTNAME)]
+        mock_manager = mock.MagicMock()
+        mock_manager.find_endpoint_agent_id.return_value = 998877
+
+        res = resolve_agent_id(mock_siemplify, mock_manager, None)
+        assert res == "998877"
+        mock_manager.find_endpoint_agent_id.assert_called_once_with("host-1", by_ip_address=False)
+
+    def test_resolve_agent_id_from_ip_entity(self):
+        mock_siemplify = mock.MagicMock()
+        mock_siemplify.target_entities = [MockEntity("10.0.0.1", EntityTypes.ADDRESS)]
+        mock_manager = mock.MagicMock()
+        mock_manager.find_endpoint_agent_id.return_value = 112233
+
+        res = resolve_agent_id(mock_siemplify, mock_manager, "")
+        assert res == "112233"
+        mock_manager.find_endpoint_agent_id.assert_called_once_with("10.0.0.1", by_ip_address=True)
+
+    def test_resolve_agent_id_not_found(self):
+        mock_siemplify = mock.MagicMock()
+        mock_siemplify.target_entities = [MockEntity("unknown-host", EntityTypes.HOSTNAME)]
+        mock_manager = mock.MagicMock()
+        mock_manager.find_endpoint_agent_id.side_effect = SentinelOneAgentNotFoundError("Not found")
+
+        res = resolve_agent_id(mock_siemplify, mock_manager, None)
+        assert res is None
+
+    def test_get_acquired_file_info_success(self):
+        zip_bytes = create_test_zip_package("/tmp/test.exe", "test.exe", b"test content")
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            info, manifest = get_acquired_file_info(zipf, "/tmp/test.exe")
+            assert info["path"] == "/tmp/test.exe"
+            assert info["included"] is True
+
+    def test_get_acquired_file_info_fallback_single_file(self):
+        zip_bytes = create_test_zip_package("C:\\path\\file.txt", "file.txt", b"test content")
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            info, manifest = get_acquired_file_info(zipf, "/other/path/file.txt")
+            assert info["name"] == "file.txt"
+
+    def test_get_acquired_file_info_bad_password(self):
+        zip_bytes = create_test_zip_package("/tmp/test.exe", "test.exe", b"test content")
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            with mock.patch.object(
+                zipf,
+                "read",
+                side_effect=RuntimeError("Bad password for file: manifest.json"),
+            ):
+                with pytest.raises(BadZipPasswordError):
+                    get_acquired_file_info(zipf, "/tmp/test.exe")
+
+    def test_process_acquired_file_bytes(self):
+        content = b"sample binary payload"
+        zip_bytes = create_test_zip_package("/tmp/test.bin", "test.bin", content)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            fname, md5_val, sha256_val, size = process_acquired_file_bytes(zipf)
+            assert fname == "test.bin"
+            assert md5_val == hashlib.md5(content).hexdigest()
+            assert sha256_val == hashlib.sha256(content).hexdigest()
+            assert size == len(content)
+
+    def test_process_acquired_file_bytes_manifest_only(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.writestr("manifest.json", b"[]")
+        with zipfile.ZipFile(buf) as zipf:
+            fname, md5_val, sha256_val, size = process_acquired_file_bytes(zipf)
+            assert fname == ""
+            assert md5_val == ""
+            assert size == 0
+
+
+class TestAcquireFileAction:
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "fetch_files")
+    def test_first_run_success_auto_password(self, mock_fetch, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "Agent ID": "123456",
+            "File Path": "/tmp/malware.exe",
+            "Password": None,
+        }
+
+        main(is_first_run=True)
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args[1]
+        assert call_args["agent_id"] == "123456"
+        assert call_args["file_path"] == "/tmp/malware.exe"
+        assert len(call_args["password"]) == 15
+
+        mock_siemplify.end.assert_called_once()
+        msg, state_json, state = mock_siemplify.end.call_args[0]
+        assert state == EXECUTION_STATE_INPROGRESS
+        parsed_state = json.loads(state_json)
+        assert parsed_state["agent_id"] == "123456"
+        assert parsed_state["file_path"] == "/tmp/malware.exe"
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "fetch_files")
+    def test_first_run_custom_password(self, mock_fetch, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "Agent ID": "agent_uuid_123",
+            "File Path": "C:\\Windows\\System32\\calc.exe",
+            "Password": "CustomSecret123!",
+        }
+
+        main(is_first_run=True)
+
+        mock_fetch.assert_called_once_with(
+            agent_id="agent_uuid_123",
+            file_path="C:\\Windows\\System32\\calc.exe",
+            password="CustomSecret123!",
+        )
+        assert mock_siemplify.end.call_args[0][2] == EXECUTION_STATE_INPROGRESS
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def test_first_run_invalid_relative_path(self, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "Agent ID": "123456",
+            "File Path": "relative_file.txt",
+            "Password": None,
+        }
+
+        main(is_first_run=True)
+
+        mock_siemplify.end.assert_called_once()
+        _, _, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def test_first_run_no_agent_id(self, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.target_entities = []
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "Agent ID": None,
+            "File Path": "/tmp/test.exe",
+            "Password": None,
+        }
+
+        main(is_first_run=True)
+
+        mock_siemplify.end.assert_called_once()
+        _, _, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    def test_polling_in_progress(self, mock_activities, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps({
+                "agent_id": "123456",
+                "file_path": "/tmp/test.exe",
+                "password": "Password123!",
+                "created_at": "2026-08-21T18:00:00Z",
+                "activities_seen": [],
+            })
+        }
+
+        mock_activities.return_value = []
+
+        main(is_first_run=False)
+
+        mock_activities.assert_called_once_with(agent_id="123456", created_at_gte="2026-08-21T18:00:00Z")
+        mock_siemplify.end.assert_called_once()
+        msg, state_json, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_INPROGRESS
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def test_polling_missing_additional_data(self, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {"additional_data": "{}"}
+
+        main(is_first_run=False)
+
+        mock_siemplify.end.assert_called_once()
+        _, _, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    @mock.patch.object(SentinelOneManager, "download_file_by_url")
+    def test_polling_completed_success(
+        self,
+        mock_download,
+        mock_activities,
+        mock_token,
+        mock_siemplify_cls,
+    ):
+        password = "SecretPass123!"
+        content = b"executable payload binary"
+        zip_bytes = create_test_zip_package("/tmp/test.exe", "test.exe", content, password)
+
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps({
+                "agent_id": "123456",
+                "file_path": "/tmp/test.exe",
+                "password": password,
+                "created_at": "2026-08-21T18:00:00Z",
+                "activities_seen": [],
+            })
+        }
+
+        mock_activities.return_value = [
+            {
+                "id": "act-101",
+                "data": {"downloadUrl": "/activities/download-file?download_url=act-101"},
+            }
+        ]
+        mock_download.return_value = zip_bytes
+
+        main(is_first_run=False)
+
+        mock_siemplify.result.add_result_json.assert_called_once()
+        result_json = mock_siemplify.result.add_result_json.call_args[0][0]
+        assert result_json["status"] == "COMPLETED"
+        assert result_json["file_path"] == "/tmp/test.exe"
+        assert result_json["md5"] == hashlib.md5(content).hexdigest()
+        assert result_json["sha256"] == hashlib.sha256(content).hexdigest()
+        assert "download_path" in result_json
+        assert result_json["download_path"].endswith(".zip")
+        assert result_json["local_package_file"].endswith(".zip")
+
+        mock_siemplify.end.assert_called_once()
+        msg, is_success, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_COMPLETED
+        assert is_success == "true"
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    @mock.patch.object(SentinelOneManager, "download_file_by_url")
+    def test_polling_file_not_included(
+        self,
+        mock_download,
+        mock_activities,
+        mock_token,
+        mock_siemplify_cls,
+    ):
+        password = "SecretPass123!"
+        zip_bytes = create_test_zip_package(
+            "/tmp/missing.exe",
+            "missing.exe",
+            b"",
+            password,
+            included=False,
+            reason="File permission denied",
+        )
+
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps({
+                "agent_id": "123456",
+                "file_path": "/tmp/missing.exe",
+                "password": password,
+                "created_at": "2026-08-21T18:00:00Z",
+                "activities_seen": [],
+            })
+        }
+
+        mock_activities.return_value = [{"id": "act-102", "data": {"downloadUrl": "/download/102"}}]
+        mock_download.return_value = zip_bytes
+
+        main(is_first_run=False)
+
+        mock_siemplify.result.add_result_json.assert_called_once()
+        result_json = mock_siemplify.result.add_result_json.call_args[0][0]
+        assert result_json["status"] == "FAILED"
+        assert result_json["reason"] == "File permission denied"
+
+        mock_siemplify.end.assert_called_once()
+        msg, is_success, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+        assert is_success == "false"
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    @mock.patch.object(SentinelOneManager, "download_file_by_url")
+    def test_polling_skip_bad_password_and_corrupt_zip(
+        self,
+        mock_download,
+        mock_activities,
+        mock_token,
+        mock_siemplify_cls,
+    ):
+        password = "TargetPassword123!"
+        good_content = b"valid file"
+        good_zip = create_test_zip_package("/tmp/target.exe", "target.exe", good_content, password)
+
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps({
+                "agent_id": "123456",
+                "file_path": "/tmp/target.exe",
+                "password": password,
+                "created_at": "2026-08-21T18:00:00Z",
+                "activities_seen": ["act-seen"],
+            })
+        }
+
+        mock_activities.return_value = [
+            {"id": "act-seen", "data": {"downloadUrl": "/download/seen"}},
+            {"id": "act-corrupt", "data": {"downloadUrl": "/download/corrupt"}},
+            {"id": "act-good", "data": {"downloadUrl": "/download/good"}},
+        ]
+
+        def download_side_effect(url: str) -> bytes:
+            if "corrupt" in url:
+                return b"corrupted not a zip"
+            return good_zip
+
+        mock_download.side_effect = download_side_effect
+
+        main(is_first_run=False)
+
+        mock_siemplify.end.assert_called_once()
+        msg, is_success, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_COMPLETED
+        assert is_success == "true"
+
+
+class TestSentinelOneManagerAcquisitionMethods:
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="mock_token")
+    def test_manager_fetch_files(self, mock_token):
+        manager = SentinelOneManager("https://test.sentinelone.net", "user", "pass")
+        with mock.patch.object(manager.session, "post") as mock_post:
+            mock_post.return_value.json.return_value = {"data": {"success": True}}
+            mock_post.return_value.status_code = 200
+
+            res = manager.fetch_files("agent_1", "/tmp/file.txt", "Pass123!")
+            assert res == {"success": True}
+            mock_post.assert_called_once()
+            assert (
+                mock_post.call_args[0][0]
+                == "https://test.sentinelone.net/web/api/v2.1/agents/agent_1/actions/fetch-files"
+            )
+
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="mock_token")
+    def test_manager_get_file_upload_activities(self, mock_token):
+        manager = SentinelOneManager("https://test.sentinelone.net", "user", "pass")
+        with mock.patch.object(manager.session, "get") as mock_get:
+            mock_get.return_value.json.return_value = {"data": [{"id": 1, "data": {"downloadUrl": "/dl/1"}}]}
+            mock_get.return_value.status_code = 200
+
+            res = manager.get_file_upload_activities("agent_1", created_at_gte="2026-08-21T00:00:00Z")
+            assert len(res) == 1
+            assert res[0]["id"] == 1
+            params = mock_get.call_args[1]["params"]
+            assert params["activity_types"] == "80"
+            assert params["agent_ids"] == "agent_1"
+            assert params["createdAt__gte"] == "2026-08-21T00:00:00Z"
+
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="mock_token")
+    def test_manager_download_file_by_url(self, mock_token):
+        manager = SentinelOneManager("https://test.sentinelone.net", "user", "pass")
+        with mock.patch.object(manager.session, "get") as mock_get:
+            mock_get.return_value.content = b"zip_content_bytes"
+            mock_get.return_value.status_code = 200
+
+            content = manager.download_file_by_url("/download/act-1")
+            assert content == b"zip_content_bytes"
+            assert mock_get.call_args[0][0] == "https://test.sentinelone.net/web/api/v2.1/download/act-1"

--- a/content/response_integrations/google/sentinel_one/tests/test_check_containment_status.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_check_containment_status.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+import unittest
+
+from ..actions import CheckContainmentStatus as check_action_module
+from ..actions.CheckContainmentStatus import main
+from ..core.SentinelOneManager import (
+    SentinelOneAgentNotFoundError,
+    SentinelOneManager,
+)
+
+
+class TestSentinelOneManagerNetworkStatus(unittest.TestCase):
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def setUp(self, mock_get_token: mock.MagicMock) -> None:
+        self.manager = SentinelOneManager("https://test.sentinelone.net", "user", "pass")
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_snake_case(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"network_status": "disconnected"}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "disconnected"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_camel_case(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"networkStatus": "connected"}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "connected"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_nested_data_dict(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"data": {"network_status": "disconnecting"}}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "disconnecting"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_nested_data_list(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"data": [{"networkStatus": "connecting"}]}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "connecting"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_network_information(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"network_information": {"network_status": "disconnected"}}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "disconnected"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_unknown(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"os_name": "linux"}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "unknown"
+
+
+class TestCheckContainmentStatusAction(unittest.TestCase):
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_contained(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-001"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "disconnected"
+
+        main()
+
+        mock_manager.get_agent_network_status.assert_called_once_with("agent-uuid-001")
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-001": {
+                    "status": "contained",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.result.add_data_table.assert_called_once_with(
+            "Containment Statuses", ["Property, Value", "agent-uuid-001,contained"]
+        )
+        mock_siemplify.end.assert_called_once_with("Containment status for agent agent-uuid-001: contained", True)
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_uncontained(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-002"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "connected"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-002": {
+                    "status": "uncontained",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with("Containment status for agent agent-uuid-002: uncontained", True)
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_containment_requested(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-003"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "disconnecting"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-003": {
+                    "status": "containment_requested",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Containment status for agent agent-uuid-003: containment_requested", True
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_uncontainment_requested(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-004"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "connecting"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-004": {
+                    "status": "uncontainment_requested",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Containment status for agent agent-uuid-004: uncontainment_requested", True
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_unknown_status(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-005"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "some_random_status"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-005": {
+                    "status": "unknown",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Could not determine containment status for agent agent-uuid-005 (raw status: some_random_status).",
+            False,
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_agent_not_found(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "nonexistent-agent"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.side_effect = SentinelOneAgentNotFoundError("Agent not found")
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "nonexistent-agent": {
+                    "status": "unknown",
+                    "reason": "Agent not found",
+                }
+            }
+        })
+        mock_siemplify.result.add_data_table.assert_called_once_with(
+            "Unsuccessful Attempts", ["Property, Value", "nonexistent-agent,Agent not found"]
+        )
+        mock_siemplify.end.assert_called_once_with(
+            "Error executing action 'Check Containment Status'. Reason: Agent not found",
+            False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content/response_integrations/google/sentinel_one/tests/test_disconnect_agent.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_disconnect_agent.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+from soar_sdk.SiemplifyDataModel import EntityTypes
+
+from sentinel_one.actions import DisconnectAgentFromNetwork
+from sentinel_one.core.SentinelOneManager import SentinelOneAgentNotFoundError
+
+
+@dataclass
+class MockEntity:
+    identifier: str
+    entity_type: str
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_direct_agent_id_success(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "agent-12345"}
+    mock_siemplify.target_entities = []
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.disconnect_agent_from_network.return_value = True
+
+    DisconnectAgentFromNetwork.main()
+
+    mock_manager.disconnect_agent_from_network.assert_called_once_with("agent-12345")
+    mock_manager.find_endpoint_agent_id.assert_not_called()
+    mock_siemplify.end.assert_called_once_with("Agent agent-12345 was disconnected from the network.", True)
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_direct_agent_id_with_whitespace_and_bypass_entities(
+    mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock
+) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "  agent-12345  "}
+    mock_siemplify.target_entities = [
+        MockEntity("192.168.1.10", EntityTypes.ADDRESS),
+        MockEntity("workstation-01", EntityTypes.HOSTNAME),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.disconnect_agent_from_network.return_value = True
+
+    DisconnectAgentFromNetwork.main()
+
+    mock_manager.disconnect_agent_from_network.assert_called_once_with("agent-12345")
+    mock_manager.find_endpoint_agent_id.assert_not_called()
+    mock_siemplify.end.assert_called_once_with("Agent agent-12345 was disconnected from the network.", True)
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_direct_agent_id_failure(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "agent-12345"}
+    mock_siemplify.target_entities = []
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.disconnect_agent_from_network.return_value = False
+
+    DisconnectAgentFromNetwork.main()
+
+    mock_manager.disconnect_agent_from_network.assert_called_once_with("agent-12345")
+    mock_siemplify.end.assert_called_once_with("Failed to disconnect agent agent-12345 from the network.", False)
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_fallback_entity_success(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {}
+    mock_siemplify.target_entities = [
+        MockEntity("192.168.1.10", EntityTypes.ADDRESS),
+        MockEntity("workstation-01", EntityTypes.HOSTNAME),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.find_endpoint_agent_id.side_effect = ["id-1", "id-2"]
+    mock_manager.disconnect_agent_from_network.return_value = True
+
+    DisconnectAgentFromNetwork.main()
+
+    assert mock_manager.find_endpoint_agent_id.call_count == 2
+    mock_manager.find_endpoint_agent_id.assert_any_call("192.168.1.10", by_ip_address=True)
+    mock_manager.find_endpoint_agent_id.assert_any_call("workstation-01")
+    assert mock_manager.disconnect_agent_from_network.call_count == 2
+    mock_siemplify.end.assert_called_once_with(
+        "The following entities were disconnected from the network: 192.168.1.10,workstation-01",
+        True,
+    )
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_fallback_entity_partial_failure(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {}
+    mock_siemplify.target_entities = [
+        MockEntity("192.168.1.10", EntityTypes.ADDRESS),
+        MockEntity("unknown-host", EntityTypes.HOSTNAME),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.find_endpoint_agent_id.side_effect = [
+        "id-1",
+        SentinelOneAgentNotFoundError("Agent not found"),
+    ]
+    mock_manager.disconnect_agent_from_network.return_value = True
+
+    DisconnectAgentFromNetwork.main()
+
+    assert mock_manager.find_endpoint_agent_id.call_count == 2
+    mock_manager.find_endpoint_agent_id.assert_any_call("192.168.1.10", by_ip_address=True)
+    mock_manager.find_endpoint_agent_id.assert_any_call("unknown-host")
+    mock_manager.disconnect_agent_from_network.assert_called_once_with("id-1")
+    mock_siemplify.result.add_data_table.assert_called_once()
+    mock_siemplify.end.assert_called_once_with(
+        "The following entities were disconnected from the network: 192.168.1.10",
+        True,
+    )
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_fallback_entity_not_found(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {}
+    mock_siemplify.target_entities = [MockEntity("unknown-host", EntityTypes.HOSTNAME)]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.find_endpoint_agent_id.side_effect = SentinelOneAgentNotFoundError("Agent not found")
+
+    DisconnectAgentFromNetwork.main()
+
+    mock_siemplify.result.add_data_table.assert_called_once()
+    mock_siemplify.end.assert_called_once_with("No target entities were disconnected from the network.", False)
+
+
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.DisconnectAgentFromNetwork.SentinelOneManager")
+def test_disconnect_fallback_whitespace_param_no_matching_entities(
+    mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock
+) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "   "}
+    mock_siemplify.target_entities = [
+        MockEntity("admin@domain.com", EntityTypes.USER),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+
+    DisconnectAgentFromNetwork.main()
+
+    mock_manager.find_endpoint_agent_id.assert_not_called()
+    mock_manager.disconnect_agent_from_network.assert_not_called()
+    mock_siemplify.end.assert_called_once_with("No target entities were disconnected from the network.", False)

--- a/content/response_integrations/google/sentinel_one/tests/test_reconnect_agent.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_reconnect_agent.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+from soar_sdk.SiemplifyDataModel import EntityTypes
+
+from sentinel_one.actions import ReconnectAgentToTheNetwork
+from sentinel_one.core.SentinelOneManager import SentinelOneAgentNotFoundError
+
+
+@dataclass
+class MockEntity:
+    identifier: str
+    entity_type: str
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_direct_agent_id_success(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "agent-12345"}
+    mock_siemplify.target_entities = []
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.reconnect_agent_to_network.return_value = True
+
+    ReconnectAgentToTheNetwork.main()
+
+    mock_manager.reconnect_agent_to_network.assert_called_once_with("agent-12345")
+    mock_manager.find_endpoint_agent_id.assert_not_called()
+    mock_siemplify.end.assert_called_once_with("Agent agent-12345 was reconnected to the network.", True)
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_direct_agent_id_with_whitespace_and_bypass_entities(
+    mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock
+) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "  agent-12345  "}
+    mock_siemplify.target_entities = [
+        MockEntity("192.168.1.10", EntityTypes.ADDRESS),
+        MockEntity("workstation-01", EntityTypes.HOSTNAME),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.reconnect_agent_to_network.return_value = True
+
+    ReconnectAgentToTheNetwork.main()
+
+    mock_manager.reconnect_agent_to_network.assert_called_once_with("agent-12345")
+    mock_manager.find_endpoint_agent_id.assert_not_called()
+    mock_siemplify.end.assert_called_once_with("Agent agent-12345 was reconnected to the network.", True)
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_direct_agent_id_failure(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "agent-12345"}
+    mock_siemplify.target_entities = []
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.reconnect_agent_to_network.return_value = False
+
+    ReconnectAgentToTheNetwork.main()
+
+    mock_manager.reconnect_agent_to_network.assert_called_once_with("agent-12345")
+    mock_siemplify.end.assert_called_once_with("Failed to reconnect agent agent-12345 to the network.", False)
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_fallback_entity_success(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {}
+    mock_siemplify.target_entities = [
+        MockEntity("192.168.1.10", EntityTypes.ADDRESS),
+        MockEntity("workstation-01", EntityTypes.HOSTNAME),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.find_endpoint_agent_id.side_effect = ["id-1", "id-2"]
+    mock_manager.reconnect_agent_to_network.return_value = True
+
+    ReconnectAgentToTheNetwork.main()
+
+    assert mock_manager.find_endpoint_agent_id.call_count == 2
+    mock_manager.find_endpoint_agent_id.assert_any_call("192.168.1.10", by_ip_address=True)
+    mock_manager.find_endpoint_agent_id.assert_any_call("workstation-01")
+    assert mock_manager.reconnect_agent_to_network.call_count == 2
+    mock_siemplify.end.assert_called_once_with(
+        "The following entities were reconnected from the network: 192.168.1.10,workstation-01",
+        True,
+    )
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_fallback_entity_partial_failure(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {}
+    mock_siemplify.target_entities = [
+        MockEntity("192.168.1.10", EntityTypes.ADDRESS),
+        MockEntity("unknown-host", EntityTypes.HOSTNAME),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.find_endpoint_agent_id.side_effect = [
+        "id-1",
+        SentinelOneAgentNotFoundError("Agent not found"),
+    ]
+    mock_manager.reconnect_agent_to_network.return_value = True
+
+    ReconnectAgentToTheNetwork.main()
+
+    assert mock_manager.find_endpoint_agent_id.call_count == 2
+    mock_manager.find_endpoint_agent_id.assert_any_call("192.168.1.10", by_ip_address=True)
+    mock_manager.find_endpoint_agent_id.assert_any_call("unknown-host")
+    mock_manager.reconnect_agent_to_network.assert_called_once_with("id-1")
+    mock_siemplify.result.add_data_table.assert_called_once()
+    mock_siemplify.end.assert_called_once_with(
+        "The following entities were reconnected from the network: 192.168.1.10",
+        True,
+    )
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_fallback_entity_not_found(mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {}
+    mock_siemplify.target_entities = [MockEntity("unknown-host", EntityTypes.HOSTNAME)]
+
+    mock_manager = mock_manager_cls.return_value
+    mock_manager.find_endpoint_agent_id.side_effect = SentinelOneAgentNotFoundError("Agent not found")
+
+    ReconnectAgentToTheNetwork.main()
+
+    mock_siemplify.result.add_data_table.assert_called_once()
+    mock_siemplify.end.assert_called_once_with("No target entities were reconnected from the network.", False)
+
+
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SiemplifyAction")
+@patch("sentinel_one.actions.ReconnectAgentToTheNetwork.SentinelOneManager")
+def test_reconnect_fallback_whitespace_param_no_matching_entities(
+    mock_manager_cls: MagicMock, mock_siemplify_cls: MagicMock
+) -> None:
+    mock_siemplify = mock_siemplify_cls.return_value
+    mock_siemplify.get_configuration.return_value = {
+        "Api Root": "https://example.sentinelone.net",
+        "Username": "user",
+        "Password": "pwd",
+    }
+    mock_siemplify.parameters = {"Agent ID": "   "}
+    mock_siemplify.target_entities = [
+        MockEntity("admin@domain.com", EntityTypes.USER),
+    ]
+
+    mock_manager = mock_manager_cls.return_value
+
+    ReconnectAgentToTheNetwork.main()
+
+    mock_manager.find_endpoint_agent_id.assert_not_called()
+    mock_manager.reconnect_agent_to_network.assert_not_called()
+    mock_siemplify.end.assert_called_once_with("No target entities were reconnected from the network.", False)

--- a/content/response_integrations/google/sentinel_one/uv.lock
+++ b/content/response_integrations/google/sentinel_one/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 
 [[package]]
 name = "sentinelone"
-version = "6.0"
+version = "7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The existing SentinelOne integration (v6.0) lacks comprehensive incident response capabilities:
1. `DisconnectAgentFromNetwork` and `ReconnectAgentToTheNetwork` only operated by sweeping all alert entities (`ADDRESS` and `HOSTNAME`) and performing slow full-inventory computer scans to resolve agent IDs. This risks containing unintended endpoints in multi-host alerts and introduces unnecessary latency when the specific agent ID is already known.
2. The integration lacked an action to check an endpoint's network containment status (the existing `GetAgentStatus` action only checks process health, i.e., `Active` vs `Not Active`). Playbooks had no way to verify whether an endpoint was contained or uncontained before or after running containment actions.
3. Live forensic file acquisition was unsupported in upstream Content Hub (`SentinelOneManager.py` v1.6 endpoint was broken/unsupported), requiring external workarounds.

**How does this PR solve the problem?**
This PR standardizes and consolidates SentinelOne response capabilities into version `7.0.0`, reconciling legacy Mandiant SSM standalone scripts into upstream Content Hub standards:

1. **Direct Agent ID Targeting for Containment & Uncontainment ([b/549776812](https://b.corp.google.com/issues/549776812), [b/549777265](https://b.corp.google.com/issues/549777265))**:
   - Added optional direct `Agent ID` parameter to `DisconnectAgentFromNetwork.py` / `.yaml` and `ReconnectAgentToTheNetwork.py` / `.yaml`.
   - Bypasses slow entity inventory queries when `Agent ID` is supplied; falls back gracefully to standard Chronicle entity resolution if omitted (100% backward compatible).
   - Retains fire-and-forget execution semantics.

2. **Check Containment Status Action ([b/549777063](https://b.corp.google.com/issues/549777063))**:
   - Added `Check Containment Status` action (`CheckContainmentStatus.py`, `CheckContainmentStatus.yaml`) taking an `Agent ID` parameter.
   - Normalizes raw SentinelOne network statuses to standard states (`connected` -> `uncontained`, `disconnected` -> `contained`, `disconnecting` -> `containment_requested`, `connecting` -> `uncontainment_requested`).
   - Added `get_agent_network_status` helper in `SentinelOneManager.py` and example JSON payload `resources/CheckContainmentStatus_JsonResult_example.json`.

3. **Unified Asynchronous File Acquisition Action ([b/549777562](https://b.corp.google.com/issues/549777562))**:
   - Added unified async `Acquire File` action (`AcquireFile.py`, `AcquireFile.yaml`) targeting SentinelOne API v2.1.
   - Handles full async state machine lifecycle in a single action: `Initiate Fetch` -> `Poll Activity 80` -> `Download Encrypted ZIP` -> `In-Memory Decryption` -> `Hash Extraction (MD5, SHA1, SHA256)`.
   - Added `fetch_files`, `get_file_upload_activities`, and `download_file_by_url` to `SentinelOneManager.py` and example JSON payload `resources/AcquireFile_JsonResult_example.json`.
   - Uses cross-platform temp directory fallbacks (`tempfile.gettempdir()`) and TIPCommon extraction patterns.

4. **Integration Configuration & Versioning**:
   - Added `Verify SSL` parameter across `definition.yaml`, `release_notes.yaml`, and `tests/config.json`.
   - Synchronized version bump `7.0.0` in `pyproject.toml` and `uv.lock`.
   - Added complete unit test suites (`test_disconnect_agent.py`, `test_reconnect_agent.py`, `test_check_containment_status.py`, `test_acquire_file.py`).

**Any other relevant information (e.g., design choices, tradeoffs, known issues):**
* **Chunky Marketplace Release Strategy**: This PR squishes and supersedes previous individual PRs (#1162, #1163, #1168) into a single cohesive release PR per maintainer recommendation.
* **Buganizer Tracking**: Parent Epic [b/549763652](https://b.corp.google.com/issues/549763652) (Subtasks: [b/549776812](https://b.corp.google.com/issues/549776812), [b/549777265](https://b.corp.google.com/issues/549777265), [b/549777063](https://b.corp.google.com/issues/549777063), [b/549777562](https://b.corp.google.com/issues/549777562)).
* **Test Verification**: All 49 unit tests passing locally via `pytest` and `ruff check` passes with 0 errors.

---

## Checklist:

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.