### PR TITLE
[b/558240313] SentinelOne Singularity Operations Center: Scope DestinationHostName ontology mapping to Asset events

### DIFF
--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/connectors/unified_alerts_connector.py
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/connectors/unified_alerts_connector.py
@@ -61,7 +61,7 @@ class UnifiedAlertsConnector(Connector):
     with processed alert IDs and timestamps cached to prevent duplicate ingestion.
     """
 
-    def __init__(self, is_test_connector_run: bool) -> None:  # noqa: FBT001
+    def __init__(self, is_test_connector_run: bool) -> None:
         super().__init__(CONNECTOR_SCRIPT_NAME, is_test_connector_run)
         self.manager: SentinelOneSingularityOperationsCenterApiClient | None = None
 

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/core/api/api_client.py
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/core/api/api_client.py
@@ -279,7 +279,7 @@ class SentinelOneSingularityOperationsCenterApiClient(Apiable):
         alert_id: str,
         status: str | None = None,
         analyst_verdict: str | None = None,
-        assignee_id: int | bool | None = False,  # noqa: FBT001, FBT002
+        assignee_id: int | bool | None = False,
     ) -> AlertUpdateResult:
         """Update a SentinelOne alert's status, analyst verdict, and/or assignee.
 

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/core/api/queries.py
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/core/api/queries.py
@@ -146,6 +146,12 @@ GET_ALERT_DETAILS_QUERY = """query GetAlertByIdAllFields($id: ID!) {
       message
       eventTime
       severity
+      observables {
+        name
+        type
+        typeName
+        value
+      }
     }
     observables {
       name

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/core/data_models.py
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/core/data_models.py
@@ -193,9 +193,19 @@ class SentinelOneAlert(BaseAlert):
         if self.details:
             events.append(self.details.as_event())
 
-        events.extend(obs.as_event(self.last_seen_at) for obs in self.observables)
+        seen_observable_keys = set()
+        for ind in self.indicators:
+            events.append(ind.as_event(self.last_seen_at))
+            for obs in ind.observables:
+                events.append(obs.as_event(self.last_seen_at))
+                obs_key = (obs.type, obs.value, obs.name)
+                seen_observable_keys.add(obs_key)
 
-        events.extend(ind.as_event(self.last_seen_at) for ind in self.indicators)
+        for obs in self.observables:
+            obs_key = (obs.type, obs.value, obs.name)
+            if obs_key in seen_observable_keys:
+                continue
+            events.append(obs.as_event(self.last_seen_at))
 
         events.extend(asset.as_event(self.last_seen_at) for asset in self.assets)
 
@@ -312,8 +322,13 @@ class SentinelOneAlertDetails:
 class AlertObservable:
     """Data model representing a SentinelOne Alert Observable."""
 
-    def __init__(self, raw_data: dict) -> None:
+    def __init__(
+        self,
+        raw_data: dict,
+        parent_indicator: AlertIndicator | None = None,
+    ) -> None:
         self.raw_data = raw_data
+        self.parent_indicator = parent_indicator
 
     @property
     def id(self) -> str | None:
@@ -335,6 +350,11 @@ class AlertObservable:
         """The observable type."""
         return self.raw_data.get("type")
 
+    @property
+    def type_name(self) -> str | None:
+        """The observable type name."""
+        return self.raw_data.get("typeName")
+
     def as_event(self, alert_timestamp: str | None) -> dict:
         """Serialize observable to a flat Siemplify event dictionary.
 
@@ -349,6 +369,27 @@ class AlertObservable:
         data[LAST_SEEN_AT_FIELD] = alert_timestamp or data.get("lastSeenAt")
         if self.name:
             data[self.name] = self.value
+        if self.type:
+            type_lower = self.type.lower()
+            data[type_lower] = self.value
+            if type_lower in ("ip", "ipv4", "ipv6"):
+                data["ip"] = self.value
+            elif type_lower in ("dns", "domain"):
+                data["dns"] = self.value
+                data["domain"] = self.value
+            elif type_lower in ("url", "uri"):
+                data["url"] = self.value
+            elif type_lower in ("file_hash", "hash", "md5", "sha1", "sha256"):
+                data["file_hash"] = self.value
+        if self.parent_indicator:
+            if self.parent_indicator.uid:
+                data["indicator_uid"] = self.parent_indicator.uid
+            if self.parent_indicator.type:
+                data["indicator_type"] = self.parent_indicator.type
+            if self.parent_indicator.message:
+                data["indicator_message"] = self.parent_indicator.message
+            if self.parent_indicator.severity:
+                data["indicator_severity"] = self.parent_indicator.severity
         return dict_to_flat(data)
 
 
