### PR TITLE
[b/507079969] Fix Tools Convert Into Simulated Case enum alignment and file extension

### DIFF
--- a/content/response_integrations/power_ups/tools/actions/ConvertIntoSimulatedCase.py
+++ b/content/response_integrations/power_ups/tools/actions/ConvertIntoSimulatedCase.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 from typing import Any
 
 from soar_sdk.ScriptResult import EXECUTION_STATE_COMPLETED, EXECUTION_STATE_FAILED
 from soar_sdk.SiemplifyAction import SiemplifyAction
 from soar_sdk.SiemplifyUtils import output_handler
-
 from TIPCommon.rest.soar_api import import_simulator_custom_case
 from TIPCommon.types import SingleJson
 
@@ -81,9 +81,7 @@ def main():
     if "SourceFileContent" in siemplify.current_alert.entities[0].additional_properties:
         # Load the alert data from the 'SourceFileContent' property.
         case_data = json.loads(
-            siemplify.current_alert.entities[0].additional_properties[
-                "SourceFileContent"
-            ],
+            siemplify.current_alert.entities[0].additional_properties["SourceFileContent"],
         )
     else:
         siemplify.LOGGER.error("Alert data is missing 'SourceFileContent' property")
@@ -92,29 +90,19 @@ def main():
     # Modify the 'Event Name' fields in the alert data.
     for i, event in enumerate(case_data["Events"]):
         if "DeviceEventClassId" in case_data["Events"][i]["_fields"]:
-            case_data["Events"][i]["_rawDataFields"]["DeviceEventClassId"] = case_data[
-                "Events"
-            ][i]["_fields"]["DeviceEventClassId"]
-            case_data["Events"][i]["_rawDataFields"]["Name"] = case_data["Events"][i][
-                "_fields"
-            ]["DeviceEventClassId"]
+            case_data["Events"][i]["_rawDataFields"]["DeviceEventClassId"] = case_data["Events"][i]["_fields"][
+                "DeviceEventClassId"
+            ]
+            case_data["Events"][i]["_rawDataFields"]["Name"] = case_data["Events"][i]["_fields"]["DeviceEventClassId"]
         if "deviceEventClassId" in case_data["Events"][i]["_fields"]:
-            case_data["Events"][i]["_rawDataFields"]["DeviceEventClassId"] = case_data[
-                "Events"
-            ][i]["_fields"]["deviceEventClassId"]
-            case_data["Events"][i]["_rawDataFields"]["Name"] = case_data["Events"][i][
-                "_fields"
-            ]["deviceEventClassId"]
+            case_data["Events"][i]["_rawDataFields"]["DeviceEventClassId"] = case_data["Events"][i]["_fields"][
+                "deviceEventClassId"
+            ]
+            case_data["Events"][i]["_rawDataFields"]["Name"] = case_data["Events"][i]["_fields"]["deviceEventClassId"]
 
     # Optionally modify the 'Name' field in the alert data.
     if fullPathName:
-        case_data["Name"] = (
-            case_data["SourceSystemName"]
-            + "_"
-            + case_data["DeviceProduct"]
-            + "_"
-            + case_data["Name"]
-        )
+        case_data["Name"] = case_data["SourceSystemName"] + "_" + case_data["DeviceProduct"] + "_" + case_data["Name"]
     if overrideName:
         case_data["Name"] = overrideName
 
@@ -134,7 +122,7 @@ def main():
         # Add the JSON data as an attachment to the case wall.
         siemplify.result.add_attachment(
             title="<<file in here>>",
-            filename=case_data["Name"] + ".case",
+            filename=sanitize_case_filename(case_data.get("Name", "")),
             file_contents=t,
         )
         output_message += " Saved to Casewall "
@@ -145,6 +133,21 @@ def main():
     # Add the JSON data to the action result and end the action.
     siemplify.result.add_result_json(myJson)
     siemplify.end(output_message, result_value, status)
+
+
+def sanitize_case_filename(name: str) -> str:
+    """Sanitize case name to construct a clean .case attachment filename.
+    Args:
+        name: The raw case or alert name.
+
+    Returns:
+        The sanitized filename ending with '.case'.
+    """
+    if not name:
+        return "case.case"
+    clean_name = re.sub(r"(\.(case|json|txt))+$", "", name.strip(), flags=re.IGNORECASE)
+    clean_name = re.sub(r'[\\/*?:"<>|\n\r\t]', "_", clean_name).strip(" ._")
+    return f"{clean_name or 'case'}.case"
 
 
 def align_case_data(case_data: SingleJson) -> SingleJson:
