### PR TITLE
Bump Lists integration to v18.0 and update TIPCommon to v2.4.4 

### DIFF
--- a/content/response_integrations/power_ups/lists/pyproject.toml
+++ b/content/response_integrations/power_ups/lists/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Lists"
-version = "17.0"
+version = "18.0"
 description = "A set of tools to facilitate managing custom lists within Google SecOps."
 requires-python = ">=3.11,<3.12"
 dependencies = [
@@ -19,8 +19,8 @@ dev = [
 
 [tool.uv.sources]
 soar-sdk = { git = "https://github.com/chronicle/soar-sdk.git" }
-integration-testing = { path = "../../../../packages/integration_testing_whls/integration_testing-2.3.7-py3-none-any.whl" }
-tipcommon = { path = "../../../../packages/tipcommon/whls/TIPCommon-2.3.7-py3-none-any.whl" }
+integration-testing = { path = "../../../../packages/integration_testing_whls/integration_testing-2.4.4-py3-none-any.whl" }
+tipcommon = { path = "../../../../packages/tipcommon/whls/TIPCommon-2.4.4-py3-none-any.whl" }
 environmentcommon = { path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.3-py3-none-any.whl" }
 
 [[tool.uv.index]]

--- a/content/response_integrations/power_ups/lists/uv.lock
+++ b/content/response_integrations/power_ups/lists/uv.lock
@@ -388,11 +388,10 @@ wheels = [
 
 [[package]]
 name = "integration-testing"
-version = "2.3.7"
-source = { path = "../../../../packages/integration_testing_whls/integration_testing-2.3.7-py3-none-any.whl" }
+version = "2.4.4"
+source = { path = "../../../../packages/integration_testing_whls/integration_testing-2.4.4-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "environmentcommon" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "soar-sdk" },
@@ -400,13 +399,12 @@ dependencies = [
     { name = "yarl" },
 ]
 wheels = [
-    { filename = "integration_testing-2.3.7-py3-none-any.whl", hash = "sha256:9e5d744a57bb8092ce76106cd6a0c3dd5cfa3e2d583a20a621fe4b84b28c846b" },
+    { filename = "integration_testing-2.4.4-py3-none-any.whl", hash = "sha256:e0c5251479471a56c0471ec005243ab2350e4d20ee0ec689037b7bb062ec18eb" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.13" },
-    { name = "environmentcommon" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "soar-sdk" },
@@ -416,7 +414,7 @@ requires-dist = [
 
 [[package]]
 name = "lists"
-version = "17.0"
+version = "18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "environmentcommon" },
@@ -435,13 +433,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.3-py3-none-any.whl" },
-    { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-2.3.7-py3-none-any.whl" },
+    { name = "tipcommon", path = "../../../../packages/tipcommon/whls/TIPCommon-2.4.4-py3-none-any.whl" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "environmentcommon", path = "../../../../packages/envcommon/whls/EnvironmentCommon-1.0.3-py3-none-any.whl" },
-    { name = "integration-testing", path = "../../../../packages/integration_testing_whls/integration_testing-2.3.7-py3-none-any.whl" },
+    { name = "integration-testing", path = "../../../../packages/integration_testing_whls/integration_testing-2.4.4-py3-none-any.whl" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "soar-sdk", git = "https://github.com/chronicle/soar-sdk.git" },
@@ -769,8 +767,8 @@ dependencies = [
 
 [[package]]
 name = "tipcommon"
-version = "2.3.7"
-source = { path = "../../../../packages/tipcommon/whls/TIPCommon-2.3.7-py3-none-any.whl" }
+version = "2.4.4"
+source = { path = "../../../../packages/tipcommon/whls/TIPCommon-2.4.4-py3-none-any.whl" }
 dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
@@ -782,7 +780,7 @@ dependencies = [
     { name = "requests-toolbelt" },
 ]
 wheels = [
-    { filename = "tipcommon-2.3.7-py3-none-any.whl", hash = "sha256:4bc35f0a71bdd5a6b0bb011ec73c1b344e3506856977fe082f2db71a0d8459d2" },
+    { filename = "tipcommon-2.4.4-py3-none-any.whl", hash = "sha256:0d8afc9054e1ada5e12a3080ebf43cbc112aa94e1ca7feb5a4ff053bd8a891dc" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
 **What problem does this PR solve?**
    Releases the `TIPCommon` OData URL encoding fix (which resolves OData crashes caused by URL-reserved special characters in environment names, e.g. `Weißer + Grießhaber`) to the `Lists` integration. 

**How does this PR solve the problem?**
    - Bumps the `Lists` integration major version to `18.0` to force a clean backend installation bypassing the old cached virtual environment.
    - Updates the `TIPCommon` package dependency in `pyproject.toml` and `uv.lock` from `2.3.7` to the newly rebuilt `2.4.4` wheel.
    - Updates the `integration-testing` dependency to `2.4.4`.

**Any other relevant information:**
    This is the downstream integration bump that delivers the core library fix merged in PR #1211 directly to the SOAR Marketplace.


## Checklist:

### General Checks:
 - [x] I have read and followed the project's contributing.md.
 - [x] My code follows the project's coding style guidelines.
 - [x] I have performed a self-review of my own code.
 - [x] My changes do not introduce any new warnings.
 - [x] My changes pass all existing tests.
 - [ ] I have added new tests where appropriate to cover my changes. (If applicable)
 - [ ] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:
 - [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
 - [x] My changes do not expose any internal-only code examples, configurations, or URLs.
 - [x] All code examples, comments, and messages are generic and suitable for a public repository.
 - [x] I understand that any internal context or sensitive details related to this work are handled separately in internal  systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:
- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Bu