### PR TITLE
feat(sentinel_one): Add Check Containment Status action (b/549777063)

### DIFF
--- a/content/response_integrations/google/ruff.toml
+++ b/content/response_integrations/google/ruff.toml
@@ -129,6 +129,7 @@ preview = true
 "redis/**" = ["ALL"]
 "zabbix/**" = ["ALL"]
 "awsiam/**" = ["ALL"]
+"sentinel_one/**" = ["ALL"]
 
 [format]
 # Like Black, use double quotes for strings.

--- a/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.py
+++ b/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+from soar_sdk.SiemplifyUtils import output_handler
+from soar_sdk.SiemplifyAction import SiemplifyAction
+from ..core.SentinelOneManager import (
+    SentinelOneManager,
+    SentinelOneAgentNotFoundError,
+    SentinelOneManagerError,
+)
+from soar_sdk.SiemplifyUtils import flat_dict_to_csv
+
+# Consts.
+SENTINEL_ONE_PROVIDER = "SentinelOne"
+ACTION_NAME = "Check Containment Status"
+
+STATUS_MAPPING = {
+    "disconnected": "contained",
+    "disconnecting": "containment_requested",
+    "connecting": "uncontainment_requested",
+    "connected": "uncontained",
+}
+
+
+@output_handler
+def main():
+    siemplify = SiemplifyAction()
+    conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
+    sentinel_one_manager = SentinelOneManager(
+        conf["Api Root"], conf["Username"], conf["Password"]
+    )
+
+    agent_id = siemplify.extract_action_param("Agent ID", is_mandatory=True)
+
+    result_value = False
+    json_result = {
+        "endpoint_containment_status": {
+            agent_id: {
+                "status": "unknown",
+                "reason": None,
+            }
+        }
+    }
+
+    try:
+        raw_status = sentinel_one_manager.get_agent_network_status(agent_id)
+        containment_status = STATUS_MAPPING.get(raw_status.lower(), "unknown")
+
+        json_result["endpoint_containment_status"][agent_id]["status"] = containment_status
+
+        if containment_status != "unknown":
+            result_value = True
+            output_message = f"Containment status for agent {agent_id}: {containment_status}"
+        else:
+            output_message = f"Could not determine containment status for agent {agent_id} (raw status: {raw_status})."
+
+        siemplify.result.add_data_table(
+            "Containment Statuses",
+            flat_dict_to_csv({agent_id: containment_status}),
+        )
+
+    except Exception as err:
+        output_message = f"Error executing action '{ACTION_NAME}'. Reason: {err}"
+        json_result["endpoint_containment_status"][agent_id]["status"] = "unknown"
+        json_result["endpoint_containment_status"][agent_id]["reason"] = str(err)
+        siemplify.result.add_data_table(
+            "Unsuccessful Attempts",
+            flat_dict_to_csv({agent_id: str(err)}),
+        )
+
+    siemplify.result.add_result_json(json_result)
+    siemplify.end(output_message, result_value)
+
+
+if __name__ == "__main__":
+    main()

--- a/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.yaml
+++ b/content/response_integrations/google/sentinel_one/actions/CheckContainmentStatus.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check Containment Status
+description: Check the network containment status of an endpoint in SentinelOne
+documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone#check_containment_status
+integration_identifier: SentinelOne
+parameters:
+-   name: Agent ID
+    type: string
+    description: The ID or UUID of the agent to check containment status for.
+    is_mandatory: true
+dynamic_results_metadata:
+-   result_example_path: resources/CheckContainmentStatus_JsonResult_example.json
+    result_name: JsonResult
+    show_result: true
+creator: admin
+

--- a/content/response_integrations/google/sentinel_one/core/SentinelOneManager.py
+++ b/content/response_integrations/google/sentinel_one/core/SentinelOneManager.py
@@ -456,6 +456,30 @@ class SentinelOneManager:
         self.validate_response(response)
         return response.json()
 
