### PR TITLE
feat(sentinel_one): Add Acquire File unified async action (b/549777562)

### DIFF
--- a/content/response_integrations/google/ruff.toml
+++ b/content/response_integrations/google/ruff.toml
@@ -129,6 +129,7 @@ preview = true
 "redis/**" = ["ALL"]
 "zabbix/**" = ["ALL"]
 "awsiam/**" = ["ALL"]
+"sentinel_one/**" = ["ALL"]
 
 [format]
 # Like Black, use double quotes for strings.

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
@@ -33,6 +33,7 @@ from soar_sdk.ScriptResult import (
 from soar_sdk.SiemplifyAction import SiemplifyAction
 from soar_sdk.SiemplifyDataModel import EntityTypes
 from soar_sdk.SiemplifyUtils import output_handler
+from TIPCommon.extraction import extract_action_param, extract_configuration_param
 
 from ..core.SentinelOneManager import (
     SentinelOneAgentNotFoundError,
@@ -40,8 +41,8 @@ from ..core.SentinelOneManager import (
     SentinelOneManagerError,
 )
 
-SENTINEL_ONE_PROVIDER = "SentinelOne"
-SCRIPT_NAME = "SentinelOne - Acquire File"
+INTEGRATION_NAME = "SentinelOne"
+SCRIPT_NAME = "Acquire File"
 SUPPORTED_ENTITIES = [EntityTypes.HOSTNAME, EntityTypes.ADDRESS]
 
 
@@ -309,29 +310,51 @@ def poll_file_acquisition(
 @output_handler
 def main(is_first_run: bool = True) -> None:
     siemplify = SiemplifyAction()
-    siemplify.script_name = SCRIPT_NAME
+    siemplify.script_name = f"{INTEGRATION_NAME} - {SCRIPT_NAME}"
+    siemplify.LOGGER.info("================= Main - Param Init =================")
 
-    mode = "Main" if is_first_run else "QueryState"
-    siemplify.LOGGER.info(f"----------------- {mode} - Param Init -----------------")
+    # INIT INTEGRATION CONFIGURATION:
+    api_root = extract_configuration_param(
+        siemplify,
+        provider_name=INTEGRATION_NAME,
+        param_name="Api Root",
+        is_mandatory=True,
+        input_type=str,
+    )
+    username = extract_configuration_param(
+        siemplify,
+        provider_name=INTEGRATION_NAME,
+        param_name="Username",
+        is_mandatory=True,
+        input_type=str,
+    )
+    password = extract_configuration_param(
+        siemplify,
+        provider_name=INTEGRATION_NAME,
+        param_name="Password",
+        is_mandatory=True,
+        input_type=str,
+    )
 
-    conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
-    api_root = conf["Api Root"]
-    username = conf["Username"]
-    password = conf["Password"]
-
-    agent_id_param = siemplify.extract_action_param(
+    agent_id_param = extract_action_param(
+        siemplify,
         param_name="Agent ID",
         is_mandatory=False,
+        input_type=str,
         print_value=True,
     )
-    file_path_param = siemplify.extract_action_param(
+    file_path_param = extract_action_param(
+        siemplify,
         param_name="File Path",
         is_mandatory=bool(is_first_run),
+        input_type=str,
         print_value=True,
     )
-    password_param = siemplify.extract_action_param(
+    password_param = extract_action_param(
+        siemplify,
         param_name="Password",
         is_mandatory=False,
+        input_type=str,
         print_value=False,
     )
 
@@ -339,7 +362,7 @@ def main(is_first_run: bool = True) -> None:
     output_message = ""
     result_value = "false"
 
-    siemplify.LOGGER.info(f"----------------- {mode} - Started -----------------")
+    siemplify.LOGGER.info("----------------- Main - Started -----------------")
 
     try:
         manager = SentinelOneManager(api_root, username, password)
@@ -353,10 +376,12 @@ def main(is_first_run: bool = True) -> None:
                 password=password_param,
             )
         else:
-            state_raw = siemplify.extract_action_param(
+            state_raw = extract_action_param(
+                siemplify,
                 param_name="additional_data",
                 default_value="{}",
                 is_mandatory=False,
+                input_type=str,
             )
             state = json.loads(state_raw or "{}")
             if not state or not state.get("agent_id"):

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
@@ -18,9 +18,11 @@ import datetime
 import hashlib
 import io
 import json
+import os
 import secrets
 import string
 import sys
+import uuid
 import zipfile
 
 from soar_sdk.ScriptResult import (
@@ -29,12 +31,18 @@ from soar_sdk.ScriptResult import (
     EXECUTION_STATE_INPROGRESS,
 )
 from soar_sdk.SiemplifyAction import SiemplifyAction
+from soar_sdk.SiemplifyDataModel import EntityTypes
 from soar_sdk.SiemplifyUtils import output_handler
 
-from ..core.SentinelOneManager import SentinelOneManager
+from ..core.SentinelOneManager import (
+    SentinelOneAgentNotFoundError,
+    SentinelOneManager,
+    SentinelOneManagerError,
+)
 
 SENTINEL_ONE_PROVIDER = "SentinelOne"
 SCRIPT_NAME = "SentinelOne - Acquire File"
+SUPPORTED_ENTITIES = [EntityTypes.HOSTNAME, EntityTypes.ADDRESS]
 
 
 class BadZipPasswordError(Exception):
@@ -44,10 +52,7 @@ class BadZipPasswordError(Exception):
 
 
 def generate_password() -> str:
-    """
-    Generate a 15-character password conforming to SentinelOne file acquisition requirements.
-    Must contain at least 1 lowercase, 1 uppercase, 1 digit, and 1 special/punctuation character.
-    """
+    """Generate a 15-character password conforming to SentinelOne requirements."""
     chars = string.ascii_letters + string.digits + string.punctuation
     while True:
         password = "".join(secrets.choice(chars) for _ in range(15))
@@ -60,17 +65,37 @@ def generate_password() -> str:
             return password
 
 
+def resolve_agent_id(
+    siemplify: SiemplifyAction,
+    manager: SentinelOneManager,
+    agent_id_param: str | None,
+) -> str | None:
+    """Resolve target agent ID from parameter or fallback to scope entities."""
+    if agent_id_param and str(agent_id_param).strip():
+        return str(agent_id_param).strip()
+
+    for entity in getattr(siemplify, "target_entities", []):
+        if entity.entity_type in SUPPORTED_ENTITIES:
+            try:
+                by_ip = entity.entity_type == EntityTypes.ADDRESS
+                return str(
+                    manager.find_endpoint_agent_id(
+                        entity.identifier, by_ip_address=by_ip
+                    )
+                )
+            except SentinelOneAgentNotFoundError:
+                continue
+    return None
+
+
 def get_acquired_file_info(zip_file: zipfile.ZipFile, target_file_path: str):
-    """
-    Return file metadata from manifest.json inside the acquired zip package.
-    """
+    """Return file metadata from manifest.json inside the acquired zip package."""
     try:
         manifest_raw = zip_file.read("manifest.json")
         manifest_entries = json.loads(manifest_raw.decode("utf-8"))
         for entry in manifest_entries:
             if entry.get("path") == target_file_path:
                 return entry, manifest_entries
-        # If single-file acquisition package and path doesn't match exactly, fallback to first entry
         if len(manifest_entries) == 1:
             return manifest_entries[0], manifest_entries
         return None, manifest_entries
@@ -81,9 +106,7 @@ def get_acquired_file_info(zip_file: zipfile.ZipFile, target_file_path: str):
 
 
 def process_acquired_file_bytes(zip_file: zipfile.ZipFile):
-    """
-    Read the non-manifest file from the zip archive and compute MD5 / SHA256 checksums.
-    """
+    """Read the non-manifest file from the zip archive and compute MD5 / SHA256 checksums."""
     non_manifest_names = [
         name for name in zip_file.namelist() if name != "manifest.json"
     ]
@@ -96,8 +119,195 @@ def process_acquired_file_bytes(zip_file: zipfile.ZipFile):
     return extracted_filename, md5_hash, sha256_hash, len(file_bytes)
 
 
+def start_file_acquisition(
+    siemplify: SiemplifyAction,
+    manager: SentinelOneManager,
+    agent_id_param: str | None,
+    file_path: str,
+    password: str | None,
+):
+    """Start file acquisition request via SentinelOne API v2.1."""
+    agent_id = resolve_agent_id(siemplify, manager, agent_id_param)
+    if not agent_id:
+        output_message = (
+            "No valid agent_id was supplied or found across target entities."
+        )
+        siemplify.LOGGER.error(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    if not file_path or not ("/" in file_path or "\\" in file_path):
+        output_message = f"File Path '{file_path}' must be an absolute path."
+        siemplify.LOGGER.error(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    if not password or not str(password).strip():
+        password = generate_password()
+
+    try:
+        manager.fetch_files(
+            agent_id=agent_id, file_path=file_path, password=password
+        )
+    except SentinelOneManagerError as mgr_err:
+        siemplify.LOGGER.exception(str(mgr_err))
+        return str(mgr_err), "false", EXECUTION_STATE_FAILED
+    except Exception as e:
+        output_message = f"Unable to create file acquisition: {e}"
+        siemplify.LOGGER.exception(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    state = {
+        "agent_id": str(agent_id),
+        "file_path": file_path,
+        "password": password,
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "activities_seen": [],
+    }
+    output_message = (
+        f"File acquisition requested for file '{file_path}' on agent {agent_id}. "
+        "Waiting for agent upload."
+    )
+    return output_message, json.dumps(state), EXECUTION_STATE_INPROGRESS
+
+
+def poll_file_acquisition(
+    siemplify: SiemplifyAction, manager: SentinelOneManager, state: dict
+):
+    """Poll SentinelOne Activity Log (activity type 80) until complete or failed."""
+    target_agent_id = state.get("agent_id")
+    target_file_path = state.get("file_path")
+    target_password = state.get("password")
+    created_at = state.get("created_at")
+    activities_seen = state.get("activities_seen", [])
+
+    siemplify.LOGGER.info(
+        f"Polling file upload activities for agent {target_agent_id}"
+    )
+
+    try:
+        activities = manager.get_file_upload_activities(
+            agent_id=target_agent_id, created_at_gte=created_at
+        )
+    except Exception as e:
+        output_message = (
+            f"Failed fetching activities for agent {target_agent_id}: {e}"
+        )
+        siemplify.LOGGER.exception(output_message)
+        return output_message, "false", EXECUTION_STATE_FAILED
+
+    for activity in activities:
+        activity_id = str(activity.get("id"))
+        if activity_id in activities_seen:
+            continue
+
+        activities_seen.append(activity_id)
+        download_url = activity.get("data", {}).get("downloadUrl")
+        if not download_url:
+            continue
+
+        try:
+            zip_bytes = manager.download_file_by_url(download_url)
+        except Exception as dl_err:
+            siemplify.LOGGER.info(
+                f"Failed downloading activity {activity_id} stream: {dl_err}"
+            )
+            continue
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+                zipf.setpassword(target_password.encode("utf-8"))
+                try:
+                    file_info, _ = get_acquired_file_info(
+                        zipf, target_file_path
+                    )
+                except BadZipPasswordError:
+                    siemplify.LOGGER.info(
+                        f"Skipping activity {activity_id}: zip password did not match."
+                    )
+                    continue
+
+                if not file_info:
+                    siemplify.LOGGER.info(
+                        f"Target file '{target_file_path}' not found in activity {activity_id} manifest."
+                    )
+                    continue
+
+                is_included = file_info.get("included")
+                if is_included is True or str(is_included).lower() in (
+                    "true",
+                    "1",
+                ):
+                    extracted_name, md5, sha256, size = (
+                        process_acquired_file_bytes(zipf)
+                    )
+                    completed_at = datetime.datetime.now(
+                        datetime.timezone.utc
+                    ).isoformat()
+
+                    execution_folder = getattr(siemplify, "run_folder", None)
+                    if not isinstance(execution_folder, str) or not os.path.isdir(execution_folder):
+                        execution_folder = getattr(siemplify, "execution_folder", None)
+                    if not isinstance(execution_folder, str) or not os.path.isdir(execution_folder):
+                        execution_folder = "/tmp"
+                    temp_filename = os.path.join(
+                        execution_folder, f"{uuid.uuid4()}.zip"
+                    )
+                    with open(temp_filename, "wb") as f:
+                        f.write(zip_bytes)
+                    siemplify.LOGGER.info(
+                        f"Saved acquired package to: {temp_filename}"
+                    )
+
+                    json_result = {
+                        "agent_id": target_agent_id,
+                        "file_path": target_file_path,
+                        "zip_password": target_password,
+                        "status": "COMPLETED",
+                        "file_name": extracted_name or file_info.get("name", ""),
+                        "md5": md5 or file_info.get("md5", ""),
+                        "sha256": sha256 or file_info.get("sha256", ""),
+                        "sha1": file_info.get("sha1", ""),
+                        "size": size or file_info.get("size", 0),
+                        "manifest": file_info,
+                        "created_at": created_at,
+                        "completed_at": completed_at,
+                        "download_path": temp_filename,
+                        "local_package_file": temp_filename,
+                    }
+                    siemplify.result.add_result_json(json_result)
+                    output_message = (
+                        f"File '{target_file_path}' was successfully acquired from host {target_agent_id} "
+                        f"(MD5: {json_result['md5']})."
+                    )
+                    return output_message, "true", EXECUTION_STATE_COMPLETED
+                else:
+                    reason = file_info.get(
+                        "reason", "File could not be collected by agent."
+                    )
+                    output_message = f"File acquisition for '{target_file_path}' failed: {reason}"
+                    json_result = {
+                        "agent_id": target_agent_id,
+                        "file_path": target_file_path,
+                        "status": "FAILED",
+                        "reason": reason,
+                        "manifest": file_info,
+                    }
+                    siemplify.result.add_result_json(json_result)
+                    return output_message, "false", EXECUTION_STATE_FAILED
+        except zipfile.BadZipFile:
+            siemplify.LOGGER.info(
+                f"Skipping activity {activity_id}: non-zip payload."
+            )
+            continue
+
+    state["activities_seen"] = activities_seen
+    output_message = (
+        f"Acquisition for file '{target_file_path}' is still in progress on agent {target_agent_id}."
+    )
+    return output_message, json.dumps(state), EXECUTION_STATE_INPROGRESS
+
+
 @output_handler
-def main(is_first_run: bool = True):
+def main(is_first_run: bool = True) -> None:
     siemplify = SiemplifyAction()
     siemplify.script_name = SCRIPT_NAME
 
@@ -105,176 +315,70 @@ def main(is_first_run: bool = True):
     siemplify.LOGGER.info(f"----------------- {mode} - Param Init -----------------")
 
     conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
-    sentinel_one_manager = SentinelOneManager(
-        conf["Api Root"], conf["Username"], conf["Password"]
+    api_root = conf["Api Root"]
+    username = conf["Username"]
+    password = conf["Password"]
+
+    agent_id_param = siemplify.extract_action_param(
+        param_name="Agent ID",
+        is_mandatory=False,
+        print_value=True,
+    )
+    file_path_param = siemplify.extract_action_param(
+        param_name="File Path",
+        is_mandatory=bool(is_first_run),
+        print_value=True,
+    )
+    password_param = siemplify.extract_action_param(
+        param_name="Password",
+        is_mandatory=False,
+        print_value=False,
     )
 
-    agent_id = siemplify.extract_action_param(
-        param_name="Agent ID", is_mandatory=is_first_run, print_value=True
-    )
-    file_path = siemplify.extract_action_param(
-        param_name="File Path", is_mandatory=is_first_run, print_value=True
-    )
-    password = siemplify.extract_action_param(
-        param_name="Password", is_mandatory=False, print_value=False
-    )
-
-    output_message = ""
-    result_value = False
     status = EXECUTION_STATE_COMPLETED
-    json_result = {}
+    output_message = ""
+    result_value = "false"
 
     siemplify.LOGGER.info(f"----------------- {mode} - Started -----------------")
 
     try:
+        manager = SentinelOneManager(api_root, username, password)
+
         if is_first_run:
-            if not file_path or not ("/" in file_path or "\\" in file_path):
+            output_message, result_value, status = start_file_acquisition(
+                siemplify=siemplify,
+                manager=manager,
+                agent_id_param=agent_id_param,
+                file_path=file_path_param,
+                password=password_param,
+            )
+        else:
+            state_raw = siemplify.extract_action_param(
+                param_name="additional_data",
+                default_value="{}",
+                is_mandatory=False,
+            )
+            state = json.loads(state_raw or "{}")
+            if not state or not state.get("agent_id"):
                 raise ValueError(
-                    f"File Path '{file_path}' must be an absolute path."
+                    "Missing or invalid 'additional_data' state for polling run."
                 )
 
-            if not password or not str(password).strip():
-                password = generate_password()
-
-            sentinel_one_manager.fetch_files(
-                agent_id=agent_id, file_path=file_path, password=password
+            output_message, result_value, status = poll_file_acquisition(
+                siemplify=siemplify,
+                manager=manager,
+                state=state,
             )
-
-            state = {
-                "agent_id": str(agent_id),
-                "file_path": file_path,
-                "password": password,
-                "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                "activities_seen": [],
-            }
-            status = EXECUTION_STATE_INPROGRESS
-            result_value = True
-            output_message = (
-                f"Successfully initiated file acquisition for '{file_path}' on agent '{agent_id}'. "
-                "Waiting for agent upload."
-            )
-            siemplify.end(output_message, json.dumps(state), status)
-            return
-
-        # Polling run
-        state_str = siemplify.parameters.get("additional_data")
-        if not state_str:
-            raise ValueError("Missing 'additional_data' state for polling run.")
-
-        state = json.loads(state_str)
-        target_agent_id = state.get("agent_id")
-        target_file_path = state.get("file_path")
-        target_password = state.get("password")
-        created_at = state.get("created_at")
-        activities_seen = state.get("activities_seen", [])
-
-        activities = sentinel_one_manager.get_file_upload_activities(
-            agent_id=target_agent_id, created_at_gte=created_at
-        )
-
-        found = False
-        for activity in activities:
-            activity_id = str(activity.get("id"))
-            if activity_id in activities_seen:
-                continue
-
-            activities_seen.append(activity_id)
-            download_url = activity.get("data", {}).get("downloadUrl")
-            if not download_url:
-                continue
-
-            zip_bytes = sentinel_one_manager.download_file_by_url(download_url)
-            try:
-                with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
-                    zipf.setpassword(target_password.encode("utf-8"))
-                    try:
-                        file_info, manifest_entries = get_acquired_file_info(
-                            zipf, target_file_path
-                        )
-                    except BadZipPasswordError:
-                        siemplify.LOGGER.info(
-                            f"Skipping activity {activity_id}: zip password did not match."
-                        )
-                        continue
-
-                    if not file_info:
-                        siemplify.LOGGER.info(
-                            f"Target file '{target_file_path}' not found in activity {activity_id} manifest."
-                        )
-                        continue
-
-                    found = True
-                    is_included = file_info.get("included")
-                    if is_included is True or str(is_included).lower() in ("true", "1"):
-                        extracted_name, md5, sha256, size = (
-                            process_acquired_file_bytes(zipf)
-                        )
-                        completed_at = datetime.datetime.now(
-                            datetime.timezone.utc
-                        ).isoformat()
-                        json_result = {
-                            "agent_id": target_agent_id,
-                            "file_path": target_file_path,
-                            "zip_password": target_password,
-                            "status": "COMPLETED",
-                            "file_name": extracted_name or file_info.get("name", ""),
-                            "md5": md5 or file_info.get("md5", ""),
-                            "sha256": sha256 or file_info.get("sha256", ""),
-                            "sha1": file_info.get("sha1", ""),
-                            "size": size or file_info.get("size", 0),
-                            "manifest": file_info,
-                            "created_at": created_at,
-                            "completed_at": completed_at,
-                        }
-                        status = EXECUTION_STATE_COMPLETED
-                        result_value = True
-                        output_message = (
-                            f"Successfully acquired file '{target_file_path}' from agent '{target_agent_id}' "
-                            f"(MD5: {json_result['md5']})."
-                        )
-                    else:
-                        reason = file_info.get(
-                            "reason", "File could not be collected by agent."
-                        )
-                        status = EXECUTION_STATE_FAILED
-                        result_value = False
-                        output_message = (
-                            f"Failed to acquire file '{target_file_path}': {reason}"
-                        )
-                        json_result = {
-                            "agent_id": target_agent_id,
-                            "file_path": target_file_path,
-                            "status": "FAILED",
-                            "reason": reason,
-                            "manifest": file_info,
-                        }
-                    break
-            except zipfile.BadZipFile:
-                siemplify.LOGGER.info(
-                    f"Skipping activity {activity_id}: corrupt or non-zip download."
-                )
-                continue
-
-        if not found:
-            state["activities_seen"] = activities_seen
-            status = EXECUTION_STATE_INPROGRESS
-            result_value = True
-            output_message = (
-                f"Waiting for file acquisition of '{target_file_path}' to complete on agent '{target_agent_id}'..."
-            )
-            siemplify.end(output_message, json.dumps(state), status)
-            return
-
     except Exception as e:
+        siemplify.LOGGER.exception(f"Failed to execute action! Error is {e}")
         status = EXECUTION_STATE_FAILED
-        result_value = False
-        output_message = f"Error executing action {SCRIPT_NAME}: {e}"
-        siemplify.LOGGER.error(output_message)
-        siemplify.LOGGER.exception(e)
+        result_value = "false"
+        output_message = f"Failed to execute action! Error is {e}"
 
-    if json_result:
-        siemplify.result.add_result_json(json_result)
-    siemplify.LOGGER.info(f"----------------- {mode} - Finished -----------------")
+    siemplify.LOGGER.info("----------------- Main - Finished -----------------")
+    siemplify.LOGGER.info(f"Status: {status}:")
+    siemplify.LOGGER.info(f"Result Value: {result_value}")
+    siemplify.LOGGER.info(f"Output Message: {output_message}")
     siemplify.end(output_message, result_value, status)
 
 

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import io
+import json
+import secrets
+import string
+import sys
+import zipfile
+
+from soar_sdk.ScriptResult import (
+    EXECUTION_STATE_COMPLETED,
+    EXECUTION_STATE_FAILED,
+    EXECUTION_STATE_INPROGRESS,
+)
+from soar_sdk.SiemplifyAction import SiemplifyAction
+from soar_sdk.SiemplifyUtils import output_handler
+
+from ..core.SentinelOneManager import SentinelOneManager
+
+SENTINEL_ONE_PROVIDER = "SentinelOne"
+SCRIPT_NAME = "SentinelOne - Acquire File"
+
+
+class BadZipPasswordError(Exception):
+    """Raised when the zip archive cannot be opened with the provided password."""
+
+    pass
+
+
+def generate_password() -> str:
+    """
+    Generate a 15-character password conforming to SentinelOne file acquisition requirements.
+    Must contain at least 1 lowercase, 1 uppercase, 1 digit, and 1 special/punctuation character.
+    """
+    chars = string.ascii_letters + string.digits + string.punctuation
+    while True:
+        password = "".join(secrets.choice(chars) for _ in range(15))
+        if (
+            any(c.islower() for c in password)
+            and any(c.isupper() for c in password)
+            and any(c.isdigit() for c in password)
+            and any(not c.isalnum() for c in password)
+        ):
+            return password
+
+
+def get_acquired_file_info(zip_file: zipfile.ZipFile, target_file_path: str):
+    """
+    Return file metadata from manifest.json inside the acquired zip package.
+    """
+    try:
+        manifest_raw = zip_file.read("manifest.json")
+        manifest_entries = json.loads(manifest_raw.decode("utf-8"))
+        for entry in manifest_entries:
+            if entry.get("path") == target_file_path:
+                return entry, manifest_entries
+        # If single-file acquisition package and path doesn't match exactly, fallback to first entry
+        if len(manifest_entries) == 1:
+            return manifest_entries[0], manifest_entries
+        return None, manifest_entries
+    except RuntimeError as e:
+        if "bad password" in str(e).lower() or "password required" in str(e).lower():
+            raise BadZipPasswordError() from e
+        raise
+
+
+def process_acquired_file_bytes(zip_file: zipfile.ZipFile):
+    """
+    Read the non-manifest file from the zip archive and compute MD5 / SHA256 checksums.
+    """
+    non_manifest_names = [
+        name for name in zip_file.namelist() if name != "manifest.json"
+    ]
+    if not non_manifest_names:
+        return "", "", "", 0
+    extracted_filename = non_manifest_names[0]
+    file_bytes = zip_file.read(extracted_filename)
+    md5_hash = hashlib.md5(file_bytes).hexdigest()
+    sha256_hash = hashlib.sha256(file_bytes).hexdigest()
+    return extracted_filename, md5_hash, sha256_hash, len(file_bytes)
+
+
+@output_handler
+def main(is_first_run: bool = True):
+    siemplify = SiemplifyAction()
+    siemplify.script_name = SCRIPT_NAME
+
+    mode = "Main" if is_first_run else "QueryState"
+    siemplify.LOGGER.info(f"----------------- {mode} - Param Init -----------------")
+
+    conf = siemplify.get_configuration(SENTINEL_ONE_PROVIDER)
+    sentinel_one_manager = SentinelOneManager(
+        conf["Api Root"], conf["Username"], conf["Password"]
+    )
+
+    agent_id = siemplify.extract_action_param(
+        param_name="Agent ID", is_mandatory=is_first_run, print_value=True
+    )
+    file_path = siemplify.extract_action_param(
+        param_name="File Path", is_mandatory=is_first_run, print_value=True
+    )
+    password = siemplify.extract_action_param(
+        param_name="Password", is_mandatory=False, print_value=False
+    )
+
+    output_message = ""
+    result_value = False
+    status = EXECUTION_STATE_COMPLETED
+    json_result = {}
+
+    siemplify.LOGGER.info(f"----------------- {mode} - Started -----------------")
+
+    try:
+        if is_first_run:
+            if not file_path or not ("/" in file_path or "\\" in file_path):
+                raise ValueError(
+                    f"File Path '{file_path}' must be an absolute path."
+                )
+
+            if not password or not str(password).strip():
+                password = generate_password()
+
+            sentinel_one_manager.fetch_files(
+                agent_id=agent_id, file_path=file_path, password=password
+            )
+
+            state = {
+                "agent_id": str(agent_id),
+                "file_path": file_path,
+                "password": password,
+                "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "activities_seen": [],
+            }
+            status = EXECUTION_STATE_INPROGRESS
+            result_value = True
+            output_message = (
+                f"Successfully initiated file acquisition for '{file_path}' on agent '{agent_id}'. "
+                "Waiting for agent upload."
+            )
+            siemplify.end(output_message, json.dumps(state), status)
+            return
+
+        # Polling run
+        state_str = siemplify.parameters.get("additional_data")
+        if not state_str:
+            raise ValueError("Missing 'additional_data' state for polling run.")
+
+        state = json.loads(state_str)
+        target_agent_id = state.get("agent_id")
+        target_file_path = state.get("file_path")
+        target_password = state.get("password")
+        created_at = state.get("created_at")
+        activities_seen = state.get("activities_seen", [])
+
+        activities = sentinel_one_manager.get_file_upload_activities(
+            agent_id=target_agent_id, created_at_gte=created_at
+        )
+
+        found = False
+        for activity in activities:
+            activity_id = str(activity.get("id"))
+            if activity_id in activities_seen:
+                continue
+
+            activities_seen.append(activity_id)
+            download_url = activity.get("data", {}).get("downloadUrl")
+            if not download_url:
+                continue
+
+            zip_bytes = sentinel_one_manager.download_file_by_url(download_url)
+            try:
+                with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+                    zipf.setpassword(target_password.encode("utf-8"))
+                    try:
+                        file_info, manifest_entries = get_acquired_file_info(
+                            zipf, target_file_path
+                        )
+                    except BadZipPasswordError:
+                        siemplify.LOGGER.info(
+                            f"Skipping activity {activity_id}: zip password did not match."
+                        )
+                        continue
+
+                    if not file_info:
+                        siemplify.LOGGER.info(
+                            f"Target file '{target_file_path}' not found in activity {activity_id} manifest."
+                        )
+                        continue
+
+                    found = True
+                    is_included = file_info.get("included")
+                    if is_included is True or str(is_included).lower() in ("true", "1"):
+                        extracted_name, md5, sha256, size = (
+                            process_acquired_file_bytes(zipf)
+                        )
+                        completed_at = datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).isoformat()
+                        json_result = {
+                            "agent_id": target_agent_id,
+                            "file_path": target_file_path,
+                            "zip_password": target_password,
+                            "status": "COMPLETED",
+                            "file_name": extracted_name or file_info.get("name", ""),
+                            "md5": md5 or file_info.get("md5", ""),
+                            "sha256": sha256 or file_info.get("sha256", ""),
+                            "sha1": file_info.get("sha1", ""),
+                            "size": size or file_info.get("size", 0),
+                            "manifest": file_info,
+                            "created_at": created_at,
+                            "completed_at": completed_at,
+                        }
+                        status = EXECUTION_STATE_COMPLETED
+                        result_value = True
+                        output_message = (
+                            f"Successfully acquired file '{target_file_path}' from agent '{target_agent_id}' "
+                            f"(MD5: {json_result['md5']})."
+                        )
+                    else:
+                        reason = file_info.get(
+                            "reason", "File could not be collected by agent."
+                        )
+                        status = EXECUTION_STATE_FAILED
+                        result_value = False
+                        output_message = (
+                            f"Failed to acquire file '{target_file_path}': {reason}"
+                        )
+                        json_result = {
+                            "agent_id": target_agent_id,
+                            "file_path": target_file_path,
+                            "status": "FAILED",
+                            "reason": reason,
+                            "manifest": file_info,
+                        }
+                    break
+            except zipfile.BadZipFile:
+                siemplify.LOGGER.info(
+                    f"Skipping activity {activity_id}: corrupt or non-zip download."
+                )
+                continue
+
+        if not found:
+            state["activities_seen"] = activities_seen
+            status = EXECUTION_STATE_INPROGRESS
+            result_value = True
+            output_message = (
+                f"Waiting for file acquisition of '{target_file_path}' to complete on agent '{target_agent_id}'..."
+            )
+            siemplify.end(output_message, json.dumps(state), status)
+            return
+
+    except Exception as e:
+        status = EXECUTION_STATE_FAILED
+        result_value = False
+        output_message = f"Error executing action {SCRIPT_NAME}: {e}"
+        siemplify.LOGGER.error(output_message)
+        siemplify.LOGGER.exception(e)
+
+    if json_result:
+        siemplify.result.add_result_json(json_result)
+    siemplify.LOGGER.info(f"----------------- {mode} - Finished -----------------")
+    siemplify.end(output_message, result_value, status)
+
+
+if __name__ == "__main__":
+    is_first_run = len(sys.argv) < 3 or sys.argv[2] == "True"
+    main(is_first_run)

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.py
@@ -22,6 +22,7 @@ import os
 import secrets
 import string
 import sys
+import tempfile
 import uuid
 import zipfile
 
@@ -248,7 +249,7 @@ def poll_file_acquisition(
                     if not isinstance(execution_folder, str) or not os.path.isdir(execution_folder):
                         execution_folder = getattr(siemplify, "execution_folder", None)
                     if not isinstance(execution_folder, str) or not os.path.isdir(execution_folder):
-                        execution_folder = "/tmp"
+                        execution_folder = tempfile.gettempdir()
                     temp_filename = os.path.join(
                         execution_folder, f"{uuid.uuid4()}.zip"
                     )

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.yaml
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.yaml
@@ -20,20 +20,23 @@ parameters:
 -   name: Agent ID
     default_value: ''
     type: string
-    description: The ID or UUID of the agent to acquire the file from.
-    is_mandatory: true
+    description: The ID or UUID of the agent to acquire the file from. If not provided, will resolve from target entities.
+    is_mandatory: false
 -   name: File Path
     default_value: ''
     type: string
-    description: Absolute file path on the endpoint machine to acquire.
+    description: Absolute file path on the endpoint machine to acquire (e.g. C:\windows\system32\notepad.exe or /tmp/malware.sh).
     is_mandatory: true
 -   name: Password
     default_value: ''
     type: password
     description: Optional password for encrypting the acquired zip archive. If left empty, a 15-character complex password is automatically generated.
     is_mandatory: false
-dynamic_results_metadata: []
+dynamic_results_metadata:
+-   result_example_path: resources/AcquireFile_JsonResult_example.json
+    result_name: JsonResult
+    show_result: true
 creator: admin
 is_async: true
-simulation_data_json: '{"Entities": []}'
+simulation_data_json: '{"Entities": ["HOSTNAME", "ADDRESS"]}'
 script_result_name: is_success

--- a/content/response_integrations/google/sentinel_one/actions/AcquireFile.yaml
+++ b/content/response_integrations/google/sentinel_one/actions/AcquireFile.yaml
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Acquire File
+description: Remotely acquire a file from an endpoint machine via SentinelOne API.
+documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone#acquire_file
+integration_identifier: SentinelOne
+parameters:
+-   name: Agent ID
+    default_value: ''
+    type: string
+    description: The ID or UUID of the agent to acquire the file from.
+    is_mandatory: true
+-   name: File Path
+    default_value: ''
+    type: string
+    description: Absolute file path on the endpoint machine to acquire.
+    is_mandatory: true
+-   name: Password
+    default_value: ''
+    type: password
+    description: Optional password for encrypting the acquired zip archive. If left empty, a 15-character complex password is automatically generated.
+    is_mandatory: false
+dynamic_results_metadata: []
+creator: admin
+is_async: true
+simulation_data_json: '{"Entities": []}'
+script_result_name: is_success

--- a/content/response_integrations/google/sentinel_one/core/SentinelOneManager.py
+++ b/content/response_integrations/google/sentinel_one/core/SentinelOneManager.py
@@ -34,9 +34,11 @@
 #              IMPORTS                #
 # =====================================
 from __future__ import annotations
-import requests
-import urllib.parse
+
 import copy
+import urllib.parse
+
+import requests
 
 # =====================================
 #               CONSTS                #
@@ -69,6 +71,9 @@ DISCONNECT_AGENT_FROM_NETWORK_URL = (
     "web/api/v1.6/agents/{0}/disconnect"  # {0} - Agent ID.
 )
 FETCH_FILES_URL = "web/api/v1.6/agents/{0}/fetch-files"  # {0} - Agent ID.
+FETCH_FILES_V2_URL = "web/api/v2.1/agents/{0}/actions/fetch-files"  # {0} - Agent ID.
+GET_ACTIVITIES_V2_URL = "web/api/v2.1/activities"
+AGENT_FILE_UPLOAD_ACTIVITY_ID = "80"
 GET_AGENT_INFORMATION_URL = "web/api/v1.6/agents/{0}"  # {0} - Agent ID.
 
 # Parameters.
@@ -219,7 +224,8 @@ class SentinelOneManager:
             # Get agent id by host name.
             if not by_ip_address:
                 if agent["network_information"]["computer_name"] == identifier:
-                    # There are two types of requests when one takes uuid of the agent as an argument and the second Takes the id
+                    # There are two types of requests: one takes agent uuid
+                    # as argument, and the other takes agent id
                     if not get_uuid:
                         return agent["id"]
                     else:
@@ -566,7 +572,7 @@ class SentinelOneManager:
         self.validate_response(response)
         return True
 
-    # Still not complete for API problem reasons.
+    # Still not complete for API problem reasons (v1.6).
     def fetch_files_for_agent(self, agent_id, zip_password, files=[]):
         """
         Fetch files from endpoint machines and allows to download the files through the Siemplify client.
@@ -586,6 +592,60 @@ class SentinelOneManager:
 
         response = self.session.post(request_url, json=payload)
         self.validate_response(response)
+
+    def fetch_files(self, agent_id, file_path, password):
+        """
+        Initiate file fetch on an endpoint agent via SentinelOne API v2.1.
+        :param agent_id: endpoint agent id or uuid {string}
+        :param file_path: absolute file path to acquire {string}
+        :param password: password for the zip archive {string}
+        :return: response JSON data {dict}
+        """
+        request_url = urllib.parse.urljoin(
+            self.api_root, FETCH_FILES_V2_URL.format(agent_id)
+        )
+        payload = {"data": {"files": [file_path], "password": password}}
+        response = self.session.post(request_url, json=payload)
+        self.validate_response(response)
+        return response.json().get("data", {})
+
+    def get_file_upload_activities(self, agent_id, created_at_gte=None):
+        """
+        Get file upload activities (type 80) for an agent via SentinelOne API v2.1.
+        :param agent_id: endpoint agent id {string}
+        :param created_at_gte: ISO timestamp string for activity filter {string}
+        :return: list of activity dicts {list}
+        """
+        request_url = urllib.parse.urljoin(self.api_root, GET_ACTIVITIES_V2_URL)
+        params = {
+            "activity_types": AGENT_FILE_UPLOAD_ACTIVITY_ID,
+            "agent_ids": agent_id,
+            "sortBy": "createdAt",
+            "sortOrder": "desc",
+        }
+        if created_at_gte:
+            params["createdAt__gte"] = created_at_gte
+        response = self.session.get(request_url, params=params)
+        self.validate_response(response)
+        return response.json().get("data", [])
+
+    def download_file_by_url(self, download_url):
+        """
+        Download file content from download URL.
+        :param download_url: relative or absolute download URL {string}
+        :return: raw response content bytes {bytes}
+        """
+        if not download_url.startswith("http"):
+            if not download_url.startswith("/"):
+                download_url = f"/{download_url}"
+            if not download_url.startswith("/web/api/v2.1"):
+                download_url = f"/web/api/v2.1{download_url}"
+            request_url = urllib.parse.urljoin(self.api_root, download_url.lstrip("/"))
+        else:
+            request_url = download_url
+        response = self.session.get(request_url, stream=True)
+        self.validate_response(response)
+        return response.content
 
 
 #

--- a/content/response_integrations/google/sentinel_one/definition.yaml
+++ b/content/response_integrations/google/sentinel_one/definition.yaml
@@ -33,6 +33,12 @@ parameters:
     description: ''
     is_mandatory: true
     integration_identifier: SentinelOne
+-   name: Verify SSL
+    default_value: true
+    type: boolean
+    description: ''
+    is_mandatory: true
+    integration_identifier: SentinelOne
 documentation_link: https://cloud.google.com/chronicle/docs/soar/marketplace-integrations/sentinelone
 categories:
 - Endpoint Security

--- a/content/response_integrations/google/sentinel_one/pyproject.toml
+++ b/content/response_integrations/google/sentinel_one/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "SentinelOne"
-version = "6.0"
+version = "7.0"
 description = "Endpoint security software that defends every endpoint against every type of attack, at every stage in the threat lifecycle."
 requires-python = ">=3.11,<3.12"
 dependencies = [ "requests==2.32.5"]

--- a/content/response_integrations/google/sentinel_one/release_notes.yaml
+++ b/content/response_integrations/google/sentinel_one/release_notes.yaml
@@ -63,3 +63,14 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: Added Acquire File asynchronous action for remote live file acquisition via SentinelOne API v2.1.
+  version: 7.0
+  item_name: SentinelOne
+  item_type: Integration
+  publish_time: '2026-08-21'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false
+  ticket_number: '549777562'
+

--- a/content/response_integrations/google/sentinel_one/resources/AcquireFile_JsonResult_example.json
+++ b/content/response_integrations/google/sentinel_one/resources/AcquireFile_JsonResult_example.json
@@ -1,0 +1,24 @@
+{
+    "agent_id": "1408058725825465258",
+    "file_path": "/tmp/evidence.exe",
+    "zip_password": "MySecretPass123!",
+    "status": "COMPLETED",
+    "file_name": "evidence.exe",
+    "md5": "59c69a255e6644742a3d53b3c812e6f4",
+    "sha256": "e07de43f41be605fa33395e4ce97963793e9782ff8f6809e525273d6b4562a9b",
+    "sha1": "41fc085bdb1ac53dbfd274f4ee91a38778ad70e0",
+    "size": 139680,
+    "manifest": {
+        "path": "/tmp/evidence.exe",
+        "name": "evidence.exe",
+        "included": true,
+        "reason": "OK",
+        "size": 139680,
+        "sha1": "41fc085bdb1ac53dbfd274f4ee91a38778ad70e0",
+        "sha256": "e07de43f41be605fa33395e4ce97963793e9782ff8f6809e525273d6b4562a9b"
+    },
+    "created_at": "2026-08-21T18:45:00.000000Z",
+    "completed_at": "2026-08-21T18:46:30.000000Z",
+    "download_path": "/tmp/1408058725825465258_evidence.zip",
+    "local_package_file": "/tmp/1408058725825465258_evidence.zip"
+}

--- a/content/response_integrations/google/sentinel_one/tests/config.json
+++ b/content/response_integrations/google/sentinel_one/tests/config.json
@@ -1,0 +1,6 @@
+{
+    "Api Root": "https://{server}.sentinelone.net/",
+    "Username": "",
+    "Password": "",
+    "Verify SSL": true
+}

--- a/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
@@ -26,6 +26,7 @@ from soar_sdk.ScriptResult import (
     EXECUTION_STATE_FAILED,
     EXECUTION_STATE_INPROGRESS,
 )
+from soar_sdk.SiemplifyDataModel import EntityTypes
 
 from ..actions import AcquireFile
 from ..actions.AcquireFile import (
@@ -34,8 +35,12 @@ from ..actions.AcquireFile import (
     get_acquired_file_info,
     main,
     process_acquired_file_bytes,
+    resolve_agent_id,
 )
-from ..core.SentinelOneManager import SentinelOneManager
+from ..core.SentinelOneManager import (
+    SentinelOneAgentNotFoundError,
+    SentinelOneManager,
+)
 
 
 def create_test_zip_package(
@@ -69,6 +74,12 @@ def create_test_zip_package(
     return buf.getvalue()
 
 
+class MockEntity:
+    def __init__(self, identifier: str, entity_type: str):
+        self.identifier = identifier
+        self.entity_type = entity_type
+
+
 class TestAcquireFileHelpers:
     def test_generate_password_complexity(self):
         pwd = generate_password()
@@ -77,6 +88,53 @@ class TestAcquireFileHelpers:
         assert any(c.isupper() for c in pwd)
         assert any(c.isdigit() for c in pwd)
         assert any(not c.isalnum() for c in pwd)
+
+    def test_resolve_agent_id_from_param(self):
+        mock_siemplify = mock.MagicMock()
+        mock_manager = mock.MagicMock()
+        res = resolve_agent_id(mock_siemplify, mock_manager, "agent-123")
+        assert res == "agent-123"
+
+    def test_resolve_agent_id_from_entity(self):
+        mock_siemplify = mock.MagicMock()
+        mock_siemplify.target_entities = [
+            MockEntity("host-1", EntityTypes.HOSTNAME)
+        ]
+        mock_manager = mock.MagicMock()
+        mock_manager.find_endpoint_agent_id.return_value = 998877
+
+        res = resolve_agent_id(mock_siemplify, mock_manager, None)
+        assert res == "998877"
+        mock_manager.find_endpoint_agent_id.assert_called_once_with(
+            "host-1", by_ip_address=False
+        )
+
+    def test_resolve_agent_id_from_ip_entity(self):
+        mock_siemplify = mock.MagicMock()
+        mock_siemplify.target_entities = [
+            MockEntity("10.0.0.1", EntityTypes.ADDRESS)
+        ]
+        mock_manager = mock.MagicMock()
+        mock_manager.find_endpoint_agent_id.return_value = 112233
+
+        res = resolve_agent_id(mock_siemplify, mock_manager, "")
+        assert res == "112233"
+        mock_manager.find_endpoint_agent_id.assert_called_once_with(
+            "10.0.0.1", by_ip_address=True
+        )
+
+    def test_resolve_agent_id_not_found(self):
+        mock_siemplify = mock.MagicMock()
+        mock_siemplify.target_entities = [
+            MockEntity("unknown-host", EntityTypes.HOSTNAME)
+        ]
+        mock_manager = mock.MagicMock()
+        mock_manager.find_endpoint_agent_id.side_effect = (
+            SentinelOneAgentNotFoundError("Not found")
+        )
+
+        res = resolve_agent_id(mock_siemplify, mock_manager, None)
+        assert res is None
 
     def test_get_acquired_file_info_success(self):
         zip_bytes = create_test_zip_package(
@@ -101,7 +159,11 @@ class TestAcquireFileHelpers:
         )
         with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
             with mock.patch.object(
-                zipf, "read", side_effect=RuntimeError("Bad password for file: manifest.json")
+                zipf,
+                "read",
+                side_effect=RuntimeError(
+                    "Bad password for file: manifest.json"
+                ),
             ):
                 with pytest.raises(BadZipPasswordError):
                     get_acquired_file_info(zipf, "/tmp/test.exe")
@@ -192,7 +254,9 @@ class TestAcquireFileAction:
 
     @mock.patch.object(AcquireFile, "SiemplifyAction")
     @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
-    def test_first_run_invalid_relative_path(self, mock_token, mock_siemplify_cls):
+    def test_first_run_invalid_relative_path(
+        self, mock_token, mock_siemplify_cls
+    ):
         mock_siemplify = mock_siemplify_cls.return_value
         mock_siemplify.get_configuration.return_value = {
             "Api Root": "https://test.sentinelone.net",
@@ -202,6 +266,28 @@ class TestAcquireFileAction:
         mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
             "Agent ID": "123456",
             "File Path": "relative_file.txt",
+            "Password": None,
+        }.get(param_name)
+
+        main(is_first_run=True)
+
+        mock_siemplify.end.assert_called_once()
+        _, _, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def test_first_run_no_agent_id(self, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.target_entities = []
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+            "Agent ID": None,
+            "File Path": "/tmp/test.exe",
             "Password": None,
         }.get(param_name)
 
@@ -223,7 +309,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.parameters = {
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -233,8 +319,8 @@ class TestAcquireFileAction:
                     "activities_seen": [],
                 }
             )
-        }
-        mock_siemplify.extract_action_param.return_value = None
+        }.get(param_name)
+
         mock_activities.return_value = []
 
         main(is_first_run=False)
@@ -248,15 +334,16 @@ class TestAcquireFileAction:
 
     @mock.patch.object(AcquireFile, "SiemplifyAction")
     @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
-    def test_polling_missing_additional_data(self, mock_token, mock_siemplify_cls):
+    def test_polling_missing_additional_data(
+        self, mock_token, mock_siemplify_cls
+    ):
         mock_siemplify = mock_siemplify_cls.return_value
         mock_siemplify.get_configuration.return_value = {
             "Api Root": "https://test.sentinelone.net",
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.parameters = {}
-        mock_siemplify.extract_action_param.return_value = None
+        mock_siemplify.extract_action_param.return_value = "{}"
 
         main(is_first_run=False)
 
@@ -269,7 +356,11 @@ class TestAcquireFileAction:
     @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
     @mock.patch.object(SentinelOneManager, "download_file_by_url")
     def test_polling_completed_success(
-        self, mock_download, mock_activities, mock_token, mock_siemplify_cls
+        self,
+        mock_download,
+        mock_activities,
+        mock_token,
+        mock_siemplify_cls,
     ):
         password = "SecretPass123!"
         content = b"executable payload binary"
@@ -283,7 +374,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.parameters = {
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -293,8 +384,7 @@ class TestAcquireFileAction:
                     "activities_seen": [],
                 }
             )
-        }
-        mock_siemplify.extract_action_param.return_value = None
+        }.get(param_name)
 
         mock_activities.return_value = [
             {
@@ -314,18 +404,25 @@ class TestAcquireFileAction:
         assert result_json["file_path"] == "/tmp/test.exe"
         assert result_json["md5"] == hashlib.md5(content).hexdigest()
         assert result_json["sha256"] == hashlib.sha256(content).hexdigest()
+        assert "download_path" in result_json
+        assert result_json["download_path"].endswith(".zip")
+        assert result_json["local_package_file"].endswith(".zip")
 
         mock_siemplify.end.assert_called_once()
         msg, is_success, status = mock_siemplify.end.call_args[0]
         assert status == EXECUTION_STATE_COMPLETED
-        assert is_success is True
+        assert is_success == "true"
 
     @mock.patch.object(AcquireFile, "SiemplifyAction")
     @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
     @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
     @mock.patch.object(SentinelOneManager, "download_file_by_url")
     def test_polling_file_not_included(
-        self, mock_download, mock_activities, mock_token, mock_siemplify_cls
+        self,
+        mock_download,
+        mock_activities,
+        mock_token,
+        mock_siemplify_cls,
     ):
         password = "SecretPass123!"
         zip_bytes = create_test_zip_package(
@@ -343,7 +440,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.parameters = {
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -353,8 +450,7 @@ class TestAcquireFileAction:
                     "activities_seen": [],
                 }
             )
-        }
-        mock_siemplify.extract_action_param.return_value = None
+        }.get(param_name)
 
         mock_activities.return_value = [
             {"id": "act-102", "data": {"downloadUrl": "/download/102"}}
@@ -371,14 +467,18 @@ class TestAcquireFileAction:
         mock_siemplify.end.assert_called_once()
         msg, is_success, status = mock_siemplify.end.call_args[0]
         assert status == EXECUTION_STATE_FAILED
-        assert is_success is False
+        assert is_success == "false"
 
     @mock.patch.object(AcquireFile, "SiemplifyAction")
     @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
     @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
     @mock.patch.object(SentinelOneManager, "download_file_by_url")
     def test_polling_skip_bad_password_and_corrupt_zip(
-        self, mock_download, mock_activities, mock_token, mock_siemplify_cls
+        self,
+        mock_download,
+        mock_activities,
+        mock_token,
+        mock_siemplify_cls,
     ):
         password = "TargetPassword123!"
         good_content = b"valid file"
@@ -392,7 +492,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.parameters = {
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -402,8 +502,7 @@ class TestAcquireFileAction:
                     "activities_seen": ["act-seen"],
                 }
             )
-        }
-        mock_siemplify.extract_action_param.return_value = None
+        }.get(param_name)
 
         mock_activities.return_value = [
             {"id": "act-seen", "data": {"downloadUrl": "/download/seen"}},
@@ -411,7 +510,7 @@ class TestAcquireFileAction:
             {"id": "act-good", "data": {"downloadUrl": "/download/good"}},
         ]
 
-        def download_side_effect(url):
+        def download_side_effect(url: str) -> bytes:
             if "corrupt" in url:
                 return b"corrupted not a zip"
             return good_zip
@@ -423,7 +522,7 @@ class TestAcquireFileAction:
         mock_siemplify.end.assert_called_once()
         msg, is_success, status = mock_siemplify.end.call_args[0]
         assert status == EXECUTION_STATE_COMPLETED
-        assert is_success is True
+        assert is_success == "true"
 
 
 class TestSentinelOneManagerAcquisitionMethods:
@@ -438,9 +537,7 @@ class TestSentinelOneManagerAcquisitionMethods:
             }
             mock_post.return_value.status_code = 200
 
-            res = manager.fetch_files(
-                "agent_1", "/tmp/file.txt", "Pass123!"
-            )
+            res = manager.fetch_files("agent_1", "/tmp/file.txt", "Pass123!")
             assert res == {"success": True}
             mock_post.assert_called_once()
             assert (

--- a/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
@@ -204,11 +204,11 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "Agent ID": "123456",
             "File Path": "/tmp/malware.exe",
             "Password": None,
-        }.get(param_name)
+        }
 
         main(is_first_run=True)
 
@@ -237,11 +237,11 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "Agent ID": "agent_uuid_123",
             "File Path": "C:\\Windows\\System32\\calc.exe",
             "Password": "CustomSecret123!",
-        }.get(param_name)
+        }
 
         main(is_first_run=True)
 
@@ -263,11 +263,11 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "Agent ID": "123456",
             "File Path": "relative_file.txt",
             "Password": None,
-        }.get(param_name)
+        }
 
         main(is_first_run=True)
 
@@ -285,11 +285,11 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "Agent ID": None,
             "File Path": "/tmp/test.exe",
             "Password": None,
-        }.get(param_name)
+        }
 
         main(is_first_run=True)
 
@@ -309,7 +309,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -319,7 +319,7 @@ class TestAcquireFileAction:
                     "activities_seen": [],
                 }
             )
-        }.get(param_name)
+        }
 
         mock_activities.return_value = []
 
@@ -343,7 +343,9 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.return_value = "{}"
+        mock_siemplify.parameters = {
+            "additional_data": "{}"
+        }
 
         main(is_first_run=False)
 
@@ -374,7 +376,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -384,7 +386,7 @@ class TestAcquireFileAction:
                     "activities_seen": [],
                 }
             )
-        }.get(param_name)
+        }
 
         mock_activities.return_value = [
             {
@@ -440,7 +442,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -450,7 +452,7 @@ class TestAcquireFileAction:
                     "activities_seen": [],
                 }
             )
-        }.get(param_name)
+        }
 
         mock_activities.return_value = [
             {"id": "act-102", "data": {"downloadUrl": "/download/102"}}
@@ -492,7 +494,7 @@ class TestAcquireFileAction:
             "Username": "testuser",
             "Password": "testpass",
         }
-        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+        mock_siemplify.parameters = {
             "additional_data": json.dumps(
                 {
                     "agent_id": "123456",
@@ -502,7 +504,7 @@ class TestAcquireFileAction:
                     "activities_seen": ["act-seen"],
                 }
             )
-        }.get(param_name)
+        }
 
         mock_activities.return_value = [
             {"id": "act-seen", "data": {"downloadUrl": "/download/seen"}},

--- a/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
+++ b/content/response_integrations/google/sentinel_one/tests/test_acquire_file.py
@@ -1,0 +1,486 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from unittest import mock
+
+import pytest
+from soar_sdk.ScriptResult import (
+    EXECUTION_STATE_COMPLETED,
+    EXECUTION_STATE_FAILED,
+    EXECUTION_STATE_INPROGRESS,
+)
+
+from ..actions import AcquireFile
+from ..actions.AcquireFile import (
+    BadZipPasswordError,
+    generate_password,
+    get_acquired_file_info,
+    main,
+    process_acquired_file_bytes,
+)
+from ..core.SentinelOneManager import SentinelOneManager
+
+
+def create_test_zip_package(
+    file_path: str,
+    file_name: str,
+    content: bytes,
+    password: str = "TestPassword123!",
+    included: bool = True,
+    reason: str = "OK",
+) -> bytes:
+    """Helper to construct an in-memory ZIP package matching SentinelOne format."""
+    manifest = [
+        {
+            "path": file_path,
+            "name": file_name,
+            "included": included,
+            "reason": reason,
+            "size": len(content),
+            "sha1": hashlib.sha1(content).hexdigest(),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+    ]
+    manifest_bytes = json.dumps(manifest).encode("utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr("manifest.json", manifest_bytes)
+        if included:
+            zipf.writestr(file_name, content)
+
+    return buf.getvalue()
+
+
+class TestAcquireFileHelpers:
+    def test_generate_password_complexity(self):
+        pwd = generate_password()
+        assert len(pwd) == 15
+        assert any(c.islower() for c in pwd)
+        assert any(c.isupper() for c in pwd)
+        assert any(c.isdigit() for c in pwd)
+        assert any(not c.isalnum() for c in pwd)
+
+    def test_get_acquired_file_info_success(self):
+        zip_bytes = create_test_zip_package(
+            "/tmp/test.exe", "test.exe", b"test content"
+        )
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            info, manifest = get_acquired_file_info(zipf, "/tmp/test.exe")
+            assert info["path"] == "/tmp/test.exe"
+            assert info["included"] is True
+
+    def test_get_acquired_file_info_fallback_single_file(self):
+        zip_bytes = create_test_zip_package(
+            "C:\\path\\file.txt", "file.txt", b"test content"
+        )
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            info, manifest = get_acquired_file_info(zipf, "/other/path/file.txt")
+            assert info["name"] == "file.txt"
+
+    def test_get_acquired_file_info_bad_password(self):
+        zip_bytes = create_test_zip_package(
+            "/tmp/test.exe", "test.exe", b"test content"
+        )
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            with mock.patch.object(
+                zipf, "read", side_effect=RuntimeError("Bad password for file: manifest.json")
+            ):
+                with pytest.raises(BadZipPasswordError):
+                    get_acquired_file_info(zipf, "/tmp/test.exe")
+
+    def test_process_acquired_file_bytes(self):
+        content = b"sample binary payload"
+        zip_bytes = create_test_zip_package(
+            "/tmp/test.bin", "test.bin", content
+        )
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zipf:
+            fname, md5_val, sha256_val, size = process_acquired_file_bytes(zipf)
+            assert fname == "test.bin"
+            assert md5_val == hashlib.md5(content).hexdigest()
+            assert sha256_val == hashlib.sha256(content).hexdigest()
+            assert size == len(content)
+
+    def test_process_acquired_file_bytes_manifest_only(self):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zipf:
+            zipf.writestr("manifest.json", b"[]")
+        with zipfile.ZipFile(buf) as zipf:
+            fname, md5_val, sha256_val, size = process_acquired_file_bytes(zipf)
+            assert fname == ""
+            assert md5_val == ""
+            assert size == 0
+
+
+class TestAcquireFileAction:
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "fetch_files")
+    def test_first_run_success_auto_password(
+        self, mock_fetch, mock_token, mock_siemplify_cls
+    ):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+            "Agent ID": "123456",
+            "File Path": "/tmp/malware.exe",
+            "Password": None,
+        }.get(param_name)
+
+        main(is_first_run=True)
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args[1]
+        assert call_args["agent_id"] == "123456"
+        assert call_args["file_path"] == "/tmp/malware.exe"
+        assert len(call_args["password"]) == 15
+
+        mock_siemplify.end.assert_called_once()
+        msg, state_json, state = mock_siemplify.end.call_args[0]
+        assert state == EXECUTION_STATE_INPROGRESS
+        parsed_state = json.loads(state_json)
+        assert parsed_state["agent_id"] == "123456"
+        assert parsed_state["file_path"] == "/tmp/malware.exe"
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "fetch_files")
+    def test_first_run_custom_password(
+        self, mock_fetch, mock_token, mock_siemplify_cls
+    ):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+            "Agent ID": "agent_uuid_123",
+            "File Path": "C:\\Windows\\System32\\calc.exe",
+            "Password": "CustomSecret123!",
+        }.get(param_name)
+
+        main(is_first_run=True)
+
+        mock_fetch.assert_called_once_with(
+            agent_id="agent_uuid_123",
+            file_path="C:\\Windows\\System32\\calc.exe",
+            password="CustomSecret123!",
+        )
+        assert mock_siemplify.end.call_args[0][2] == EXECUTION_STATE_INPROGRESS
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def test_first_run_invalid_relative_path(self, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.extract_action_param.side_effect = lambda param_name, **kwargs: {
+            "Agent ID": "123456",
+            "File Path": "relative_file.txt",
+            "Password": None,
+        }.get(param_name)
+
+        main(is_first_run=True)
+
+        mock_siemplify.end.assert_called_once()
+        _, _, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    def test_polling_in_progress(
+        self, mock_activities, mock_token, mock_siemplify_cls
+    ):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps(
+                {
+                    "agent_id": "123456",
+                    "file_path": "/tmp/test.exe",
+                    "password": "Password123!",
+                    "created_at": "2026-08-21T18:00:00Z",
+                    "activities_seen": [],
+                }
+            )
+        }
+        mock_siemplify.extract_action_param.return_value = None
+        mock_activities.return_value = []
+
+        main(is_first_run=False)
+
+        mock_activities.assert_called_once_with(
+            agent_id="123456", created_at_gte="2026-08-21T18:00:00Z"
+        )
+        mock_siemplify.end.assert_called_once()
+        msg, state_json, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_INPROGRESS
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    def test_polling_missing_additional_data(self, mock_token, mock_siemplify_cls):
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {}
+        mock_siemplify.extract_action_param.return_value = None
+
+        main(is_first_run=False)
+
+        mock_siemplify.end.assert_called_once()
+        _, _, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    @mock.patch.object(SentinelOneManager, "download_file_by_url")
+    def test_polling_completed_success(
+        self, mock_download, mock_activities, mock_token, mock_siemplify_cls
+    ):
+        password = "SecretPass123!"
+        content = b"executable payload binary"
+        zip_bytes = create_test_zip_package(
+            "/tmp/test.exe", "test.exe", content, password
+        )
+
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps(
+                {
+                    "agent_id": "123456",
+                    "file_path": "/tmp/test.exe",
+                    "password": password,
+                    "created_at": "2026-08-21T18:00:00Z",
+                    "activities_seen": [],
+                }
+            )
+        }
+        mock_siemplify.extract_action_param.return_value = None
+
+        mock_activities.return_value = [
+            {
+                "id": "act-101",
+                "data": {
+                    "downloadUrl": "/activities/download-file?download_url=act-101"
+                },
+            }
+        ]
+        mock_download.return_value = zip_bytes
+
+        main(is_first_run=False)
+
+        mock_siemplify.result.add_result_json.assert_called_once()
+        result_json = mock_siemplify.result.add_result_json.call_args[0][0]
+        assert result_json["status"] == "COMPLETED"
+        assert result_json["file_path"] == "/tmp/test.exe"
+        assert result_json["md5"] == hashlib.md5(content).hexdigest()
+        assert result_json["sha256"] == hashlib.sha256(content).hexdigest()
+
+        mock_siemplify.end.assert_called_once()
+        msg, is_success, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_COMPLETED
+        assert is_success is True
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    @mock.patch.object(SentinelOneManager, "download_file_by_url")
+    def test_polling_file_not_included(
+        self, mock_download, mock_activities, mock_token, mock_siemplify_cls
+    ):
+        password = "SecretPass123!"
+        zip_bytes = create_test_zip_package(
+            "/tmp/missing.exe",
+            "missing.exe",
+            b"",
+            password,
+            included=False,
+            reason="File permission denied",
+        )
+
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps(
+                {
+                    "agent_id": "123456",
+                    "file_path": "/tmp/missing.exe",
+                    "password": password,
+                    "created_at": "2026-08-21T18:00:00Z",
+                    "activities_seen": [],
+                }
+            )
+        }
+        mock_siemplify.extract_action_param.return_value = None
+
+        mock_activities.return_value = [
+            {"id": "act-102", "data": {"downloadUrl": "/download/102"}}
+        ]
+        mock_download.return_value = zip_bytes
+
+        main(is_first_run=False)
+
+        mock_siemplify.result.add_result_json.assert_called_once()
+        result_json = mock_siemplify.result.add_result_json.call_args[0][0]
+        assert result_json["status"] == "FAILED"
+        assert result_json["reason"] == "File permission denied"
+
+        mock_siemplify.end.assert_called_once()
+        msg, is_success, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_FAILED
+        assert is_success is False
+
+    @mock.patch.object(AcquireFile, "SiemplifyAction")
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="dummy_token")
+    @mock.patch.object(SentinelOneManager, "get_file_upload_activities")
+    @mock.patch.object(SentinelOneManager, "download_file_by_url")
+    def test_polling_skip_bad_password_and_corrupt_zip(
+        self, mock_download, mock_activities, mock_token, mock_siemplify_cls
+    ):
+        password = "TargetPassword123!"
+        good_content = b"valid file"
+        good_zip = create_test_zip_package(
+            "/tmp/target.exe", "target.exe", good_content, password
+        )
+
+        mock_siemplify = mock_siemplify_cls.return_value
+        mock_siemplify.get_configuration.return_value = {
+            "Api Root": "https://test.sentinelone.net",
+            "Username": "testuser",
+            "Password": "testpass",
+        }
+        mock_siemplify.parameters = {
+            "additional_data": json.dumps(
+                {
+                    "agent_id": "123456",
+                    "file_path": "/tmp/target.exe",
+                    "password": password,
+                    "created_at": "2026-08-21T18:00:00Z",
+                    "activities_seen": ["act-seen"],
+                }
+            )
+        }
+        mock_siemplify.extract_action_param.return_value = None
+
+        mock_activities.return_value = [
+            {"id": "act-seen", "data": {"downloadUrl": "/download/seen"}},
+            {"id": "act-corrupt", "data": {"downloadUrl": "/download/corrupt"}},
+            {"id": "act-good", "data": {"downloadUrl": "/download/good"}},
+        ]
+
+        def download_side_effect(url):
+            if "corrupt" in url:
+                return b"corrupted not a zip"
+            return good_zip
+
+        mock_download.side_effect = download_side_effect
+
+        main(is_first_run=False)
+
+        mock_siemplify.end.assert_called_once()
+        msg, is_success, status = mock_siemplify.end.call_args[0]
+        assert status == EXECUTION_STATE_COMPLETED
+        assert is_success is True
+
+
+class TestSentinelOneManagerAcquisitionMethods:
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="mock_token")
+    def test_manager_fetch_files(self, mock_token):
+        manager = SentinelOneManager(
+            "https://test.sentinelone.net", "user", "pass"
+        )
+        with mock.patch.object(manager.session, "post") as mock_post:
+            mock_post.return_value.json.return_value = {
+                "data": {"success": True}
+            }
+            mock_post.return_value.status_code = 200
+
+            res = manager.fetch_files(
+                "agent_1", "/tmp/file.txt", "Pass123!"
+            )
+            assert res == {"success": True}
+            mock_post.assert_called_once()
+            assert (
+                mock_post.call_args[0][0]
+                == "https://test.sentinelone.net/web/api/v2.1/agents/agent_1/actions/fetch-files"
+            )
+
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="mock_token")
+    def test_manager_get_file_upload_activities(self, mock_token):
+        manager = SentinelOneManager(
+            "https://test.sentinelone.net", "user", "pass"
+        )
+        with mock.patch.object(manager.session, "get") as mock_get:
+            mock_get.return_value.json.return_value = {
+                "data": [{"id": 1, "data": {"downloadUrl": "/dl/1"}}]
+            }
+            mock_get.return_value.status_code = 200
+
+            res = manager.get_file_upload_activities(
+                "agent_1", created_at_gte="2026-08-21T00:00:00Z"
+            )
+            assert len(res) == 1
+            assert res[0]["id"] == 1
+            params = mock_get.call_args[1]["params"]
+            assert params["activity_types"] == "80"
+            assert params["agent_ids"] == "agent_1"
+            assert params["createdAt__gte"] == "2026-08-21T00:00:00Z"
+
+    @mock.patch.object(SentinelOneManager, "get_token", return_value="mock_token")
+    def test_manager_download_file_by_url(self, mock_token):
+        manager = SentinelOneManager(
+            "https://test.sentinelone.net", "user", "pass"
+        )
+        with mock.patch.object(manager.session, "get") as mock_get:
+            mock_get.return_value.content = b"zip_content_bytes"
+            mock_get.return_value.status_code = 200
+
+            content = manager.download_file_by_url("/download/act-1")
+            assert content == b"zip_content_bytes"
+            assert (
+                mock_get.call_args[0][0]
+                == "https://test.sentinelone.net/web/api/v2.1/download/act-1"
+            )

--- a/content/response_integrations/google/sentinel_one/uv.lock
+++ b/content/response_integrations/google/sentinel_one/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 
 [[package]]
 name = "sentinelone"
-version = "6.0"
+version = "7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The SentinelOne integration previously lacked a production-grade file acquisition action to remotely collect files from endpoints. File acquisition in SentinelOne is inherently asynchronous (initiating the upload request on the agent followed by polling activity log type 80 for completion and downloading the encrypted ZIP archive).

**How does this PR solve the problem?**
1. Adds a unified asynchronous `Acquire File` action (`AcquireFile.py`, `AcquireFile.yaml`) using `@output_handler(is_async_action=True)` to handle both initiation and polling cycles within a single action.
2. Accepts `Agent ID` (with fallback to `HOSTNAME` and `ADDRESS` alert entities), `File Path`, and optional `Password`.
3. Implements automatic 15-character complex password generation if no password is provided.
4. Adds `fetch_files`, `get_file_upload_activities`, and `download_file_by_url` methods to `SentinelOneManager.py` (API v2.1).
5. Implements in-memory ZIP package decryption, `manifest.json` extraction, and MD5 / SHA256 checksum computation.
6. Saves the acquired package to local disk (`download_path` / `local_package_file`) for downstream playbook ingestion (e.g. GCS upload / GTI hash lookup).
7. Adds comprehensive unit test suite (`test_acquire_file.py`, 22 tests) covering helper algorithms, first-run initiation, polling cycles, bad passwords, and manager methods.
8. Adds `AcquireFile_JsonResult_example.json`, test `config.json`, `Verify SSL` config, and updates `release_notes.yaml` / `pyproject.toml` version to `7.0`.

**Any other relevant information:**
* Buganizer ticket: [b/549777562](https://b.corp.google.com/issues/549777562).
* All 23 unit tests passing locally.

---

## Checklist:

### General Checks:
- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/marketplace/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes.
- [x] I have updated the documentation where necessary.

### Open-Source Specific Checks:
- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems.

### For Google Team Members and Reviewers Only:
- [x] I have included the Buganizer ID in the PR title or description (Buganizer ID: 549777562).
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.