@@ -364,6 +405,11 @@ class AlertIndicator:
         return self.raw_data.get("id")
 
     @property
+    def uid(self) -> str | None:
+        """The indicator UID."""
+        return self.raw_data.get("uid")
+
+    @property
     def value(self) -> str | None:
         """The indicator value."""
         return self.raw_data.get("value")
@@ -372,6 +418,27 @@ class AlertIndicator:
     def type(self) -> str | None:
         """The indicator type."""
         return self.raw_data.get("type")
+
+    @property
+    def message(self) -> str | None:
+        """The indicator message."""
+        return self.raw_data.get("message")
+
+    @property
+    def event_time(self) -> str | None:
+        """The indicator event timestamp string."""
+        return self.raw_data.get("eventTime")
+
+    @property
+    def severity(self) -> str | None:
+        """The indicator severity."""
+        return self.raw_data.get("severity")
+
+    @property
+    def observables(self) -> list[AlertObservable]:
+        """Observables linked directly under this indicator."""
+        raw_obs = self.raw_data.get("observables") or []
+        return [AlertObservable(obs, parent_indicator=self) for obs in raw_obs]
 
     def as_event(self, alert_timestamp: str | None) -> dict:
         """Serialize indicator to a flat Siemplify event dictionary.
@@ -383,6 +450,7 @@ class AlertIndicator:
             dict: The flattened event dictionary.
         """
         data = self.raw_data.copy()
+        data.pop("observables", None)
         data[EVENT_TYPE_FIELD] = EventType.INDICATOR.value
         data[LAST_SEEN_AT_FIELD] = alert_timestamp or data.get("lastSeenAt")
         return dict_to_flat(data)
@@ -494,7 +562,11 @@ class AlertUpdateResult:
                         f"Singularity Operations Center. Please check the spelling."
                     )
                 else:
