### PR TITLE
[Buganizer ID: 493283474] Chore: Add cyberint to mapping rules exclusions and bump mp to 1.35.2

### DIFF
--- a/packages/mp/pyproject.toml
+++ b/packages/mp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mp"
-version = "1.35.1"
+version = "1.35.2"
 description = "General Purpose CLI tool for Google SecOps Marketplace"
 readme = "README.md"
 authors = [

--- a/packages/mp/src/mp/core/data/exclusions.yaml
+++ b/packages/mp/src/mp/core/data/exclusions.yaml
@@ -368,6 +368,7 @@ excluded_integrations_with_connectors_and_no_mapping:
   - "air_table"
   - "be_secure"
   - "connectors"
+  - "cyberint"
   - "cybersixgill_actionable_alerts"
   - "cybersixgill_darkfeed"
   - "cybersixgill_dve_feed"

--- a/packages/mp/uv.lock
+++ b/packages/mp/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "mp"
-version = "1.35.1"
+version = "1.35.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Cyberint's `AlertsConnector` does not ship with a default mapping rules file. Without an exemption, the automated `IntegrationHasMappingRulesIfHasConnectorValidation` validator in `mp check` raises a validation error and fails CI pipelines touching Cyberint.

**How does this PR solve the problem?**
- Added `cyberint` to the `excluded_integrations_with_connectors_and_no_mapping` list in `packages/mp/src/mp/core/data/exclusions.yaml`.
- Bumped `mp` package patch version to `1.35.2` in `packages/mp/pyproject.toml`.
- Synchronized `packages/mp/uv.lock` with the updated package version.

**Any other relevant information (e.g., design choices, tradeoffs, known issues):**
This is a dedicated package PR created per repository guidelines to isolate `packages/mp` changes from integration changes in downstream PR #1231.

---

## Checklist:

### General Checks:

- [x] I have read and followed the project's [contributing.md](https://github.com/chronicle/content-hub/blob/main/docs/contributing.md) guide.
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings.
- [x] My changes pass all existing tests.
- [x] I have added new tests where appropriate to cover my changes. (If applicable)
- [x] I have updated the documentation where necessary (e.g., README, API docs). (If applicable)

### Open-Source Specific Checks:

- [x] My changes do not introduce any Personally Identifiable Information (PII) or sensitive customer data.
- [x] My changes do not expose any internal-only code examples, configurations, or URLs.
- [x] All code examples, comments, and messages are generic and suitable for a public repository.
- [x] I understand that any internal context or sensitive details related to this work are handled separately in internal systems (Buganizer for Google team members).

### For Google Team Members and Reviewers Only:

- [x] I have included the Buganizer ID in the PR title or description (e.g., "Internal Buganizer ID: 123456789" or "Related Buganizer: go/buganizer/123456789").
- [x] I have ensured that all internal discussions and PII related to this work remain in Buganizer.
- [x] I have tagged the PR with one or more labels that reflect the pull request purpose.