@@ -170,6 +173,9 @@ def align_case_data(case_data: SingleJson) -> SingleJson:
             new_case[camel_k] = transform_events_list(v)
         else:
             new_case[camel_k] = v
+
+    if "caseType" in new_case and "type" not in new_case:
+        new_case["type"] = new_case["caseType"]
 
     return new_case
 
@@ -206,11 +212,18 @@ def align_enum_field(
     for key in keys:
         if key in data:
             val: Any = data[key]
-            if isinstance(val, int) and not isinstance(val, bool):
+            if isinstance(val, bool):
+                continue
+            if isinstance(val, int):
                 if val in value_map:
                     data[key] = value_map[val]
                 else:
                     data.pop(key, None)
+            elif isinstance(val, str):
+                if val.isdigit() and int(val) in value_map:
+                    data[key] = value_map[int(val)]
+                elif val.upper() in value_map.values():
+                    data[key] = val.upper()
 
 
 def transform_events_list(events: list[Any]) -> list[Any]:
@@ -245,16 +258,14 @@ def transform_event(event: SingleJson) -> SingleJson:
         camel_ek: str = to_camel_case(ek)
 
         if camel_ek in (constants.FIELDS_KEY, constants.DATA_FIELDS_KEY) and isinstance(ev, dict):
-            new_event[camel_ek] = {
-                k2: v2 for k2, v2 in ev.items() if not k2.startswith("__")
-            }
+            new_event[camel_ek] = {k2: v2 for k2, v2 in ev.items() if not k2.startswith("__")}
         else:
             new_event[camel_ek] = ev
     return new_event
 
 
 def to_camel_case(key_name: str) -> str:
-    """Convert PascalCase property names to camelCase.
+    """Convert PascalCase or snake_case property names to camelCase.
     Args:
         key_name: The string to convert.
 
@@ -267,6 +278,9 @@ def to_camel_case(key_name: str) -> str:
         return constants.FIELDS_KEY
     if key_name == constants.RAW_DATA_FIELDS_KEY:
         return constants.DATA_FIELDS_KEY
+    if "_" in key_name and not key_name.startswith("_"):
+        parts = key_name.split("_")
+        return parts[0].lower() + "".join(p.capitalize() for p in parts[1:])
     return key_name[0].lower() + key_name[1:]
 
 

--- a/content/response_integrations/power_ups/tools/core/constants.py
+++ b/content/response_integrations/power_ups/tools/core/constants.py
@@ -17,15 +17,14 @@ from __future__ import annotations
 import re
 
 INTEGRATION_NAME: str = "Tools"
-DELAY_PLAYBOOK_SYNCHRONOUS_SCRIPT_NAME: str = (
-    f"{INTEGRATION_NAME} - Delay Playbook Synchronous"
-)
+DELAY_PLAYBOOK_SYNCHRONOUS_SCRIPT_NAME: str = f"{INTEGRATION_NAME} - Delay Playbook Synchronous"
 
 MAX_SYNC_DELAY_TIME_IN_SECONDS: int = 30
 MIN_SYNC_DELAY_TIME_IN_SECONDS: int = 0
 LABEL_REGEX = re.compile(r"^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$")
 
 CASE_TYPE_MAP: dict[int, str] = {
+    0: "SIMULATED",
     1: "EXTERNAL",
     2: "TEST",
     3: "REQUEST",
@@ -48,6 +47,24 @@ RAW_DATA_FIELDS_KEY: str = "_rawDataFields"
 DATA_FIELDS_KEY: str = "rawDataFields"
 UNDEFINED_VALUE: str = "undefined"
 
-CASE_TYPE_KEYS: list[str] = ["Type", "type"]
-DATA_TYPE_KEYS: list[str] = ["DataType", "Datatype", "dataType", "datatype"]
-SOURCE_TYPE_KEYS: list[str] = ["SourceType", "sourceType", "sourcetype"]
+CASE_TYPE_KEYS: list[str] = [
+    "CaseType",
+    "caseType",
+    "casetype",
+    "case_type",
+    "Type",
+    "type",
+]
+DATA_TYPE_KEYS: list[str] = [
+    "DataType",
+    "Datatype",
+    "dataType",
+    "datatype",
+    "data_type",
+]
+SOURCE_TYPE_KEYS: list[str] = [
+    "SourceType",
+    "sourceType",
+    "sourcetype",
+    "source_type",
+]

--- a/content/response_integrations/power_ups/tools/pyproject.toml
+++ b/content/response_integrations/power_ups/tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Tools"
-version = "84.0"
+version = "85.0"
 description = "A set of utility actions for data manipulation and common platform tasks to power up playbook capabilities."
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/power_ups/tools/release_notes.yaml
+++ b/content/response_integrations/power_ups/tools/release_notes.yaml
@@ -640,3 +640,9 @@
   item_type: Integration
   publish_time: '2026-07-17'
   ticket_number: ''
+- description: Convert Into Simulated Case - Fixed CaseType enum string token alignment and sanitized attachment file extension for custom case imports.
+  version: 85.0
+  item_name: Convert Into Simulated Case
+  item_type: Action
+  publish_time: '2026-09-07'
+  ticket_number: '74347249'

--- a/content/response_integrations/power_ups/tools/tests/test_actions/test_convert_into_simulated_case.py
+++ b/content/response_integrations/power_ups/tools/tests/test_actions/test_convert_into_simulated_case.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import copy
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -55,9 +57,7 @@ def test_convert_into_simulated_case_success(
     action_output: MockActionOutput,
 ) -> None:
     """Test ConvertIntoSimulatedCase action success."""
-    tools.set_alerts_full_details(
-        load_mock_data[CONVERT_INTO_SIMULATED_CASE_ALERT_DETAILS_KEY]
-    )
+    tools.set_alerts_full_details(load_mock_data[CONVERT_INTO_SIMULATED_CASE_ALERT_DETAILS_KEY])
 
     ConvertIntoSimulatedCase.main()
 
@@ -73,3 +73,140 @@ def test_convert_into_simulated_case_success(
     expected_json = load_mock_data[CONVERT_INTO_SIMULATED_CASE_EXPECTED_DATA_KEY]
 
     assert payload == expected_json
+
+
+@pytest.mark.execution_scope("Alert")
+@set_metadata(
+    parameters={
+        "Push to Simulated Cases": True,
+        "Save JSON as Case Wall File": False,
+        "Override Alert Name": "",
+        "Full path name": "",
+    },
+    input_context=CONVERT_INTO_SIMULATED_CASE_CONTEXT,
+)
+def test_convert_into_simulated_case_with_casetype(
+    tools: Tools,
+    script_session: ToolsSession,
+    load_mock_data: SingleJson,
+    action_output: MockActionOutput,
+) -> None:
+    """Test ConvertIntoSimulatedCase action converts CaseType integer to string."""
+    alert_details = copy.deepcopy(load_mock_data[CONVERT_INTO_SIMULATED_CASE_ALERT_DETAILS_KEY])
+    alert_details[0]["domain_entities"][0]["additional_properties"]["SourceFileContent"] = json.dumps({
+        "Name": "Simulated Alert",
+        "CaseType": 1,
+        "DataType": 1,
+        "SourceType": 1,
+        "Events": [],
+    })
+    tools.set_alerts_full_details(alert_details)
+
+    ConvertIntoSimulatedCase.main()
+
+    assert action_output.results.execution_state.value == EXECUTION_STATE_COMPLETED
+    assert OUTPUT_MESSAGE in action_output.results.output_message
+
+    import_request = script_session.request_history[-1]
+    payload = import_request.request.kwargs.get("json") or {}
+    case = payload["cases"][0]
+    assert case["caseType"] == "EXTERNAL"
+    assert case["type"] == "EXTERNAL"
+    assert isinstance(case["caseType"], str)
+    assert isinstance(case["type"], str)
+
+
+@pytest.mark.execution_scope("Alert")
+@set_metadata(
+    parameters={
+        "Push to Simulated Cases": False,
+        "Save JSON as Case Wall File": True,
+        "Override Alert Name": "Exported_Alert.json",
+        "Full path name": "",
+    },
+    input_context=CONVERT_INTO_SIMULATED_CASE_CONTEXT,
+)
+def test_convert_into_simulated_case_save_to_casewall(
+    tools: Tools,
+    load_mock_data: SingleJson,
+    action_output: MockActionOutput,
+) -> None:
+    """Test ConvertIntoSimulatedCase saves to Casewall with sanitized .case filename."""
+    tools.set_alerts_full_details(load_mock_data[CONVERT_INTO_SIMULATED_CASE_ALERT_DETAILS_KEY])
+
+    ConvertIntoSimulatedCase.main()
+
+    assert action_output.results.execution_state.value == EXECUTION_STATE_COMPLETED
+    assert "Saved to Casewall" in action_output.results.output_message
+
+
+@pytest.mark.parametrize(
+    ("input_case_type", "expected_type"),
+    [
+        (0, "SIMULATED"),
+        (1, "EXTERNAL"),
+        (2, "TEST"),
+        (3, "REQUEST"),
+        ("1", "EXTERNAL"),
+        ("external", "EXTERNAL"),
+    ],
+)
+def test_align_case_data_case_type_values(
+    input_case_type: int | str,
+    expected_type: str,
+) -> None:
+    """Test align_case_data correctly converts various CaseType values to string tokens."""
+    raw_case = {
+        "Name": "Test Case",
+        "CaseType": input_case_type,
+        "Events": [],
+    }
+    aligned = ConvertIntoSimulatedCase.align_case_data(raw_case)
+    assert aligned["caseType"] == expected_type
+    assert aligned["type"] == expected_type
+
+
+def test_align_case_data_drops_invalid_integer() -> None:
+    """Test align_case_data drops unknown integers to avoid backend enum parse errors."""
+    raw_case = {
+        "Name": "Test Case",
+        "CaseType": 99,
+        "Events": [],
+    }
+    aligned = ConvertIntoSimulatedCase.align_case_data(raw_case)
+    assert "caseType" not in aligned
+    assert "type" not in aligned
+
+
+def test_align_case_data_snake_case_fields() -> None:
+    """Test align_case_data handles snake_case keys correctly."""
+    raw_case = {
+        "Name": "Test Case",
+        "case_type": 1,
+        "data_type": 1,
+        "source_type": 1,
+        "Events": [],
+    }
+    aligned = ConvertIntoSimulatedCase.align_case_data(raw_case)
+    assert aligned["caseType"] == "EXTERNAL"
+    assert aligned["type"] == "EXTERNAL"
+    assert aligned["dataType"] == "1"
+    assert aligned["sourceType"] == "CONNECTOR"
+
+
+@pytest.mark.parametrize(
+    ("raw_name", "expected_filename"),
+    [
+        ("NormalCase", "NormalCase.case"),
+        ("Alert.json", "Alert.case"),
+        ("Alert.txt", "Alert.case"),
+        ("Alert.case", "Alert.case"),
+        ("Alert.json.txt", "Alert.case"),
+        ("Alert:Special/Chars*", "Alert_Special_Chars.case"),
+        ("", "case.case"),
+    ],
+)
+def test_sanitize_case_filename(raw_name: str, expected_filename: str) -> None:
+    """Test sanitize_case_filename properly strips extensions and bad chars."""
+    result = ConvertIntoSimulatedCase.sanitize_case_filename(raw_name)
+    assert result == expected_filename

--- a/content/response_integrations/power_ups/tools/uv.lock
+++ b/content/response_integrations/power_ups/tools/uv.lock
@@ -923,7 +923,7 @@ wheels = [
 
 [[package]]
 name = "tools"
-version = "84.0"
+version = "85.0"
 source = { virtual = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
### Description
Resolves Virgin Media customer issue (Case 74347249 / Bug b/507079969) where exporting and importing simulated cases via the "Convert into Simulated Case" action failed with:
`Expected string TokenType for enum [CaseType], but got [Integer]`
and saved files with incorrect `.json.txt` / `.txt` extensions.

### Changes
- **constants.py**:
  - Expanded `CASE_TYPE_KEYS` to include `["CaseType", "caseType", "casetype", "case_type", "Type", "type"]`.
  - Added `0: "SIMULATED"` to `CASE_TYPE_MAP`.
  - Added snake_case variants to `DATA_TYPE_KEYS` and `SOURCE_TYPE_KEYS`.
- **ConvertIntoSimulatedCase.py**:
  - Updated `align_enum_field()` to handle integer values, string integers (`"1"`), and string enum names, while dropping unmapped integers.
  - Synchronized `type` and `caseType` in `align_case_data()` to ensure backend deserializer matches string enum tokens.
  - Added `sanitize_case_filename()` to strip trailing `.json`, `.txt`, `.case` extensions and clean illegal characters.
  - Updated `to_camel_case()` to support snake_case keys.
- **pyproject.toml & release_notes.yaml**:
  - Bumped version to `85.0`.
  - Added release notes entry for Case 74347249.
- **Tests**:
  - Added comprehensive unit tests in `test_convert_into_simulated_case.py` covering all `CaseType` values, invalid integers, snake_case keys, and filename sanitization.

### Testing
- `ruff check`: Passed (0 errors).
- `mp format`: Passed (0 violations).
- `mp test -i Tools`: All unit tests passed.
- `mp validate -i Tools`: All validations passed.