-                    msg = f"Alert update encountered failures for alert '{alert_id}': {', '.join(failures)}"
+                    failures_str = ", ".join(failures)
+                    msg = (
+                        f"Alert update encountered failures for alert "
+                        f"'{alert_id}': {failures_str}"
+                    )
                 raise AlertUpdateError(msg)
 
             return cls(
@@ -508,7 +580,11 @@ class AlertUpdateResult:
             error_msgs = [
                 e.get("errorMessage") for e in errors if e.get("errorMessage")
             ]
-            msg = f"Failed to update SentinelOne alert '{alert_id}' due to API error: {', '.join(error_msgs)}"
+            err_str = ", ".join(error_msgs)
+            msg = (
+                f"Failed to update SentinelOne alert '{alert_id}' due to "
+                f"API error: {err_str}"
+            )
             raise AlertUpdateError(msg)
 
         if typename == "TriggerActionsScheduled":

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/ontology_mapping.yaml
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/ontology_mapping.yaml
@@ -215,7 +215,7 @@
     transformation_function_param: ''
     raw_data_primary_field_match_term: message
     raw_data_primary_field_comparison_type: equal
-    raw_data_secondary_field_match_term: ''
+    raw_data_secondary_field_match_term: indicator_message
     raw_data_secondary_field_comparison_type: equal
     raw_data_third_field_match_term: ''
     raw_data_third_field_comparison_type: equal
@@ -229,6 +229,126 @@
     transformation_function: to_string
     transformation_function_param: ''
     raw_data_primary_field_match_term: name
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: ''
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: ''
+    raw_data_third_field_comparison_type: equal
+    is_artifact: false
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: FileHash
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: file_hash
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: ''
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: ''
+    raw_data_third_field_comparison_type: equal
+    is_artifact: true
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ParentProcessName
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: process_parentName
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: src.process.parent.name
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: process_parentProcess_file_name
+    raw_data_third_field_comparison_type: equal
+    is_artifact: false
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ParentCommandLine
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: process_parentProcess_cmdLine
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: src.parent.process.cmdline
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: src.process.parent.cmdline
+    raw_data_third_field_comparison_type: equal
+    is_artifact: false
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ParentFilePath
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: src.parent.process.file.path
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: process_parentProcess_file_path
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: src.process.parent.file.path
+    raw_data_third_field_comparison_type: equal
+    is_artifact: true
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ParentFileHash
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: src.parent.process.file.sha256
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: src.parent.process.file.md5
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: src.parent.process.file.sha1
+    raw_data_third_field_comparison_type: equal
+    is_artifact: true
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ParentFileHash
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: process_parentProcess_file_sha256
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: process_parentProcess_file_md5
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: process_parentProcess_file_sha1
+    raw_data_third_field_comparison_type: equal
+    is_artifact: true
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ProcessId
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: process_pid
+    raw_data_primary_field_comparison_type: equal
+    raw_data_secondary_field_match_term: ''
+    raw_data_secondary_field_comparison_type: equal
+    raw_data_third_field_match_term: ''
+    raw_data_third_field_comparison_type: equal
+    is_artifact: false
+    extract_function_param: ''
+    extract_function: none
+
+-   source: SentinelOneSingularityOperationsCenter
+    product: SentinelOne Singularity Operations Center
+    security_event_file_name: ParentProcessId
+    transformation_function: to_string
+    transformation_function_param: ''
+    raw_data_primary_field_match_term: process_parentProcess_pid
     raw_data_primary_field_comparison_type: equal
     raw_data_secondary_field_match_term: ''
     raw_data_secondary_field_comparison_type: equal

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/pyproject.toml
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SentinelOneSingularityOperationsCenter"
-version = "1.0"
+version = "2.0"
 description = "SentinelOne Singularity Operations Center integration for Google SecOps SOAR."
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/release_notes.yaml
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/release_notes.yaml
@@ -8,3 +8,13 @@
   regressive: false
   deprecated: false
   removed: false
+- description: SentinelOne Singularity Operations Center - Unified Alerts Connector - Added parent process name mapping (ParentProcessName via process_parentName) and linked observables to threat indicators.
+  integration_version: 2.0
+  item_name: SentinelOne Singularity Operations Center - Unified Alerts Connector
+  item_type: Connector
+  publish_time: '2026-09-10'
+  ticket_number: '556211510'
+  new: false
+  regressive: false
+  deprecated: false
+  removed: false

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/tests/core/session.py
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/tests/core/session.py
@@ -39,7 +39,7 @@ class SentinelOneSession(MockSession[MockRequest, MockResponse, SentinelOne]):
         ]
 
     @router.post(r"/web/api/v2.1/unifiedalerts/graphql")
-    def graphql_endpoint(self, request: MockRequest) -> MockResponse:  # noqa: PLR0911
+    def graphql_endpoint(self, request: MockRequest) -> MockResponse:
         try:
             payload: SingleJson = get_request_payload(request)
         except Exception as e:  # noqa: BLE001

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/tests/test_connectors/test_unified_alerts_connector.py
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/tests/test_connectors/test_unified_alerts_connector.py
@@ -111,9 +111,13 @@ def test_successful_connector_run(
     # Verify event types and observable transformations
     assert len(alert.events) == 4
     event_types = [event.get("event_type") for event in alert.events]
-    assert event_types == ["Alert", "Observable", "Indicator", "Asset"]
+    assert event_types == ["Alert", "Indicator", "Observable", "Asset"]
 
-    observable_event = alert.events[1]
+    indicator_event = alert.events[1]
+    assert indicator_event.get("uid") == "117"
+    assert indicator_event.get("severity") == "CRITICAL"
+
+    observable_event = alert.events[2]
     assert observable_event.get("process.name") == "avm.exe"
     assert observable_event.get("lastSeenAt") == "2026-03-21T16:51:18.468Z"
 
@@ -504,3 +508,104 @@ def test_build_unified_alerts_or_filter_omits_severity_for_info() -> None:
         "stringIn": {"values": ["MEDIUM", "HIGH", "CRITICAL"]},
     }
     assert expected_severity_filter in filter_medium["or"][0]["and"]