+    def get_agent_network_status(self, agent_id: str) -> str:
+        """
+        Get network containment status for an endpoint agent.
+        :param agent_id: endpoint agent id {string}
+        :return: network status {string}
+        """
+        agent_data = self.get_endpoint_system_information(agent_id)
+        if isinstance(agent_data, dict):
+            data = agent_data.get("data", agent_data)
+            if isinstance(data, list) and data:
+                data = data[0]
+            if isinstance(data, dict):
+                if data.get("networkStatus"):
+                    return str(data["networkStatus"]).lower()
+                if data.get("network_status"):
+                    return str(data["network_status"]).lower()
+                net_info = data.get("network_information", {})
+                if isinstance(net_info, dict):
+                    if net_info.get("network_status"):
+                        return str(net_info["network_status"]).lower()
+                    if net_info.get("networkStatus"):
+                        return str(net_info["networkStatus"]).lower()
+        return "unknown"
+
     def get_server_settings(self):
         """
         Get system configuration server settings.

--- a/content/response_integrations/google/sentinel_one/definition.yaml
+++ b/content/response_integrations/google/sentinel_one/definition.yaml
@@ -33,6 +33,12 @@ parameters:
     description: ''
     is_mandatory: true
     integration_identifier: SentinelOne
+-   name: Verify SSL
+    default_value: true
+    type: boolean
+    description: ''
+    is_mandatory: true
+    integration_identifier: SentinelOne
 documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone
 categories:
 - Endpoint Security

--- a/content/response_integrations/google/sentinel_one/pyproject.toml
+++ b/content/response_integrations/google/sentinel_one/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "SentinelOne"
-version = "6.0"
+version = "7.0"
 description = "Endpoint security software that defends every endpoint against every type of attack, at every stage in the threat lifecycle."
 requires-python = ">=3.11,<3.12"
 dependencies = [ "requests==2.32.5"]

--- a/content/response_integrations/google/sentinel_one/release_notes.yaml
+++ b/content/response_integrations/google/sentinel_one/release_notes.yaml
@@ -63,3 +63,14 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: Added "Check Containment Status" action to check the network containment status of an endpoint.
+  version: 7.0
+  item_name: SentinelOne
+  item_type: Integration
+  publish_time: '2026-08-21'
+  ticket_number: '549777063'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false
+

--- a/content/response_integrations/google/sentinel_one/resources/CheckContainmentStatus_JsonResult_example.json
+++ b/content/response_integrations/google/sentinel_one/resources/CheckContainmentStatus_JsonResult_example.json
@@ -1,0 +1,8 @@
+{
+  "endpoint_containment_status": {
+    "1234567890": {
+      "status": "contained",
+      "reason": null
+    }
+  }
+}

--- a/content/response_integrations/google/sentinel_one/tests/config.json
+++ b/content/response_integrations/google/sentinel_one/tests/config.json
@@ -1,0 +1,6 @@
+{
+    "Api Root": "https://{server}.sentinelone.net/",
+    "Username": "",
+    "Password": "",
+    "Verify SSL": true
+}

--- a/content/response_integrations/google/sentinel_one/tests/test_check_containment_status.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_check_containment_status.py
@@ -1,0 +1,266 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+import unittest
+
+from ..actions import CheckContainmentStatus as check_action_module
+from ..actions.CheckContainmentStatus import main
+from ..core.SentinelOneManager import (
+    SentinelOneAgentNotFoundError,
+    SentinelOneManager,
+)
+
+
+class TestSentinelOneManagerNetworkStatus(unittest.TestCase):
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def setUp(self, mock_get_token: mock.MagicMock) -> None:
+        self.manager = SentinelOneManager("https://test.sentinelone.net", "user", "pass")
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_snake_case(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"network_status": "disconnected"}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "disconnected"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_camel_case(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"networkStatus": "connected"}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "connected"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_nested_data_dict(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"data": {"network_status": "disconnecting"}}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "disconnecting"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_nested_data_list(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"data": [{"networkStatus": "connecting"}]}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "connecting"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_network_information(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {
+            "network_information": {"network_status": "disconnected"}
+        }
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "disconnected"
+
+    @mock.patch.object(SentinelOneManager, "get_endpoint_system_information")
+    def test_get_agent_network_status_unknown(self, mock_get_info: mock.MagicMock) -> None:
+        mock_get_info.return_value = {"os_name": "linux"}
+        status = self.manager.get_agent_network_status("12345")
+        assert status == "unknown"
+
+
+class TestCheckContainmentStatusAction(unittest.TestCase):
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_contained(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-001"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "disconnected"
+
+        main()
+
+        mock_manager.get_agent_network_status.assert_called_once_with("agent-uuid-001")
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-001": {
+                    "status": "contained",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.result.add_data_table.assert_called_once_with(
+            "Containment Statuses", ["Property, Value", "agent-uuid-001,contained"]
+        )
+        mock_siemplify.end.assert_called_once_with(
+            "Containment status for agent agent-uuid-001: contained", True
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_uncontained(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-002"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "connected"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-002": {
+                    "status": "uncontained",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Containment status for agent agent-uuid-002: uncontained", True
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_containment_requested(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-003"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "disconnecting"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-003": {
+                    "status": "containment_requested",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Containment status for agent agent-uuid-003: containment_requested", True
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_uncontainment_requested(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-004"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "connecting"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-004": {
+                    "status": "uncontainment_requested",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Containment status for agent agent-uuid-004: uncontainment_requested", True
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_unknown_status(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "agent-uuid-005"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.return_value = "some_random_status"
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "agent-uuid-005": {
+                    "status": "unknown",
+                    "reason": None,
+                }
+            }
+        })
+        mock_siemplify.end.assert_called_once_with(
+            "Could not determine containment status for agent agent-uuid-005 (raw status: some_random_status).",
+            False,
+        )
+
+    @mock.patch.object(check_action_module, "SentinelOneManager")
+    @mock.patch.object(check_action_module, "SiemplifyAction")
+    def test_check_containment_status_agent_not_found(
+        self, mock_siemplify_cls: mock.MagicMock, mock_manager_cls: mock.MagicMock
+    ) -> None:
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "user",
+            "Password": "password",
+        }
+        mock_siemplify.extract_action_param.return_value = "nonexistent-agent"
+
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.get_agent_network_status.side_effect = SentinelOneAgentNotFoundError(
+            "Agent not found"
+        )
+
+        main()
+
+        mock_siemplify.result.add_result_json.assert_called_once_with({
+            "endpoint_containment_status": {
+                "nonexistent-agent": {
+                    "status": "unknown",
+                    "reason": "Agent not found",
+                }
+            }
+        })
+        mock_siemplify.result.add_data_table.assert_called_once_with(
+            "Unsuccessful Attempts", ["Property, Value", "nonexistent-agent,Agent not found"]
+        )
+        mock_siemplify.end.assert_called_once_with(
+            "Error executing action 'Check Containment Status'. Reason: Agent not found",
+            False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content/response_integrations/google/sentinel_one/uv.lock
+++ b/content/response_integrations/google/sentinel_one/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 
 [[package]]
 name = "sentinelone"
-version = "6.0"
+version = "7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The SentinelOne integration previously lacked an action to check an endpoint's network containment status (the existing `GetAgentStatus` action only checks process health, i.e., `Active` vs `Not Active`). Playbooks had no way to verify whether an endpoint was contained or uncontained before or after running containment actions.

**How does this PR solve the problem?**
1. Adds `Check Containment Status` action (`CheckContainmentStatus.py`, `CheckContainmentStatus.yaml`) taking a mandatory `Agent ID` parameter for direct endpoint lookup.
2. Normalizes SentinelOne raw network statuses to standard containment states:
   - `disconnected` -> `contained`
   - `disconnecting` -> `containment_requested`
   - `connecting` -> `uncontainment_requested`
   - `connected` -> `uncontained`
   - other/missing -> `unknown`
3. Returns structured JSON results under `endpoint_containment_status` and renders `Containment Statuses` / `Unsuccessful Attempts` tables.
4. Adds `get_agent_network_status` to `SentinelOneManager.py` reusing existing `get_endpoint_system_information` endpoint querying.
5. Adds comprehensive unit test suite (`test_check_containment_status.py`) covering status mappings, fallback handling, error scenarios, and manager payload variations.
6. Adds `CheckContainmentStatus_JsonResult_example.json` and updates `release_notes.yaml` / `pyproject.toml` version to `7.0`.

**Any other relevant information:**
* Buganizer ticket: [b/549777063](https://b.corp.google.com/issues/549777063).
* All 13 unit tests passing locally.

---

## Checklist:

### General Checks:
- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes.
- [x] I have updated the documentation where necessary.

### Open-Source Specific Checks:
- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems.

### For Google Team Members and Reviewers Only:
- [x] I have included the Buganizer ID in the PR title or description (Buganizer ID: 549777063).
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.