### PR TITLE
[b/73850464] TrendVisionOne: Enforce Description parameter as mandato…

### DIFF
--- a/content/response_integrations/google/trend_vision_one/actions/IsolateEndpoint.py
+++ b/content/response_integrations/google/trend_vision_one/actions/IsolateEndpoint.py
@@ -278,7 +278,7 @@ def main(is_first_run):
         print_value=True,
     )
     description = extract_action_param(
-        siemplify, param_name="Description", print_value=True, is_mandatory=False
+        siemplify, param_name="Description", print_value=True, is_mandatory=True
     )
     agent_uuids = string_to_multi_value(
         extract_action_param(

--- a/content/response_integrations/google/trend_vision_one/actions/IsolateEndpoint.yaml
+++ b/content/response_integrations/google/trend_vision_one/actions/IsolateEndpoint.yaml
@@ -23,7 +23,7 @@ parameters:
     default_value: ''
     type: string
     description: Specify the reasoning for the isolation of the endpoints.
-    is_mandatory: false
+    is_mandatory: true
 -   name: Agent UUID
     default_value: ''
     type: string

--- a/content/response_integrations/google/trend_vision_one/pyproject.toml
+++ b/content/response_integrations/google/trend_vision_one/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "TrendVisionOne"
-version = "11.0"
+version = "12.0"
 description = "Trend Vision One is a purpose-built threat defense platform that provides added value and new benefits beyond XDR solutions, allowing you to see more and respond faster. Providing deep and broad extended detection and response."
 requires-python = ">=3.11,<3.12"
 dependencies = [ "environmentcommon", "requests==2.32.4", "tipcommon",]

--- a/content/response_integrations/google/trend_vision_one/release_notes.yaml
+++ b/content/response_integrations/google/trend_vision_one/release_notes.yaml
@@ -139,3 +139,9 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: Isolate Endpoint - Enforced the Description parameter as mandatory.
+  version: 12.0
+  item_name: Isolate Endpoint
+  item_type: Action
+  publish_time: '2026-09-04'
+  ticket_number: '73850464'

--- a/content/response_integrations/google/trend_vision_one/resources/ai/actions_ai_description.yaml
+++ b/content/response_integrations/google/trend_vision_one/resources/ai/actions_ai_description.yaml
@@ -581,7 +581,7 @@ Isolate Endpoint:
 
     | --- | --- | --- | --- |
 
-    | Description | String | No | Specify the reasoning for the isolation of the endpoints.
+    | Description | String | Yes | Specify the reasoning for the isolation of the endpoints.
     |
 
     | Agent UUID | String | No | A comma-separated list of UUIDs. The action processes

--- a/content/response_integrations/google/trend_vision_one/uv.lock
+++ b/content/response_integrations/google/trend_vision_one/uv.lock
@@ -386,7 +386,7 @@ requires-dist = [
 
 [[package]]
 name = "trendvisionone"
-version = "11.0"
+version = "12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "environmentcommon" },


### PR DESCRIPTION
## Description

### What problem does this PR solve?
In the TrendVisionOne integration, running the "Isolate Endpoint" action without providing a "Description" resulted in an API exception (`400 Bad Request: Invalid field format: description`) because the underlying Trend Vision One API endpoint requires a description. This field was previously set as optional (`is_mandatory: false`).

### How does this PR solve the problem?
- Enforced the `Description` parameter as mandatory (`is_mandatory: true`) in `IsolateEndpoint.yaml`.
- Updated parameter extraction in `IsolateEndpoint.py` to `is_mandatory=True`.
- Updated `actions_ai_description.yaml` to reflect `Description` as mandatory (`Yes`).
- Bumped integration version from `11.0` to `12.0` in `pyproject.toml` and `uv.lock`.
- Appended release note entry for version `12.0` in `release_notes.yaml` referencing ticket `73850464`.

### Any other relevant information:
- Integration: TrendVisionOne
- Affected Action: Isolate Endpoint
- Ticket / Case ID: b/73850464

---

## Checklist:

### General Checks:
- I have read and followed the project's contributing guide.
- My code follows the project's coding style guidelines.
- I have performed a self-review of my own code.
- My changes do not introduce any new warnings.
- My changes pass all existing tests.
- I have added new tests where appropriate to cover my changes.
- I have updated the documentation where necessary.

### Open-Source Specific Checks:
-My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- My changes do not expose any internal-only code examples, configurations, or URLs.
- All code examples, comments, and messages are generic and suitable for a public repository.
-  I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:
- I have included the Buganizer ID in the PR title or description (Internal Buganizer ID: 73850464).
- I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- I have tagged the PR with one or more labels that reflect the pull request purpose.