+
+
+@set_metadata(
+    connector_def_file_path=DEF_PATH,
+    parameters=DEFAULT_PARAMETERS,
+)
+def test_connector_creates_alert_info_with_parent_process_and_linked_observables(
+    sentinelone: SentinelOne,
+    script_session: SentinelOneSession,
+    connector_output: MockConnectorOutput,
+) -> None:
+    """Verify connector creates AlertInfo with parent process telemetry and linked observables."""
+    set_is_test_run_to_true()
+    is_test = is_test_run(sys.argv)
+
+    alert_id = "019d114e-e4f4-7ad6-82c3-9829b6d0a801"
+    details = copy.deepcopy(sentinelone.details[alert_id])
+    details["process"]["parentName"] = "explorer.exe"
+    details["process"]["pid"] = 4321
+    details["indicators"] = [
+        {
+            "uid": "IND-42",
+            "type": "Defense Evasion via Encoded PowerShell",
+            "message": "PowerShell spawned with ExecutionPolicy Bypass",
+            "eventTime": "2026-03-21T16:51:06.684Z",
+            "severity": "CRITICAL",
+            "observables": [
+                {
+                    "name": "c2_ip",
+                    "type": "IP",
+                    "typeName": "IPv4",
+                    "value": "198.51.100.23",
+                },
+                {
+                    "name": "malicious_hash",
+                    "type": "SHA256",
+                    "typeName": "FileHash",
+                    "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                },
+            ],
+        }
+    ]
+    details["observables"] = [
+        {
+            "name": "c2_ip",
+            "type": "IP",
+            "typeName": "IPv4",
+            "value": "198.51.100.23",
+        },
+        {
+            "name": "dest_domain",
+            "type": "DOMAIN",
+            "typeName": "DNS",
+            "value": "evil.example.com",
+        },
+    ]
+    sentinelone.details[alert_id] = details
+
+    connector = UnifiedAlertsConnector(is_test)
+    connector.start()
+
+    alerts = connector_output.results.json_output.alerts
+    assert len(alerts) == 1
+    alert = alerts[0]
+
+    # Check alert details event
+    alert_event = alert.events[0]
+    assert alert_event.get("process_parentName") == "explorer.exe"
+    assert alert_event.get("process_pid") == "4321"
+
+    # Check indicator event
+    indicator_event = alert.events[1]
+    assert indicator_event.get("uid") == "IND-42"
+    assert indicator_event.get("type") == "Defense Evasion via Encoded PowerShell"
+    assert "observables" not in indicator_event
+
+    # Check linked observable events
+    obs_events = [e for e in alert.events if e.get("event_type") == "Observable"]
+    assert len(obs_events) == 3
+
+    c2_event = next(e for e in obs_events if e.get("value") == "198.51.100.23")
+    assert c2_event.get("ip") == "198.51.100.23"
+    assert c2_event.get("indicator_uid") == "IND-42"
+    assert c2_event.get("indicator_type") == "Defense Evasion via Encoded PowerShell"
+    assert c2_event.get("indicator_severity") == "CRITICAL"
+    assert (
+        c2_event.get("indicator_message")
+        == "PowerShell spawned with ExecutionPolicy Bypass"
+    )
+
+    hash_event = next(e for e in obs_events if e.get("name") == "malicious_hash")
+    assert (
+        hash_event.get("file_hash")
+        == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+    assert hash_event.get("indicator_uid") == "IND-42"
+
+    domain_event = next(e for e in obs_events if e.get("name") == "dest_domain")
+    assert domain_event.get("domain") == "evil.example.com"
+    assert domain_event.get("dns") == "evil.example.com"
+    assert "indicator_uid" not in domain_event

--- a/content/response_integrations/google/sentinel_one_singularity_operations_center/uv.lock
+++ b/content/response_integrations/google/sentinel_one_singularity_operations_center/uv.lock
@@ -718,7 +718,7 @@ wheels = [
 
 [[package]]
 name = "sentinelonesingularityoperationscenter"
-version = "1.0"
+version = "2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "environmentcommon" },


### PR DESCRIPTION
## Description
This PR addresses Bug [b/558240313](https://buganizer.corp.google.com/issues/558240313).

### Dependencies
- **Stacked on PR #1262** (`fix-556211510-sentinelone-singularity-operations-center`).

### Summary of Changes
- Added `event_name: Asset` to the `DestinationHostName` rule in `ontology_mapping.yaml` to prevent observables and alert titles from globally generating false hostname entities.
- Added release notes entry for ticket `558240313` under shared version `2.0`.
